### PR TITLE
Update Harbor chart

### DIFF
--- a/apps/kubenuc/harbor/release.yml
+++ b/apps/kubenuc/harbor/release.yml
@@ -46,3 +46,6 @@ spec:
         enabled: "true"
         secretName: "harbor-ingress-certificate"
       type: ingress
+    database:
+      internal: 
+        password: "changeit"


### PR DESCRIPTION
It looks like that if you don't specify a password for the DB on `values.yaml` file, Harbor chart will pickup the one in the secret but the helper of the chart will decode it instead of keep it encoded, see: https://github.com/goharbor/harbor-helm/blob/main/templates/_helpers.tpl#L101

Let's try a dummy thing by setting the default dummy password