### PR TITLE
chore(authentik): Bump to 2025.8.4

### DIFF
--- a/clusters/kubenuc/apps/sso/manifests/release.yml
+++ b/clusters/kubenuc/apps/sso/manifests/release.yml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: authentik
-      version: "2025.6.1"
+      version: "2025.8.4"
       sourceRef:
         kind: HelmRepository
         name: goauthentik-chart


### PR DESCRIPTION
Update SSO to [2025.8.4](https://github.com/goauthentik/helm/releases/tag/authentik-2025.8.4)