### PR TITLE
[Ansible] Workaround for Ansible Tower/AWX

### DIFF
--- a/ansible/os_updates/collections/requirements.yml
+++ b/ansible/os_updates/collections/requirements.yml
@@ -1,0 +1,3 @@
+---
+collections:
+  - name: community.general

--- a/ansible/os_updates/playbook.yml
+++ b/ansible/os_updates/playbook.yml
@@ -4,6 +4,16 @@
   become: yes
   gather_facts: yes
 
+  pre_tasks:
+    - name : Install Collections dependencies
+      shell: ansible-galaxy install -r collections/requirements.yml
+      delegate_to: 127.0.0.1
+
+    - name : Install Roles Dependencies
+      shell: ansible-galaxy install -r roles/requirements.yml
+      delegate_to: 127.0.0.1
+
+ansible-galaxy install namespace.role_name
   collections:
     - community.general
  


### PR DESCRIPTION
Tower/AWX reads only from <root-project-folder>/roles/requirements.yml, see: 
https://github.com/ansible/awx/issues/106 
https://github.com/ansible/awx/pull/9945

Signed-off-by: Daniele De Lorenzi <daniele.delorenzi@fastnetserv.net>