### PR TITLE
Fix AWX backup cronjob

### DIFF
--- a/clusters/k8s-vms-daniele/apps/awx/backup/backup.yml
+++ b/clusters/k8s-vms-daniele/apps/awx/backup/backup.yml
@@ -59,5 +59,5 @@ spec:
                   name: awx-postgres-configuration
                   key: password
             - name: BACKUP_KEEP_DAYS
-              value: 60
+              value: "60"
           restartPolicy: OnFailure


### PR DESCRIPTION
Fix flux error:
```
kustomization/flux-system                   	main@sha1:896e44d7	False    	False
CronJob/awx/awx-backup dry-run failed: failed to create typed patch object (awx/awx-backup; batch/v1, Kind=CronJob): .spec.jobTemplate.spec.template.spec.containers[name="pgbackup"].env[name="BACKUP_KEEP_DAYS"].value: expected string, got &value.valueUnstructured{Value:60}
```