### PR TITLE
fix(k8s-vms-daniele): Replace AWX Backup image from schickling with eeshugerman

### DIFF
--- a/clusters/k8s-vms-daniele/apps/awx/backup/backup.yml
+++ b/clusters/k8s-vms-daniele/apps/awx/backup/backup.yml
@@ -12,7 +12,7 @@ spec:
         spec:
           containers:
           - name: pgbackup
-            image: schickling/postgres-backup-s3
+            image: eeshugerman/postgres-backup-s3:15
             imagePullPolicy: IfNotPresent
             env:
             - name: S3_REGION


### PR DESCRIPTION
`schickling/postgres-backup-s3` contains `pg_dump` v14.2 which is not compatible with PGSQL 15:
```
Creating dump of awx database from awx-postgres-15...
pg_dump: error: server version: 15.2; pg_dump version: 14.2
pg_dump: error: aborting because of server version mismatch
```

Replacing the image with `eeshugerman/postgres-backup-s3` which does support `12`, `13`, `14`, `15` or `16`.