### PR TITLE
Fix minio-operator dependency

### DIFF
--- a/apps/kubenuc/minio/release.yml
+++ b/apps/kubenuc/minio/release.yml
@@ -38,7 +38,7 @@ metadata:
   namespace: nextcloud-fastnetserv
 spec:
   dependsOn:
-    - name: minio-operator
+    - name: minio-operator/minio-operator
   interval: 15m
   maxHistory: 20
   chart:


### PR DESCRIPTION
Operator is on a different namespace therefore `dependsOn` needs to be cross namespace `<namespace>/<name>`