### PR TITLE
Bump zabbix chart

### DIFF
--- a/clusters/kubenuc/apps/zabbix/release.yml
+++ b/clusters/kubenuc/apps/zabbix/release.yml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: zabbix
-      version: 2.0.0
+      version: 2.0.1
       sourceRef:
         kind: HelmRepository
         name: cetic-charts


### PR DESCRIPTION
Bump zabbix chart version to 2.0.1, for chart 3.x.x a review of values.yaml is required