### PR TITLE
Fix Telerport Agent chart

### DIFF
--- a/apps/k8s-vms-daniele/teleport-agent/release.yml
+++ b/apps/k8s-vms-daniele/teleport-agent/release.yml
@@ -25,3 +25,6 @@ spec:
   values:
     proxyAddr: teleport.fastnetserv.cloud:443
     kubeClusterName: "k8s-vms-daniele"
+    joinTokenSecret:
+      create: false
+      name: "teleport-kube-agent-join-token"


### PR DESCRIPTION
Syntax have been changed in latest version of the chart and is returning this error while upgrading:
```
NAMESPACE        NAME             AGE    READY   STATUS
teleport-agent   teleport-agent   303d   False   Helm upgrade failed for release teleport-agent/teleport-agent with chart teleport-kube-agent@14.2.4: Unable to continue with update: Secret "teleport-kube-agent-join-token" in namespace "teleport-agent" exists and cannot be imported into the current release: invalid ownership metadata; label validation error: missing key "app.kubernetes.io/managed-by": must be set to "Helm"; annotation validation error: missing key "meta.helm.sh/release-name": must be set to "teleport-agent"; annotation validation error: missing key "meta.helm.sh/release-namespace": must be set to "teleport-agent"
```