### PR TITLE
chore(kubenuc,nextcloud): Enable startupProbe

### DIFF
--- a/clusters/kubenuc/apps/nextcloud/manifests/release.yml
+++ b/clusters/kubenuc/apps/nextcloud/manifests/release.yml
@@ -24,6 +24,9 @@ spec:
     remediation:
       retries: 5
   values:
+    startupProbe:
+      enabled: true
+      initialDelaySeconds: 120
     image:
       tag: stable-apache
       pullPolicy: Always


### PR DESCRIPTION
Enabling startupProbe for nextcloud in order to avoid CLBO when Nextcloud is performing the upgrade.