### PR TITLE
[flux] Common base setting for sysdig-agent

### DIFF
--- a/clusters/common/sysdig-agent/kustomization.yaml
+++ b/clusters/common/sysdig-agent/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: sysdig-agent
+resources:
+  - namespace.yml
+  - release.yml

--- a/clusters/common/sysdig-agent/namespace.yml
+++ b/clusters/common/sysdig-agent/namespace.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sysdig-agent

--- a/clusters/common/sysdig-agent/release.yml
+++ b/clusters/common/sysdig-agent/release.yml
@@ -9,7 +9,6 @@ spec:
   chart:
     spec:
       chart: sysdig-deploy
-      version: 1.3.25
       sourceRef:
         kind: HelmRepository
         name: sysdig-charts
@@ -30,8 +29,6 @@ spec:
         registry: quay.io
 
     agent:
-      #image:
-      #  tag: 12.8.1
       enabled: true
       sysdig:
         settings:
@@ -56,16 +53,9 @@ spec:
             prom_service_discovery: true
 
     nodeAnalyzer:
-      nodeAnalyzer:
-        runtimeScanner:
-          deploy: true
-          settings:
-            eveEnabled: true
-      secure:
-        vulnerabilityManagement:
-          newEngineOnly: true
+      enabled: true
 
     rapidResponse:
-      enabled: true
+      enabled: false
       rapidResponse:
         existingPassphraseSecret: "sysdig-rapid-response"

--- a/clusters/common/sysdig-agent/release.yml
+++ b/clusters/common/sysdig-agent/release.yml
@@ -1,0 +1,71 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: sysdig-deploy
+  namespace: sysdig-agent
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: sysdig-deploy
+      version: 1.3.25
+      sourceRef:
+        kind: HelmRepository
+        name: sysdig-charts
+        namespace: flux-system
+      interval: 5m
+  install:
+    createNamespace: true
+    remediation:
+      retries: 5
+  upgrade:
+    remediation:
+      retries: 5
+  values:
+    global:
+      sysdig:
+        accessKeySecret: "sysdig-agent"
+      image:
+        registry: quay.io
+
+    agent:
+      #image:
+      #  tag: 12.8.1
+      enabled: true
+      sysdig:
+        settings:
+          app_checks_enabled: false
+          feature:
+            mode: monitor
+          jmx:
+            enabled: false
+          log:
+            rotate: 20
+            max_size: 20
+            console_priority: warning
+            file_priority: debug
+            file_priority_by_component:
+              - "promscrape: warning"
+              - "promscrape:prom_emitter: warning"
+              - "watchdog_runnable: warning"
+              - "sdjagent: warning"
+              - "mountedfs_reader: warning"
+          prometheus:
+            enabled: true
+            prom_service_discovery: true
+
+    nodeAnalyzer:
+      nodeAnalyzer:
+        runtimeScanner:
+          deploy: true
+          settings:
+            eveEnabled: true
+      secure:
+        vulnerabilityManagement:
+          newEngineOnly: true
+
+    rapidResponse:
+      enabled: true
+      rapidResponse:
+        existingPassphraseSecret: "sysdig-rapid-response"

--- a/clusters/k8s-vms-daniele/apps/sysdig-agent/release.yml
+++ b/clusters/k8s-vms-daniele/apps/sysdig-agent/release.yml
@@ -5,26 +5,10 @@ metadata:
   name: sysdig-deploy
   namespace: sysdig-agent
 spec:
-  interval: 5m
   chart:
     spec:
       chart: sysdig-deploy
-      version: 1.3.25
-      sourceRef:
-        kind: HelmRepository
-        name: sysdig-charts
-        namespace: flux-system
-      interval: 5m
-  install:
-    createNamespace: true
-    remediation:
-      retries: 5
-  upgrade:
-    remediation:
-      retries: 5
-  valuesFrom:
-  - chartFileRef:
-      path: ../clusters/common/sysdig-agent/release.yml
+      version: ">=1.3.25"
   values:
     global:
       clusterConfig:
@@ -48,11 +32,6 @@ spec:
           key: "CriticalAddonsOnly"
           operator: "Equal"
           value: "true"
-      sysdig:
-        settings:
-          prometheus:
-            enabled: true
-            prom_service_discovery: true
 
     nodeAnalyzer:
       nodeAnalyzer:
@@ -68,6 +47,15 @@ spec:
             limits:
               cpu: 250m
         runtimeScanner:
+          deploy: true
           resources:
             limits:
               cpu: 300m
+          settings:
+            eveEnabled: true
+      secure:
+        vulnerabilityManagement:
+          newEngineOnly: true
+
+    rapidResponse:
+      enabled: true

--- a/clusters/k8s-vms-daniele/apps/sysdig-agent/release.yml
+++ b/clusters/k8s-vms-daniele/apps/sysdig-agent/release.yml
@@ -22,20 +22,17 @@ spec:
   upgrade:
     remediation:
       retries: 5
+  valuesFrom:
+  - chartFileRef:
+      path: ../clusters/common/sysdig-agent/release.yml
   values:
     global:
       clusterConfig:
         name: "k8s-daniele-vms"
       sysdig:
-        accessKeySecret: "sysdig-agent"
         region: "us1"
-      image:
-        registry: quay.io
 
     agent:
-      #image:
-      #  tag: 12.8.1
-      enabled: true
       resourceProfile: custom
       resources:
         requests:
@@ -53,32 +50,9 @@ spec:
           value: "true"
       sysdig:
         settings:
-          app_checks_enabled: false
-          feature:
-            mode: monitor
-          jmx:
-            enabled: false
-          log:
-            rotate: 20
-            max_size: 20
-            console_priority: warning
-            file_priority: debug
-            file_priority_by_component:
-              - "promscrape: warning"
-              - "promscrape:prom_emitter: warning"
-              - "watchdog_runnable: warning"
-              - "sdjagent: warning"
-              - "mountedfs_reader: warning"
-          #metrics_filter:
-          #  - include: container_fs*
-          #  - exclude: container_*
           prometheus:
             enabled: true
             prom_service_discovery: true
-          #skip_events_by_process:
-          #  - fluent-bit
-          #skip_events_by_type:
-          #  - recvfrom
 
     nodeAnalyzer:
       nodeAnalyzer:
@@ -94,17 +68,6 @@ spec:
             limits:
               cpu: 250m
         runtimeScanner:
-          deploy: true
           resources:
             limits:
               cpu: 300m
-          settings:
-            eveEnabled: true
-      secure:
-        vulnerabilityManagement:
-          newEngineOnly: true
-
-    rapidResponse:
-      enabled: true
-      rapidResponse:
-        existingPassphraseSecret: "sysdig-rapid-response"

--- a/clusters/k8s-vms-daniele/charts.yaml
+++ b/clusters/k8s-vms-daniele/charts.yaml
@@ -1,4 +1,4 @@
-
+---
 apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
 kind: Kustomization
 metadata:

--- a/clusters/k8s-vms-daniele/kustomization.yaml
+++ b/clusters/k8s-vms-daniele/kustomization.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: sysdig-agent
+resources:
+  - ../common/sysdig-agent
+patchesStrategicMerge:
+  - sysdig-agent/release.yml
+---
+#apiVersion: kustomize.config.k8s.io/v1beta1
+#kind: Kustomization
+#namespace: sysdig-admission-controller
+#resources:
+#  - ../common/sysdig-admission-controller
+#patchesStrategicMerge:
+#  - sysdig-admission-controller/release.yaml


### PR DESCRIPTION
The aim of this PR is to create a basic common sysdig-agent config across all clusters and then create a specific customisations for each cluster like: resources, image tag, logging, etc..