### PR TITLE
chore(kubenuc,sysdig): Bump Shield chart to 1.19.2

### DIFF
--- a/clusters/kubenuc/apps/sysdig-agent/manifests/release.yml
+++ b/clusters/kubenuc/apps/sysdig-agent/manifests/release.yml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: shield
-      version: "1.12.2"
+      version: "1.19.2"
       interval: 15m
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
Bump Sysdig Shield chart to [1.19.2](https://github.com/sysdiglabs/charts/releases/tag/shield-1.19.2)