### PR TITLE
[k8s] downgrade unifi-controller version to v6

### DIFF
--- a/clusters/kubenuc/apps/unifi/release-unifi.yml
+++ b/clusters/kubenuc/apps/unifi/release-unifi.yml
@@ -23,6 +23,8 @@ spec:
     remediation:
       retries: 6
   values:
+    image:
+      tag: v6
     env:
       TZ: Europe/Rome
     ingress:


### PR DESCRIPTION
Downgrade unifi-controller version to v6 in order to be able to perform a smooth migration between old and new controller