### PR TITLE
feat(kubenuc,postgres): Change StorageClass to openebs-hostpath

### DIFF
--- a/clusters/kubenuc/apps/postgresql/manifests/db.yaml
+++ b/clusters/kubenuc/apps/postgresql/manifests/db.yaml
@@ -16,7 +16,7 @@ spec:
   teamId: "ddlns"
   volume:
     size: 20Gi
-    storageClass: "longhorn"
+    storageClass: "openebs-hostpath"
   numberOfInstances: 3
   podAnnotations:
     prometheus.io/port: "9187"


### PR DESCRIPTION
Migrate from Longhorn to openebs-hostpath and rely only on PostgreSQL HA