### PR TITLE
Switch Bitnami repo to OCI

### DIFF
--- a/clusters/kubenuc/charts/bitnami.yml
+++ b/clusters/kubenuc/charts/bitnami.yml
@@ -6,5 +6,6 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h
-  url: https://charts.bitnami.com/bitnami
+  url: oci://charts.bitnami.com/bitnami
   timeout: 3m
+  type: "oci"


### PR DESCRIPTION
```
2024-12-28T18:08:50.494Z error HelmChart/jenkins-jenkins.flux-system - Reconciler error chart pull error: failed to download chart for remote reference: Get "oci://registry-1.docker.io/bitnamicharts/jenkins:13.5.1": unsupported protocol scheme "oci"
```