### PR TITLE
fix(prod-k3s,node-exporter): Wrong chart name and bump version to 4.48.0

### DIFF
--- a/clusters/k8s-vms-daniele/apps/node-exporter/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/node-exporter/manifests/release.yml
@@ -18,8 +18,8 @@ spec:
     timeout: 30m
   chart:
     spec:
-      chart: shield
-      version: 4.46.0
+      chart: prometheus-node-exporter
+      version: 4.48.0
       interval: 15m
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
Fixed wrong chart name for node-exporter and bumped the version to 4.48.0