### PR TITLE
[ranchernuc]: Bump replicas to 3 and implement pod Anti-Affinity

### DIFF
--- a/apps/kubenuc/nfs-sc/release.yml
+++ b/apps/kubenuc/nfs-sc/release.yml
@@ -25,7 +25,6 @@ spec:
       retries: 5
   values:
     replicaCount: 0
-    nodeSelector: "kubenuc"
     nfs:
       server: 10.10.8.5
       path: /volume2/video

--- a/apps/kubenuc/nginx-ingress/release.yml
+++ b/apps/kubenuc/nginx-ingress/release.yml
@@ -24,6 +24,7 @@ spec:
     remediation:
       retries: 5
   values:
+    replicaCount: 3
     controller:
       podAnnotations:
         prometheus.io/scrape: "true"
@@ -83,3 +84,21 @@ spec:
     ##
     udp:
       "3478": "unifi/unifi:3478"
+
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: app.kubernetes.io/name
+            operator: In
+            values:
+            - ingress-nginx
+          - key: app.kubernetes.io/instance
+            operator: In
+            values:
+            - ingress-nginx
+          - key: app.kubernetes.io/component
+            operator: In
+            values:
+            - controller
+        topologyKey: "kubernetes.io/hostname"


### PR DESCRIPTION
- POD replicas to 3
- POD Anti-Affinity for spread at least 1 replica per node (we can evaluate later on to switch to daemonset instead of deployment)