### PR TITLE
Set an image tag for exportarr

### DIFF
--- a/apps/kubenuc/film-tv-exporter/manifests/deployment.yaml
+++ b/apps/kubenuc/film-tv-exporter/manifests/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app: radarr-exporter
     spec:
       containers:
-      - image: ghcr.io/onedr0p/exportarr
+      - image: ghcr.io/onedr0p/exportarr:v1.1.0
         name: radarr-exporter
         args: ["radarr"]
         env:
@@ -69,7 +69,7 @@ spec:
         app: lidarr-exporter
     spec:
       containers:
-      - image: ghcr.io/onedr0p/exportarr
+      - image: ghcr.io/onedr0p/exportarr:v1.1.0
         name: lidarr-exporter
         args: ["lidarr"]
         env:
@@ -118,7 +118,7 @@ spec:
         app: sonarr-exporter
     spec:
       containers:
-      - image: ghcr.io/onedr0p/exportarr
+      - image: ghcr.io/onedr0p/exportarr:v1.1.0
         name: sonarr-exporter
         args: ["sonarr"]
         env:
@@ -145,4 +145,3 @@ spec:
           limits:
             cpu: 100m
             memory: 128Mi
-


### PR DESCRIPTION
Set an image tag for exportarr in order to avoid crash loop backoff:
```
NAME                               READY   STATUS             RESTARTS      AGE
lidarr-exporter-54647cb4d7-vkzxv   0/1     CrashLoopBackOff   3 (51s ago)   97s

 ➜ k logs ]lidarr-exporter-54647cb4d7-vkzxv -n film-tv
LogLevel:
 ValidateLogLevel: log-level must be one of: debug, info, warn, error, dpanic, panic, fatal
Usage:
  exportarr [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  lidarr      Prometheus Exporter for Lidarr
  prowlarr    Prometheus Exporter for Prowlarr
  radarr      Prometheus Exporter for Radarr
  readarr     Prometheus Exporter for Readarr
  sonarr      Prometheus Exporter for Sonarr

Flags:
  -a, --api-key string               API Key for *arr instance
      --api-key-file string          File containing API Key for *arr instance
      --auth-password string         Password for basic or form auth
```