### PR TITLE
Migrate zabbix

### DIFF
--- a/clusters/kubenuc/apps/zabbix/manifests/release.yml
+++ b/clusters/kubenuc/apps/zabbix/manifests/release.yml
@@ -67,4 +67,4 @@ spec:
       enabled: false
 
     nodeSelector:
-      kubernetes.io/hostname: "kubenuc"
+      kubernetes.io/hostname: "kubenuc-w1"


### PR DESCRIPTION
Changed node selector in order to move zabbix proxy to a different node on the same zone of kubenuc node. In the future we should use the annotation kubernetes.io/zone