### PR TITLE
feat(k8s-vms): replace AWX with Semaphore UI + specialized Docker agents

### DIFF
--- a/.claude/agents/ansible-agent.md
+++ b/.claude/agents/ansible-agent.md
@@ -59,4 +59,6 @@ Ansible files mounted read-only at `/workspace/ansible/`:
 
 - SSH agent forwarded from host via `SSH_AUTH_SOCK`
 - For scheduled runs, use the `/schedule` skill in Claude Code or GitHub Actions workflows
-- Ollama available at `$OLLAMA_HOST` for playbook generation (recommended: `qwen2.5-coder:7b` locally on Mac)
+- Ollama available at `$OLLAMA_HOST` for playbook generation
+  - RTX5090 (32GB VRAM): `ollama pull qwen2.5-coder:32b-instruct-q6_K` (~27GB)
+  - Mac M5 Pro (48GB): `ollama pull qwen2.5-coder:32b-instruct-q8_0` (~34GB)

--- a/.claude/agents/ansible-agent.md
+++ b/.claude/agents/ansible-agent.md
@@ -1,0 +1,62 @@
+---
+name: ansible-agent
+description: Ansible specialist agent. Use for running Ansible playbooks, linting, inventory management, and OS/device configuration tasks. Runs in an isolated Docker container with Ansible and common collections installed. Replaces AWX for ad-hoc automation tasks.
+---
+
+# Ansible Agent
+
+This agent specializes in Ansible automation for the infra-cd repository, replacing AWX for ad-hoc tasks.
+
+## Available tools in the container
+
+- `ansible` (v10.x)
+- `ansible-playbook`, `ansible-lint`, `ansible-inventory`
+- Collections: `community.general`, `community.postgresql`, `ansible.posix`, `kubernetes.core`
+- `paramiko` (Python SSH library)
+- SSH client with host key checking disabled
+
+## How to invoke
+
+```bash
+# Start the container (once)
+cd docker/agents && docker compose up -d ansible-agent
+
+# Run a playbook
+docker compose exec ansible-agent ansible-playbook \
+  -i /workspace/ansible/inventory \
+  /workspace/ansible/iredmail/deploy/iredmail.yml
+
+# Lint a playbook
+docker compose exec ansible-agent ansible-lint /workspace/ansible/iredmail/deploy/iredmail.yml
+
+# Check inventory
+docker compose exec ansible-agent ansible-inventory -i /workspace/ansible/inventory --list
+
+# Dry run (check mode)
+docker compose exec ansible-agent ansible-playbook \
+  -i /workspace/ansible/inventory \
+  /workspace/ansible/iredmail/deploy/iredmail.yml \
+  --check --diff
+```
+
+## Workspace layout
+
+Ansible files mounted read-only at `/workspace/ansible/`:
+- `/workspace/ansible/inventory` — host groups: [web], [docker], [k8s], [hzmail]
+- `/workspace/ansible/iredmail/` — iRedMail deployment playbooks
+- SSH keys from host `~/.ssh/` available for connections
+
+## Migration from AWX
+
+| AWX feature | Ansible Agent equivalent |
+|-------------|--------------------------|
+| Job Templates | `ansible-playbook` in container |
+| Inventories | `/workspace/ansible/inventory` |
+| Scheduling | GitHub Actions cron or Claude Code `/schedule` skill |
+| Web UI | Use Semaphore UI (see `clusters/k8s-vms-daniele/apps/semaphore/`) |
+
+## Notes
+
+- SSH agent forwarded from host via `SSH_AUTH_SOCK`
+- For scheduled runs, use the `/schedule` skill in Claude Code or GitHub Actions workflows
+- Ollama available at `$OLLAMA_HOST` for playbook generation (recommended: `qwen2.5-coder:7b` locally on Mac)

--- a/.claude/agents/kubernetes-agent.md
+++ b/.claude/agents/kubernetes-agent.md
@@ -47,4 +47,6 @@ All cluster configs mounted read-only at `/workspace/clusters/`:
 
 - kubeconfig mounted from host's `~/.kube/config` (read-only)
 - For production cluster operations, always prefer GitOps (commit → PR → merge)
-- Ollama available at `$OLLAMA_HOST` for YAML generation (recommended: `qwen2.5-coder:32b` on RTX5090)
+- Ollama available at `$OLLAMA_HOST` for YAML generation
+  - RTX5090 (32GB VRAM): `ollama pull qwen2.5-coder:32b-instruct-q6_K` (~27GB)
+  - Mac M5 Pro (48GB): `ollama pull qwen2.5-coder:32b-instruct-q8_0` (~34GB)

--- a/.claude/agents/kubernetes-agent.md
+++ b/.claude/agents/kubernetes-agent.md
@@ -1,0 +1,50 @@
+---
+name: kubernetes-agent
+description: Kubernetes/Helm/FluxCD specialist agent. Use for kubectl operations, helm template rendering, flux manifest validation, kustomize builds, and GitOps troubleshooting. Runs in an isolated Docker container with kubectl, helm, flux, and kustomize installed.
+---
+
+# Kubernetes / Helm / FluxCD Agent
+
+This agent specializes in Kubernetes, Helm, and FluxCD operations for the infra-cd repository.
+
+## Available tools in the container
+
+- `kubectl` (v1.33.x)
+- `helm` (v3.17.x)
+- `flux` CLI (v2.7.5)
+- `kustomize` (v5.6.x)
+- `yq`, `jq`, `git`, `curl`
+
+## How to invoke
+
+```bash
+# Start the container (once)
+cd docker/agents && docker compose up -d kubernetes-agent
+
+# Validate kustomize builds for a cluster
+docker compose exec kubernetes-agent kustomize build /workspace/clusters/kubenuc/apps/nextcloud/manifests
+
+# Render Helm chart values
+docker compose exec kubernetes-agent helm template nextcloud nextcloud/nextcloud -f /workspace/clusters/kubenuc/apps/nextcloud/manifests/release.yml
+
+# Validate Flux Kustomization manifests
+docker compose exec kubernetes-agent flux check --pre
+
+# Run kubectl against a live cluster (requires kubeconfig mount)
+docker compose exec kubernetes-agent kubectl get pods -A
+```
+
+## Workspace layout
+
+All cluster configs mounted read-only at `/workspace/clusters/`:
+- `/workspace/clusters/kubenuc/`
+- `/workspace/clusters/kubenuc-test/`
+- `/workspace/clusters/k8s-vms-daniele/`
+- `/workspace/clusters/k3s-prod-test/`
+- `/workspace/clusters/common/`
+
+## Notes
+
+- kubeconfig mounted from host's `~/.kube/config` (read-only)
+- For production cluster operations, always prefer GitOps (commit → PR → merge)
+- Ollama available at `$OLLAMA_HOST` for YAML generation (recommended: `qwen2.5-coder:32b` on RTX5090)

--- a/.claude/agents/terraform-agent.md
+++ b/.claude/agents/terraform-agent.md
@@ -1,0 +1,50 @@
+---
+name: terraform-agent
+description: Terraform specialist agent. Use for terraform plan/validate/fmt, provider docs lookups, security scanning with checkov, and infrastructure changes in the terraform/ directory. Runs in an isolated Docker container with all Terraform tools pre-installed.
+---
+
+# Terraform Agent
+
+This agent specializes in Terraform operations for the infra-cd repository.
+
+## Available tools in the container
+
+- `terraform` CLI (v1.10+)
+- `tflint` — Terraform linter
+- `checkov` — Infrastructure security scanner
+- `op` — 1Password CLI for secret lookups
+- `jq`, `git`, `curl`
+
+## How to invoke
+
+```bash
+# Start the container (once)
+cd docker/agents && docker compose up -d terraform-agent
+
+# Run terraform plan in a specific environment
+docker compose exec terraform-agent sh -c "cd /workspace/terraform/hetzner && terraform init && terraform plan"
+
+# Run checkov security scan
+docker compose exec terraform-agent checkov -d /workspace/terraform/hetzner --quiet
+
+# Run tflint
+docker compose exec terraform-agent sh -c "cd /workspace/terraform/hetzner && tflint"
+```
+
+## Workspace layout
+
+All Terraform environments are mounted read-only at `/workspace/terraform/`:
+- `/workspace/terraform/hetzner/`
+- `/workspace/terraform/ec200/`
+- `/workspace/terraform/gozzi-01-bio/`
+- `/workspace/terraform/oci/`
+- `/workspace/terraform/proxmox/`
+- `/workspace/terraform/rabbit-01-psp/`
+- `/workspace/terraform/DNS/`
+
+## Notes
+
+- Terraform state is in Terraform Cloud (Fastnetserv org) — `terraform init` requires `TF_API_TOKEN`
+- 1Password provider requires `OP_TOKEN` and `OP_ENDPOINT` env vars
+- Always run `terraform fmt -check` before committing
+- Ollama available at `$OLLAMA_HOST` for code generation (recommended: `qwen2.5-coder:32b` on RTX5090)

--- a/.claude/agents/terraform-agent.md
+++ b/.claude/agents/terraform-agent.md
@@ -47,4 +47,6 @@ All Terraform environments are mounted read-only at `/workspace/terraform/`:
 - Terraform state is in Terraform Cloud (Fastnetserv org) — `terraform init` requires `TF_API_TOKEN`
 - 1Password provider requires `OP_TOKEN` and `OP_ENDPOINT` env vars
 - Always run `terraform fmt -check` before committing
-- Ollama available at `$OLLAMA_HOST` for code generation (recommended: `qwen2.5-coder:32b` on RTX5090)
+- Ollama available at `$OLLAMA_HOST` for code generation
+  - RTX5090 (32GB VRAM): `ollama pull qwen2.5-coder:32b-instruct-q6_K` (~27GB)
+  - Mac M5 Pro (48GB): `ollama pull qwen2.5-coder:32b-instruct-q8_0` (~34GB)

--- a/clusters/k8s-vms-daniele/apps/semaphore/deploy.yaml
+++ b/clusters/k8s-vms-daniele/apps/semaphore/deploy.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: semaphore-secrets
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: 1p-operator
+  interval: 15m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./clusters/k8s-vms-daniele/apps/semaphore/secrets
+  prune: true
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: semaphore
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: semaphore-secrets
+  interval: 15m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./clusters/k8s-vms-daniele/apps/semaphore/manifests
+  prune: true
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: semaphore
+      namespace: semaphore

--- a/clusters/k8s-vms-daniele/apps/semaphore/manifests/namespace.yml
+++ b/clusters/k8s-vms-daniele/apps/semaphore/manifests/namespace.yml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: semaphore
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/clusters/k8s-vms-daniele/apps/semaphore/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/semaphore/manifests/release.yml
@@ -1,0 +1,94 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: semaphore
+  namespace: semaphore
+spec:
+  interval: 15m
+  maxHistory: 10
+  chart:
+    spec:
+      chart: semaphore
+      version: ">=1.0.0"
+      sourceRef:
+        kind: HelmRepository
+        name: semaphoreui
+        namespace: flux-system
+      interval: 1h
+  install:
+    createNamespace: true
+    remediation:
+      retries: 5
+  upgrade:
+    remediation:
+      retries: 5
+  # Credentials injected from 1Password via semaphore-credentials secret.
+  # The secret must contain:
+  #   admin-username  - Initial admin username
+  #   admin-password  - Initial admin password
+  #   admin-email     - Admin email address
+  #   db-host         - PostgreSQL host (e.g. postgresql-db.postgresql-db.svc.cluster.local)
+  #   db-name         - PostgreSQL database name
+  #   db-user         - PostgreSQL username
+  #   db-password     - PostgreSQL password
+  #   access-key      - Random 32-char string used as encryption key
+  valuesFrom:
+    - kind: Secret
+      name: semaphore-credentials
+      valuesKey: admin-username
+      targetPath: auth.admin.username
+    - kind: Secret
+      name: semaphore-credentials
+      valuesKey: admin-password
+      targetPath: auth.admin.password
+    - kind: Secret
+      name: semaphore-credentials
+      valuesKey: admin-email
+      targetPath: auth.admin.email
+    - kind: Secret
+      name: semaphore-credentials
+      valuesKey: db-host
+      targetPath: database.host
+    - kind: Secret
+      name: semaphore-credentials
+      valuesKey: db-name
+      targetPath: database.name
+    - kind: Secret
+      name: semaphore-credentials
+      valuesKey: db-user
+      targetPath: database.username
+    - kind: Secret
+      name: semaphore-credentials
+      valuesKey: db-password
+      targetPath: database.password
+    - kind: Secret
+      name: semaphore-credentials
+      valuesKey: access-key
+      targetPath: semaphore.accessKey
+  values:
+    database:
+      type: postgres
+
+    ingress:
+      enabled: true
+      className: traefik
+      annotations:
+        cert-manager.io/cluster-issuer: "letsencrypt"
+      hosts:
+        - host: semaphore.fastnetserv.net
+          paths:
+            - path: /
+              pathType: Prefix
+      tls:
+        - secretName: semaphore-tls
+          hosts:
+            - semaphore.fastnetserv.net
+
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi

--- a/clusters/k8s-vms-daniele/apps/semaphore/secrets/kustomization.yaml
+++ b/clusters/k8s-vms-daniele/apps/semaphore/secrets/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: semaphore
+resources:
+  - semaphore-secret.yml

--- a/clusters/k8s-vms-daniele/apps/semaphore/secrets/semaphore-secret.yml
+++ b/clusters/k8s-vms-daniele/apps/semaphore/secrets/semaphore-secret.yml
@@ -1,0 +1,16 @@
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: semaphore-credentials
+  namespace: semaphore
+spec:
+  # Create this item in 1Password with fields:
+  #   admin-username  - Initial admin username
+  #   admin-password  - Initial admin password
+  #   admin-email     - Admin email address
+  #   db-host         - PostgreSQL host
+  #   db-name         - PostgreSQL database name
+  #   db-user         - PostgreSQL username
+  #   db-password     - PostgreSQL password
+  #   access-key      - Random 32-char encryption key (generate with: openssl rand -hex 16)
+  itemPath: "vaults/k8s_secrets/items/semaphore_k8s-vms-daniele"

--- a/clusters/k8s-vms-daniele/charts/kustomization.yaml
+++ b/clusters/k8s-vms-daniele/charts/kustomization.yaml
@@ -2,8 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: flux-system
 resources:
-  - awx.yml
   - falcosecurity.yml
   - grafana.yml
   - prometheus-community.yml
+  - semaphoreui.yml
   - teleport.yml

--- a/clusters/k8s-vms-daniele/charts/semaphoreui.yml
+++ b/clusters/k8s-vms-daniele/charts/semaphoreui.yml
@@ -1,0 +1,10 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: semaphoreui
+  namespace: flux-system
+spec:
+  url: https://semaphoreui.github.io/semaphore
+  interval: 1h
+  timeout: 3m

--- a/docker/agents/ansible/Dockerfile
+++ b/docker/agents/ansible/Dockerfile
@@ -1,0 +1,25 @@
+FROM python:3.12-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    openssh-client \
+    sshpass \
+    jq \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Ansible and tools
+RUN pip install --no-cache-dir \
+    ansible==10.* \
+    ansible-lint \
+    netaddr \
+    jmespath \
+    paramiko
+
+# Install commonly used Ansible collections
+RUN ansible-galaxy collection install \
+    community.general \
+    community.postgresql \
+    ansible.posix \
+    kubernetes.core
+
+WORKDIR /workspace

--- a/docker/agents/docker-compose.yml
+++ b/docker/agents/docker-compose.yml
@@ -3,10 +3,14 @@
 # Usage: docker compose up -d
 # Then use `docker compose exec <service> <command>` or via Claude Code MCP Docker tools
 #
-# For Ollama integration on RTX5090:
+# For Ollama integration on RTX5090 (32GB VRAM):
 #   set OLLAMA_HOST=http://<rtx5090-ip>:11434 in your environment
-# For local Ollama on Mac:
+#   Recommended model: ollama pull qwen2.5-coder:32b-instruct-q6_K  (~27GB)
+#
+# For local Ollama on Mac M5 Pro (48GB unified memory):
 #   set OLLAMA_HOST=http://host.docker.internal:11434
+#   Recommended model (coding): ollama pull qwen2.5-coder:32b-instruct-q8_0  (~34GB)
+#   Recommended model (reasoning): ollama pull deepseek-r1:32b-qwen-distill-q8_0  (~34GB)
 
 services:
   terraform-agent:

--- a/docker/agents/docker-compose.yml
+++ b/docker/agents/docker-compose.yml
@@ -1,0 +1,64 @@
+---
+# Claude Code specialized agent containers
+# Usage: docker compose up -d
+# Then use `docker compose exec <service> <command>` or via Claude Code MCP Docker tools
+#
+# For Ollama integration on RTX5090:
+#   set OLLAMA_HOST=http://<rtx5090-ip>:11434 in your environment
+# For local Ollama on Mac:
+#   set OLLAMA_HOST=http://host.docker.internal:11434
+
+services:
+  terraform-agent:
+    build:
+      context: ./terraform
+      dockerfile: Dockerfile
+    image: infra-cd-terraform-agent:latest
+    container_name: infra-cd-terraform
+    volumes:
+      - ../../terraform:/workspace/terraform:ro
+      - terraform-cache:/root/.terraform.d
+    environment:
+      - TF_CLI_ARGS_plan=-compact-warnings
+      - OLLAMA_HOST=${OLLAMA_HOST:-http://host.docker.internal:11434}
+    working_dir: /workspace/terraform
+    restart: unless-stopped
+    command: ["sleep", "infinity"]
+
+  kubernetes-agent:
+    build:
+      context: ./kubernetes
+      dockerfile: Dockerfile
+    image: infra-cd-kubernetes-agent:latest
+    container_name: infra-cd-kubernetes
+    volumes:
+      - ../../clusters:/workspace/clusters:ro
+      - ${KUBECONFIG:-~/.kube/config}:/root/.kube/config:ro
+    environment:
+      - KUBECONFIG=/root/.kube/config
+      - OLLAMA_HOST=${OLLAMA_HOST:-http://host.docker.internal:11434}
+    working_dir: /workspace
+    restart: unless-stopped
+    command: ["sleep", "infinity"]
+
+  ansible-agent:
+    build:
+      context: ./ansible
+      dockerfile: Dockerfile
+    image: infra-cd-ansible-agent:latest
+    container_name: infra-cd-ansible
+    volumes:
+      - ../../ansible:/workspace/ansible:ro
+      - ${SSH_AUTH_SOCK:-/dev/null}:/ssh-agent
+      - ~/.ssh:/root/.ssh:ro
+    environment:
+      - SSH_AUTH_SOCK=/ssh-agent
+      - ANSIBLE_HOST_KEY_CHECKING=False
+      - OLLAMA_HOST=${OLLAMA_HOST:-http://host.docker.internal:11434}
+    working_dir: /workspace/ansible
+    restart: unless-stopped
+    command: ["sleep", "infinity"]
+
+volumes:
+  terraform-cache:
+    driver: local

--- a/docker/agents/kubernetes/Dockerfile
+++ b/docker/agents/kubernetes/Dockerfile
@@ -1,0 +1,31 @@
+FROM alpine:3.21
+
+ARG KUBECTL_VERSION=v1.33.3
+ARG HELM_VERSION=v3.17.3
+ARG FLUX_VERSION=2.7.5
+ARG KUSTOMIZE_VERSION=v5.6.0
+
+RUN apk add --no-cache \
+    bash \
+    curl \
+    git \
+    jq \
+    yq
+
+# kubectl
+RUN curl -fsSL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
+    -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
+
+# helm
+RUN curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" | \
+    tar xz --strip-components=1 -C /usr/local/bin linux-amd64/helm
+
+# flux CLI
+RUN curl -fsSL "https://github.com/fluxcd/flux2/releases/download/v${FLUX_VERSION}/flux_${FLUX_VERSION}_linux_amd64.tar.gz" | \
+    tar xz -C /usr/local/bin flux
+
+# kustomize
+RUN curl -fsSL "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz" | \
+    tar xz -C /usr/local/bin kustomize
+
+WORKDIR /workspace

--- a/docker/agents/terraform/Dockerfile
+++ b/docker/agents/terraform/Dockerfile
@@ -1,0 +1,24 @@
+FROM hashicorp/terraform:1.10
+
+# Install supporting tools
+RUN apk add --no-cache \
+    bash \
+    curl \
+    git \
+    jq \
+    python3 \
+    py3-pip
+
+# Install tflint
+RUN curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
+
+# Install checkov for security scanning
+RUN pip3 install checkov --break-system-packages
+
+# Install 1Password CLI
+RUN OP_VERSION=$(curl -s https://app-updates.agilebits.com/check/1/0/CLI2/en/2.0.0/N -H "User-Agent: op" | jq -r '.version') && \
+    curl -sSfo /tmp/op.zip "https://cache.agilebits.com/dist/1P/op2/pkg/v${OP_VERSION}/op_linux_amd64_v${OP_VERSION}.zip" && \
+    unzip /tmp/op.zip -d /usr/local/bin/ && \
+    rm /tmp/op.zip
+
+WORKDIR /workspace


### PR DESCRIPTION
## Summary

Replaces Ansible AWX (abandoned upstream) with **Semaphore UI** as the open-source Ansible automation platform. Adds three specialized Docker-based Claude Code agents for Terraform, Kubernetes/FluxCD, and Ansible operations.

---

## Semaphore UI

[Semaphore](https://github.com/semaphoreui/semaphore) is the most popular open-source AWX alternative — actively maintained, lightweight (vs AWX's heavy resource requirements), and purpose-built for running Ansible playbooks via a web UI.

**What it provides vs AWX:**
- Same core features: job templates, schedules, inventory management, RBAC
- Much lighter: ~256Mi RAM vs AWX's 2Gi+
- Simple PostgreSQL backend (reuses existing `postgresql-db`)
- No operator complexity — standard Helm chart

**Access:** `https://semaphore.fastnetserv.net`

### Required setup before merging

Create 1Password item at `vaults/k8s_secrets/items/semaphore_k8s-vms-daniele` with fields:
- `admin-username` / `admin-password` / `admin-email`
- `db-host` / `db-name` / `db-user` / `db-password` (point to existing postgresql-db)
- `access-key` → generate with: `openssl rand -hex 16`

---

## Test plan

- [x] Create 1Password item as described above
- [x] After merge, verify `semaphore` HelmRelease is Ready: `flux get hr -n semaphore`
- [ ] Access `https://semaphore.fastnetserv.net` — login with admin credentials
- [ ] Create a test project in Semaphore pointing to the ansible inventory
- [x] Build docker agents: `cd docker/agents && docker compose build`
- [x] Test terraform agent: `docker compose exec terraform-agent terraform version`
- [x] Test kubernetes agent: `docker compose exec kubernetes-agent flux version`
- [x] Test ansible agent: `docker compose exec ansible-agent ansible --version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)