### PR TITLE
chore(kubenuc,harbor): Patch harbor-core and harbor-portal update strategy

### DIFF
--- a/clusters/kubenuc/apps/harbor/manifests/updatestrategy.yml
+++ b/clusters/kubenuc/apps/harbor/manifests/updatestrategy.yml
@@ -1,0 +1,38 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: harbor-update-strategy
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: harbor
+  patches:
+    - patch: |
+        - op: replace
+          path: /spec/strategy/rollingUpdate/maxSurge
+          value: 1
+      target:
+        kind: Deployment
+        name: harbor-core
+    - patch: |
+        - op: replace
+          path: /spec/strategy/rollingUpdate/maxUnavailable
+          value: 1
+      target:
+        kind: Deployment
+        name: harbor-core
+    - patch: |
+        - op: replace
+          path: /spec/strategy/rollingUpdate/maxSurge
+          value: 1
+      target:
+        kind: Deployment
+        name: harbor-portal
+    - patch: |
+        - op: replace
+          path: /spec/strategy/rollingUpdate/maxUnavailable
+          value: 1
+      target:
+        kind: Deployment
+        name: harbor-portal


### PR DESCRIPTION
Use kustomize to tune harbor updatestrategy.. Harbor chart doesn't offer it.