### PR TITLE
Update minio annotation

### DIFF
--- a/clusters/kubenuc/apps/minio/manifests/release.yml
+++ b/clusters/kubenuc/apps/minio/manifests/release.yml
@@ -73,6 +73,7 @@ spec:
         pathType: Prefix
         annotations:
           cert-manager.io/cluster-issuer: "letsencrypt"
+          nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
           nginx.ingress.kubernetes.io/ssl-redirect: "true"
           nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
         tls:
@@ -87,6 +88,7 @@ spec:
         pathType: Prefix
         annotations:
           cert-manager.io/cluster-issuer: "letsencrypt"
+          nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
           nginx.ingress.kubernetes.io/ssl-redirect: "true"
           nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
         tls:


### PR DESCRIPTION
Set nginx annotation for talk https to backend minio services:
```
nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
```