### PR TITLE
[k8s] unifi - remove ssl redirect

### DIFF
--- a/clusters/kubenuc/apps/unifi/release-unifi.yml
+++ b/clusters/kubenuc/apps/unifi/release-unifi.yml
@@ -34,7 +34,6 @@ spec:
         annotations:
           nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
           cert-manager.io/cluster-issuer: letsencrypt
-          nginx.ingress.kubernetes.io/ssl-redirect: "true"
         hosts:
           - host: unifi.ddlns.net
             paths:


### PR DESCRIPTION
removed ssl redirect otherwise unifi devices are unable to call /inform endpoint