### PR TITLE
Migrate Nextcloud redis to Longhorn SC

### DIFF
--- a/clusters/kubenuc/apps/nextcloud/manifests/release.yml
+++ b/clusters/kubenuc/apps/nextcloud/manifests/release.yml
@@ -89,8 +89,8 @@ spec:
         username: nextcloud
     redis:
       enabled: true
-      persistence:
-      storageClass: longhorn
+      global:
+        storageClass: longhorn
       master:
         resources:
           limits:


### PR DESCRIPTION
Migrate Nextcloud redis to Longhorn storage-class in order to have it scheduled on different nodes