### PR TITLE
feat: migrate from nginx-ingress to haproxy-ingress

### DIFF
--- a/charts/haproxy-ingress.yml
+++ b/charts/haproxy-ingress.yml
@@ -1,0 +1,10 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: haproxy-ingress
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://haproxytech.github.io/helm-charts
+  timeout: 3m

--- a/clusters/kubenuc/apps/cloudflare/manifests/cloudflared.yml
+++ b/clusters/kubenuc/apps/cloudflare/manifests/cloudflared.yml
@@ -120,7 +120,7 @@ data:
     # E.g. `cloudflared tunnel route dns example-tunnel tunnel.example.com`.
     ingress:
     - hostname: "*.ddlns.net"
-      service: https://ingress-nginx-controller.ingress-nginx.svc.cluster.local:443
+      service: https://haproxy-ingress-kubernetes-ingress.haproxy-ingress.svc.cluster.local:443
       originRequest:
         originServerName: ddlns.net
     #- hostname: "*.example.dev"

--- a/clusters/kubenuc/apps/haproxy-ingress/deploy.yaml
+++ b/clusters/kubenuc/apps/haproxy-ingress/deploy.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: haproxy-ingress
+  namespace: flux-system
+spec:
+  interval: 15m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./clusters/kubenuc/apps/haproxy-ingress/manifests
+  prune: true
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: haproxy-ingress
+      namespace: haproxy-ingress

--- a/clusters/kubenuc/apps/haproxy-ingress/manifests/namespace.yml
+++ b/clusters/kubenuc/apps/haproxy-ingress/manifests/namespace.yml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: haproxy-ingress

--- a/clusters/kubenuc/apps/haproxy-ingress/manifests/release.yml
+++ b/clusters/kubenuc/apps/haproxy-ingress/manifests/release.yml
@@ -1,0 +1,86 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: haproxy-ingress
+  namespace: haproxy-ingress
+spec:
+  interval: 15m
+  maxHistory: 20
+  chart:
+    spec:
+      chart: kubernetes-ingress
+      version: ">=1.0.0 <2.0.0"
+      sourceRef:
+        kind: HelmRepository
+        name: haproxy-ingress
+        namespace: flux-system
+      interval: 15m
+  install:
+    createNamespace: true
+    remediation:
+      retries: 5
+  upgrade:
+    remediation:
+      retries: 5
+  values:
+    controller:
+      kind: DaemonSet
+      ingressClass: haproxy
+      ingressClassResource:
+        name: haproxy
+        enabled: true
+        default: true
+      service:
+        type: ClusterIP
+        externalTrafficPolicy: "Local"
+        # Enable metrics
+        enablePorts:
+          stat: 1024
+      resources:
+        requests:
+          cpu: 500m
+          memory: 512Mi
+        limits:
+          cpu: 2000m
+          memory: 2Gi
+      # Enable metrics endpoint
+      stats:
+        enabled: true
+        port: 1024
+      # Configure for 3 replicas with anti-affinity (when using DaemonSet, this will run on all nodes)
+      replicaCount: 3
+      # Pod anti-affinity to spread across nodes
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - kubernetes-ingress
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - haproxy-ingress
+              topologyKey: "kubernetes.io/hostname"
+      # Enable real IP forwarding
+      config:
+        ssl-redirect: "true"
+        # Client max body size (0 = unlimited)
+        client-body-buffer-size: "0"
+        # Forward headers
+        forwarded-for: "true"
+        original-forwarded-for: "true"
+      # Expose UDP and TCP services similar to nginx-ingress
+      tcp:
+        "50000": "jenkins/jenkins-agent:50000"
+      udp:
+        "3478": "unifi/unifi:3478"
+    # Enable default backend
+    defaultBackend:
+      enabled: true
+      replicaCount: 2

--- a/clusters/kubenuc/apps/harbor/manifests/release.yml
+++ b/clusters/kubenuc/apps/harbor/manifests/release.yml
@@ -106,11 +106,10 @@ spec:
       enabled: false
     expose:
       ingress:
-        className: "nginx"
+        className: "haproxy"
         annotations:
           cert-manager.io/cluster-issuer: letsencrypt
-          nginx.ingress.kubernetes.io/client-max-body-size: "0"
-          nginx.ingress.kubernetes.io/proxy-body-size: "0"
+          haproxy.org/request-body-size: "0"
         hosts:
           core: "harbor.ddlns.net"
       tls:

--- a/clusters/kubenuc/apps/jellyfin/manifests/release.yml
+++ b/clusters/kubenuc/apps/jellyfin/manifests/release.yml
@@ -37,10 +37,10 @@ spec:
     #    gpu.intel.com/i915: 1
     ingress:
       main:
-        ingressClassName: nginx
+        ingressClassName: haproxy
         annotations:
           cert-manager.io/cluster-issuer: letsencrypt
-          nginx.ingress.kubernetes.io/ssl-redirect: "true"
+          haproxy.org/ssl-redirect: "true"
         enabled: true
         hosts:
           - host: tv.ddlns.net

--- a/clusters/kubenuc/apps/jenkins/manifests/release.yml
+++ b/clusters/kubenuc/apps/jenkins/manifests/release.yml
@@ -38,9 +38,8 @@ spec:
     
         annotations:
           cert-manager.io/cluster-issuer: letsencrypt
-          nginx.ingress.kubernetes.io/client-max-body-size: "100M"
-          nginx.ingress.kubernetes.io/proxy-body-size: "100M"
-        ingressClassName: nginx
+          haproxy.org/request-body-size: "100M"
+        ingressClassName: haproxy
     
         hostName: jenkins.ddlns.net
         tls:

--- a/clusters/kubenuc/apps/portainer/manifests/release.yml
+++ b/clusters/kubenuc/apps/portainer/manifests/release.yml
@@ -35,11 +35,11 @@ spec:
 
     ingress:
       enabled: true
-      ingressClassName: nginx
+      ingressClassName: haproxy
       annotations:
-        nginx.ingress.kubernetes.io/backend-protocol: HTTPS
+        haproxy.org/backend-protocol: https
         cert-manager.io/cluster-issuer: letsencrypt
-        nginx.ingress.kubernetes.io/proxy-read-timeout: "240"
+        haproxy.org/timeout-server: "240s"
       hosts:
         - host: portainer.ddlns.net
           paths:

--- a/clusters/kubenuc/apps/sso/manifests/release.yml
+++ b/clusters/kubenuc/apps/sso/manifests/release.yml
@@ -85,14 +85,13 @@ spec:
         memory: 2Gi
 
       ingress:
-        ingressClassName: nginx
+        ingressClassName: haproxy
         enabled: true
         hosts:
           - sso.ddlns.net
         annotations:
           cert-manager.io/cluster-issuer: "letsencrypt"
-          nginx.ingress.kubernetes.io/ssl-redirect: "true"
-          nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+          haproxy.org/ssl-redirect: "true"
         tls:
           - secretName: sso-tls
             hosts:

--- a/clusters/kubenuc/apps/unifi/manifests/release-unifi.yml
+++ b/clusters/kubenuc/apps/unifi/manifests/release-unifi.yml
@@ -31,13 +31,13 @@
 #      TZ: Europe/Rome
 #    ingress:
 #      main:
-#        ingressClassName: nginx
+#        ingressClassName: haproxy
 #        enabled: true
 #        annotations:
-#          nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+#          haproxy.org/backend-protocol: https
 #          cert-manager.io/cluster-issuer: letsencrypt
-#          nginx.ingress.kubernetes.io/ssl-redirect: "false"
-#          nginx.ingress.kubernetes.io/whitelist-source-range: 10.10.0.0/24,10.10.8.0/24,192.168.0.0/24,192.168.1.0/24,192.168.2.0/24
+#          haproxy.org/ssl-redirect: "false"
+#          haproxy.org/whitelist: 10.10.0.0/24,10.10.8.0/24,192.168.0.0/24,192.168.1.0/24,192.168.2.0/24
 #        hosts:
 #          - host: unifi.ddlns.net
 #            paths:

--- a/clusters/kubenuc/charts/haproxy-ingress.yml
+++ b/clusters/kubenuc/charts/haproxy-ingress.yml
@@ -1,0 +1,10 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: haproxy-ingress
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://haproxytech.github.io/helm-charts
+  timeout: 3m

--- a/docs/haproxy-ingress-migration.md
+++ b/docs/haproxy-ingress-migration.md
@@ -1,0 +1,249 @@
+# HAProxy Ingress Migration Guide
+
+This document outlines the migration from nginx-ingress to haproxy-ingress for the kubenuc Kubernetes cluster.
+
+## Overview
+
+The migration involves:
+1. Deploying HAProxy ingress controller alongside nginx-ingress
+2. Updating Cloudflare tunnel to route traffic to HAProxy ingress
+3. Migrating all application ingress resources to use HAProxy
+4. Testing all ingresses with RobotFramework
+5. Decommissioning nginx-ingress controller
+
+## Prerequisites
+
+- FluxCD installed and configured
+- Cloudflare tunnel credentials (for tunnel configuration)
+- Better Uptime API token (for maintenance mode management)
+- kubectl access to kubenuc cluster
+
+## Migration Steps
+
+### Step 1: Enable Better Uptime Maintenance Mode
+
+Before starting the migration, enable maintenance mode to prevent false alerts:
+
+```bash
+export BETTERUPTIME_API_TOKEN="your_token_here"
+./scripts/betteruptime-maintenance.sh enable
+```
+
+### Step 2: Deploy HAProxy Ingress Controller
+
+The HAProxy ingress controller is deployed via FluxCD:
+
+```bash
+# Verify the deployment
+kubectl get kustomization -n flux-system haproxy-ingress
+
+# Check HAProxy ingress controller pods
+kubectl get pods -n haproxy-ingress
+
+# Verify the service is created
+kubectl get svc -n haproxy-ingress
+```
+
+Expected service name: `haproxy-ingress-kubernetes-ingress`
+
+### Step 3: Update Cloudflare Tunnel Configuration
+
+The Cloudflare tunnel configuration has been updated to route traffic to HAProxy ingress:
+
+**File**: `clusters/kubenuc/apps/cloudflare/manifests/cloudflared.yml`
+
+The tunnel now routes `*.ddlns.net` traffic to:
+```
+https://haproxy-ingress-kubernetes-ingress.haproxy-ingress.svc.cluster.local:443
+```
+
+Wait for the cloudflared pods to restart and pick up the new configuration:
+
+```bash
+kubectl rollout status daemonset/cloudflared -n cloudflare
+```
+
+### Step 4: Verify Application Ingresses
+
+All application ingress resources have been updated to use `ingressClassName: haproxy`:
+
+- **harbor**: Container registry
+- **jenkins**: CI/CD server
+- **jellyfin**: Media server (tv.ddlns.net)
+- **portainer**: Container management
+- **sso**: Authentication (Authentik)
+- **unifi**: Network controller (commented out)
+
+Check that ingresses are created with the correct class:
+
+```bash
+kubectl get ingress -A | grep haproxy
+```
+
+### Step 5: Test All Ingresses
+
+Run the RobotFramework test suite to verify all ingresses are working:
+
+```bash
+cd tests/robot
+robot ingress_tests.robot
+```
+
+The tests will:
+- Discover all ingresses in the cluster
+- Send HTTP requests to each ingress endpoint
+- Verify HTTP status codes (200-399)
+- Take screenshots of each successfully loaded page
+- Save screenshots to `tests/robot/screenshots/`
+
+### Step 6: Monitor and Verify
+
+Monitor the HAProxy ingress controller:
+
+```bash
+# Check controller logs
+kubectl logs -n haproxy-ingress -l app.kubernetes.io/name=kubernetes-ingress --tail=100
+
+# Check metrics (if enabled)
+kubectl port-forward -n haproxy-ingress svc/haproxy-ingress-kubernetes-ingress 1024:1024
+# Access stats at http://localhost:1024/stats
+```
+
+### Step 7: Disable Better Uptime Maintenance Mode
+
+Once verified, disable maintenance mode:
+
+```bash
+./scripts/betteruptime-maintenance.sh disable
+```
+
+### Step 8: Remove nginx-ingress (Optional)
+
+After confirming HAProxy ingress is working correctly for at least 24-48 hours:
+
+```bash
+# Suspend the nginx-ingress Kustomization
+flux suspend kustomization nginx-ingress -n flux-system
+
+# Delete the nginx-ingress resources
+kubectl delete kustomization nginx-ingress -n flux-system
+
+# Remove the nginx-ingress app directory
+rm -rf clusters/kubenuc/apps/nginx-ingress/
+```
+
+## HAProxy vs Nginx Annotation Mapping
+
+| Nginx Annotation | HAProxy Annotation | Notes |
+|-----------------|-------------------|-------|
+| `nginx.ingress.kubernetes.io/ssl-redirect` | `haproxy.org/ssl-redirect` | Force HTTPS redirect |
+| `nginx.ingress.kubernetes.io/client-max-body-size` | `haproxy.org/request-body-size` | Max request body size |
+| `nginx.ingress.kubernetes.io/proxy-body-size` | `haproxy.org/request-body-size` | Same as above |
+| `nginx.ingress.kubernetes.io/backend-protocol` | `haproxy.org/backend-protocol` | Backend protocol (http/https) |
+| `nginx.ingress.kubernetes.io/proxy-read-timeout` | `haproxy.org/timeout-server` | Server timeout (add 's' suffix) |
+| `nginx.ingress.kubernetes.io/whitelist-source-range` | `haproxy.org/whitelist` | IP whitelist |
+
+## Terraform Module for Cloudflare Tunnel
+
+A Terraform module has been created to manage the Cloudflare tunnel configuration:
+
+**Location**: `terraform/cloudflare-tunnel/`
+
+### Usage
+
+1. Set required variables in `terraform.tfvars`:
+```hcl
+cloudflare_account_id = "your_account_id"
+cloudflare_api_token  = "your_api_token"
+ddlns_net_zone_id     = "your_zone_id"
+tunnel_secret         = "base64_encoded_secret"
+```
+
+2. Import existing tunnel:
+```bash
+cd terraform/cloudflare-tunnel
+terraform init
+terraform import cloudflare_tunnel.kubenuc <account_id>/<tunnel_id>
+```
+
+3. Apply configuration:
+```bash
+terraform plan
+terraform apply
+```
+
+## Rollback Procedure
+
+If issues occur, rollback to nginx-ingress:
+
+1. Revert Cloudflare tunnel configuration:
+```bash
+git revert <commit-hash>
+kubectl apply -f clusters/kubenuc/apps/cloudflare/manifests/cloudflared.yml
+```
+
+2. Revert application ingress resources:
+```bash
+git revert <commit-hash>
+flux reconcile kustomization --with-source flux-system
+```
+
+3. Suspend HAProxy ingress:
+```bash
+flux suspend kustomization haproxy-ingress -n flux-system
+```
+
+## Troubleshooting
+
+### Ingress not accessible
+
+1. Check HAProxy ingress controller logs:
+```bash
+kubectl logs -n haproxy-ingress -l app.kubernetes.io/name=kubernetes-ingress
+```
+
+2. Verify ingress resource:
+```bash
+kubectl describe ingress <ingress-name> -n <namespace>
+```
+
+3. Check Cloudflare tunnel status:
+```bash
+kubectl logs -n cloudflare -l app=cloudflared
+```
+
+### Certificate issues
+
+Ensure cert-manager is running and issuing certificates:
+```bash
+kubectl get certificates -A
+kubectl describe certificate <cert-name> -n <namespace>
+```
+
+### TCP/UDP services not working
+
+HAProxy ingress controller is configured to expose:
+- TCP port 50000 → jenkins/jenkins-agent:50000 (Jenkins agents)
+- UDP port 3478 → unifi/unifi:3478 (UniFi STUN)
+
+Verify the configuration in `clusters/kubenuc/apps/haproxy-ingress/manifests/release.yml`
+
+## References
+
+- [HAProxy Ingress Documentation](https://haproxy-ingress.github.io/)
+- [HAProxy Kubernetes Ingress Controller](https://github.com/haproxytech/kubernetes-ingress)
+- [Cloudflare Tunnel Documentation](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/)
+- [Better Uptime API](https://betterstack.com/docs/uptime/api/)
+
+## Post-Migration Checklist
+
+- [ ] All ingresses accessible via browser
+- [ ] HTTPS certificates valid
+- [ ] Jenkins agents can connect (TCP 50000)
+- [ ] UniFi STUN working (UDP 3478)
+- [ ] RobotFramework tests passing
+- [ ] Screenshots generated successfully
+- [ ] Better Uptime monitors active (maintenance mode disabled)
+- [ ] Prometheus metrics accessible (if enabled)
+- [ ] No errors in HAProxy ingress controller logs
+- [ ] Cloudflare tunnel healthy

--- a/scripts/betteruptime-maintenance.sh
+++ b/scripts/betteruptime-maintenance.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+# Better Uptime Maintenance Mode Management Script
+#
+# This script helps manage maintenance mode for Better Uptime monitors
+# during ingress controller transitions (nginx -> haproxy)
+#
+# Usage:
+#   ./betteruptime-maintenance.sh enable    # Enable maintenance mode
+#   ./betteruptime-maintenance.sh disable   # Disable maintenance mode
+#   ./betteruptime-maintenance.sh status    # Check maintenance mode status
+
+set -euo pipefail
+
+# Configuration
+BETTERUPTIME_API_TOKEN="${BETTERUPTIME_API_TOKEN:-}"
+BETTERUPTIME_API_URL="https://betteruptime.com/api/v2"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Function to print colored output
+log_info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Check if API token is set
+check_api_token() {
+    if [ -z "$BETTERUPTIME_API_TOKEN" ]; then
+        log_error "BETTERUPTIME_API_TOKEN environment variable is not set"
+        log_info "Export your Better Uptime API token:"
+        log_info "  export BETTERUPTIME_API_TOKEN='your_token_here'"
+        exit 1
+    fi
+}
+
+# Get all monitors
+get_monitors() {
+    curl -s -X GET "$BETTERUPTIME_API_URL/monitors" \
+        -H "Authorization: Bearer $BETTERUPTIME_API_TOKEN" \
+        -H "Content-Type: application/json"
+}
+
+# Enable maintenance mode for all monitors
+enable_maintenance() {
+    log_info "Enabling maintenance mode for all monitors..."
+
+    monitors=$(get_monitors)
+    monitor_ids=$(echo "$monitors" | jq -r '.data[].id')
+
+    if [ -z "$monitor_ids" ]; then
+        log_warn "No monitors found"
+        return
+    fi
+
+    for monitor_id in $monitor_ids; do
+        monitor_name=$(echo "$monitors" | jq -r ".data[] | select(.id==\"$monitor_id\") | .attributes.pronounceable_name")
+
+        log_info "Enabling maintenance for: $monitor_name (ID: $monitor_id)"
+
+        curl -s -X POST "$BETTERUPTIME_API_URL/monitors/$monitor_id/maintenance" \
+            -H "Authorization: Bearer $BETTERUPTIME_API_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d '{
+                "starts_at": "'$(date -u +%Y-%m-%dT%H:%M:%S)'Z",
+                "duration": "3600"
+            }' > /dev/null
+    done
+
+    log_info "Maintenance mode enabled for all monitors"
+}
+
+# Disable maintenance mode for all monitors
+disable_maintenance() {
+    log_info "Disabling maintenance mode for all monitors..."
+
+    monitors=$(get_monitors)
+    monitor_ids=$(echo "$monitors" | jq -r '.data[].id')
+
+    if [ -z "$monitor_ids" ]; then
+        log_warn "No monitors found"
+        return
+    fi
+
+    for monitor_id in $monitor_ids; do
+        monitor_name=$(echo "$monitors" | jq -r ".data[] | select(.id==\"$monitor_id\") | .attributes.pronounceable_name")
+
+        log_info "Checking maintenance for: $monitor_name (ID: $monitor_id)"
+
+        # Get ongoing maintenances
+        maintenances=$(curl -s -X GET "$BETTERUPTIME_API_URL/monitors/$monitor_id/maintenance" \
+            -H "Authorization: Bearer $BETTERUPTIME_API_TOKEN")
+
+        maintenance_ids=$(echo "$maintenances" | jq -r '.data[].id')
+
+        for maintenance_id in $maintenance_ids; do
+            log_info "  Disabling maintenance ID: $maintenance_id"
+            curl -s -X DELETE "$BETTERUPTIME_API_URL/monitors/$monitor_id/maintenance/$maintenance_id" \
+                -H "Authorization: Bearer $BETTERUPTIME_API_TOKEN" > /dev/null
+        done
+    done
+
+    log_info "Maintenance mode disabled for all monitors"
+}
+
+# Check maintenance mode status
+check_status() {
+    log_info "Checking maintenance mode status..."
+
+    monitors=$(get_monitors)
+    monitor_ids=$(echo "$monitors" | jq -r '.data[].id')
+
+    if [ -z "$monitor_ids" ]; then
+        log_warn "No monitors found"
+        return
+    fi
+
+    for monitor_id in $monitor_ids; do
+        monitor_name=$(echo "$monitors" | jq -r ".data[] | select(.id==\"$monitor_id\") | .attributes.pronounceable_name")
+
+        maintenances=$(curl -s -X GET "$BETTERUPTIME_API_URL/monitors/$monitor_id/maintenance" \
+            -H "Authorization: Bearer $BETTERUPTIME_API_TOKEN")
+
+        maintenance_count=$(echo "$maintenances" | jq '.data | length')
+
+        if [ "$maintenance_count" -gt 0 ]; then
+            echo -e "  ${YELLOW}✓${NC} $monitor_name: Maintenance mode ACTIVE"
+        else
+            echo -e "  ${GREEN}✗${NC} $monitor_name: Maintenance mode INACTIVE"
+        fi
+    done
+}
+
+# Main script
+main() {
+    local command="${1:-}"
+
+    if [ -z "$command" ]; then
+        log_error "No command specified"
+        echo "Usage: $0 {enable|disable|status}"
+        exit 1
+    fi
+
+    check_api_token
+
+    case "$command" in
+        enable)
+            enable_maintenance
+            ;;
+        disable)
+            disable_maintenance
+            ;;
+        status)
+            check_status
+            ;;
+        *)
+            log_error "Unknown command: $command"
+            echo "Usage: $0 {enable|disable|status}"
+            exit 1
+            ;;
+    esac
+}
+
+main "$@"

--- a/terraform/cloudflare-tunnel/README.md
+++ b/terraform/cloudflare-tunnel/README.md
@@ -1,0 +1,51 @@
+# Cloudflare Tunnel Terraform Module
+
+This module manages the Cloudflare tunnel configuration for the kubenuc cluster.
+
+## Features
+
+- Manages Cloudflare tunnel resource
+- Configures tunnel ingress rules to route traffic to HAProxy ingress controller
+- Creates DNS CNAME records for tunnel endpoints
+- Supports importing existing tunnels
+
+## Usage
+
+### Initial Import
+
+If you have an existing Cloudflare tunnel, import it first:
+
+```bash
+# Get your tunnel ID from Cloudflare dashboard or CLI
+# cloudflared tunnel list
+
+terraform import cloudflare_tunnel.kubenuc <account_id>/<tunnel_id>
+```
+
+### Apply Configuration
+
+```bash
+terraform init
+terraform plan
+terraform apply
+```
+
+## Variables
+
+- `cloudflare_account_id`: Your Cloudflare account ID
+- `cloudflare_api_token`: API token with Tunnel and DNS edit permissions
+- `ddlns_net_zone_id`: Zone ID for the ddlns.net domain
+- `tunnel_secret`: Base64-encoded tunnel secret (from credentials.json)
+- `tunnel_hostnames`: List of hostnames to route through the tunnel (default: harbor, jenkins, tv, portainer, sso, unifi)
+
+## Outputs
+
+- `tunnel_id`: The Cloudflare tunnel ID
+- `tunnel_cname`: The CNAME target for DNS records
+- `tunnel_endpoints`: Map of configured endpoint hostnames
+
+## Notes
+
+- The tunnel routes all `*.ddlns.net` traffic to the HAProxy ingress controller
+- The HAProxy ingress controller should be deployed in the `haproxy-ingress` namespace
+- Ensure the service name matches your HAProxy ingress service: `haproxy-ingress-kubernetes-ingress`

--- a/terraform/cloudflare-tunnel/main.tf
+++ b/terraform/cloudflare-tunnel/main.tf
@@ -1,0 +1,49 @@
+terraform {
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 4.0"
+    }
+  }
+}
+
+# Import existing Cloudflare tunnel
+# To import: terraform import cloudflare_tunnel.kubenuc <account_id>/<tunnel_id>
+resource "cloudflare_tunnel" "kubenuc" {
+  account_id = var.cloudflare_account_id
+  name       = "kubenuc"
+  secret     = var.tunnel_secret
+}
+
+# Tunnel configuration
+resource "cloudflare_tunnel_config" "kubenuc" {
+  account_id = var.cloudflare_account_id
+  tunnel_id  = cloudflare_tunnel.kubenuc.id
+
+  config {
+    ingress_rule {
+      hostname = "*.ddlns.net"
+      service  = "https://haproxy-ingress-kubernetes-ingress.haproxy-ingress.svc.cluster.local:443"
+
+      origin_request {
+        origin_server_name = "ddlns.net"
+      }
+    }
+
+    # Catch-all rule (required)
+    ingress_rule {
+      service = "http_status:404"
+    }
+  }
+}
+
+# DNS records for tunnel endpoints
+resource "cloudflare_record" "tunnel_endpoints" {
+  for_each = toset(var.tunnel_hostnames)
+
+  zone_id = var.ddlns_net_zone_id
+  name    = each.value
+  value   = "${cloudflare_tunnel.kubenuc.id}.cfargotunnel.com"
+  type    = "CNAME"
+  proxied = true
+}

--- a/terraform/cloudflare-tunnel/outputs.tf
+++ b/terraform/cloudflare-tunnel/outputs.tf
@@ -1,0 +1,14 @@
+output "tunnel_id" {
+  description = "Cloudflare tunnel ID"
+  value       = cloudflare_tunnel.kubenuc.id
+}
+
+output "tunnel_cname" {
+  description = "Cloudflare tunnel CNAME target"
+  value       = "${cloudflare_tunnel.kubenuc.id}.cfargotunnel.com"
+}
+
+output "tunnel_endpoints" {
+  description = "Map of tunnel endpoint hostnames"
+  value       = { for record in cloudflare_record.tunnel_endpoints : record.name => record.value }
+}

--- a/terraform/cloudflare-tunnel/provider.tf
+++ b/terraform/cloudflare-tunnel/provider.tf
@@ -1,0 +1,3 @@
+provider "cloudflare" {
+  api_token = var.cloudflare_api_token
+}

--- a/terraform/cloudflare-tunnel/variables.tf
+++ b/terraform/cloudflare-tunnel/variables.tf
@@ -1,0 +1,34 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_api_token" {
+  description = "Cloudflare API token"
+  type        = string
+  sensitive   = true
+}
+
+variable "ddlns_net_zone_id" {
+  description = "Zone ID for ddlns.net domain"
+  type        = string
+}
+
+variable "tunnel_secret" {
+  description = "Cloudflare tunnel secret (base64 encoded)"
+  type        = string
+  sensitive   = true
+}
+
+variable "tunnel_hostnames" {
+  description = "List of hostnames to route through the tunnel"
+  type        = list(string)
+  default = [
+    "harbor",
+    "jenkins",
+    "tv",
+    "portainer",
+    "sso",
+    "unifi",
+  ]
+}

--- a/tests/robot/ingress_tests.robot
+++ b/tests/robot/ingress_tests.robot
@@ -1,18 +1,21 @@
 *** Settings ***
-Documentation    Test that all Kubernetes ingresses return HTTP 200
+Documentation    Test that all Kubernetes ingresses return HTTP 200 and take screenshots
 Library          RequestsLibrary
 Library          Collections
 Library          OperatingSystem
 Library          String
 Library          ingress_helper.py
+Library          SeleniumLibrary
 
 Suite Setup      Initialize Test Suite
-Suite Teardown   Log Test Summary
+Suite Teardown   Cleanup Test Suite
 
 *** Variables ***
 ${TIMEOUT}              30
 ${VERIFY_SSL}           ${FALSE}
 ${EXPECTED_STATUS}      200
+${SCREENSHOT_DIR}       ${CURDIR}/screenshots
+${HEADLESS}             ${TRUE}
 
 *** Test Cases ***
 Test All Ingresses Return HTTP 200
@@ -31,6 +34,7 @@ Initialize Test Suite
     Create Session     ingress_session    https://localhost    verify=${VERIFY_SSL}    disable_warnings=1
     ${count}=          Get Ingress Count
     Log To Console     \nDiscovered ${count} ingresses for testing
+    Create Directory   ${SCREENSHOT_DIR}
 
 Test Single Ingress
     [Documentation]    Test a single ingress endpoint
@@ -57,8 +61,35 @@ Test Single Ingress
     ...    Should Be True    ${response.status_code} >= 200 and ${response.status_code} < 400
     ...    Ingress ${name} (${url}) returned unexpected status: ${response.status_code}
 
-Log Test Summary
-    [Documentation]    Log final test summary
+    # Take screenshot of the ingress endpoint if status is successful
+    Run Keyword If    '${response}' != 'None' and ${response.status_code} >= 200 and ${response.status_code} < 400
+    ...    Take Ingress Screenshot    ${url}    ${name}
+
+Take Ingress Screenshot
+    [Documentation]    Take a screenshot of an ingress endpoint using Selenium
+    [Arguments]        ${url}    ${name}
+    ${options}=        Evaluate    sys.modules['selenium.webdriver'].ChromeOptions()    sys, selenium.webdriver
+    Run Keyword If    ${HEADLESS}    Call Method    ${options}    add_argument    --headless
+    Call Method        ${options}    add_argument    --no-sandbox
+    Call Method        ${options}    add_argument    --disable-dev-shm-usage
+    Call Method        ${options}    add_argument    --ignore-certificate-errors
+    Call Method        ${options}    add_argument    --disable-gpu
+    ${screenshot_path}=    Set Variable    ${SCREENSHOT_DIR}/${name}.png
+    TRY
+        Open Browser       ${url}    chrome    options=${options}
+        Set Window Size    1920    1080
+        Sleep              2s    # Wait for page to load
+        Capture Page Screenshot    ${screenshot_path}
+        Log To Console     Screenshot saved: ${screenshot_path}
+    EXCEPT
+        Log To Console     Failed to take screenshot for ${name}: ${url}
+    FINALLY
+        Close Browser
+    END
+
+Cleanup Test Suite
+    [Documentation]    Cleanup after tests
     Log To Console     \n========================================
     Log To Console     Ingress HTTP validation completed
+    Log To Console     Screenshots saved to: ${SCREENSHOT_DIR}
     Log To Console     ========================================


### PR DESCRIPTION
This commit implements a complete migration from nginx-ingress to haproxy-ingress for the kubenuc Kubernetes cluster, including all necessary configuration changes, testing enhancements, and automation tools.

Changes:
- Add HAProxy ingress controller deployment with FluxCD HelmRelease
- Update Cloudflare tunnel to route traffic to HAProxy ingress
- Migrate all application ingresses (harbor, jenkins, jellyfin, portainer, sso, unifi)
- Convert nginx annotations to HAProxy equivalents
- Enhance RobotFramework tests with screenshot capability using SeleniumLibrary
- Create Terraform module for Cloudflare tunnel management
- Add Better Uptime maintenance mode management script
- Add comprehensive migration documentation

Related to #1025

🤖 Generated with [Claude Code](https://claude.com/claude-code)