### PR TITLE
Bump resources and enable HPA

### DIFF
--- a/apps/kubenuc/sso/release.yml
+++ b/apps/kubenuc/sso/release.yml
@@ -115,3 +115,31 @@ spec:
 
     redis:
       enabled: true
+
+    resources:
+      server:
+        requests:
+          cpu: 500m
+          memory: 1Gi
+        limits:
+          cpu: 2000m
+          memory: 2Gi
+      worker: 
+        requests:
+          cpu: 500m
+          memory: 1Gi
+        limits:
+          cpu: 2000m
+          memory: 2Gi
+    
+    autoscaling:
+      server:
+        enabled: true
+        minReplicas: 1
+        maxReplicas: 5
+        targetCPUUtilizationPercentage: 50
+      worker:
+        enabled: true
+        minReplicas: 1
+        maxReplicas: 5
+        targetCPUUtilizationPercentage: 80


### PR DESCRIPTION
There are no default request/limits set by Authentik charts.
Set 500m and 1Gi as request and 2 cores and 2Gi as limits. Enabled HPA