### PR TITLE
feat(terraform): add hetzner-server reusable module

### DIFF
--- a/terraform/hetzner/main.tf
+++ b/terraform/hetzner/main.tf
@@ -13,21 +13,23 @@ data "onepassword_item" "hcloud_hostname" {
   uuid  = "m4dsdf2ndph7m67czape24qscy"
 }
 
-# Create a server
-resource "hcloud_server" "mail" {
+module "mail" {
+  source = "../modules/hetzner-server"
 
-  name = data.onepassword_item.hcloud_hostname.username
-
+  name        = data.onepassword_item.hcloud_hostname.username
   server_type = "cx23"
   image       = "debian-10"
-
-  location   = "nbg1"
-
-  backups = true
+  location    = "nbg1"
+  backups     = true
+  ssh_key_ids = [hcloud_ssh_key.default.id]
 
   delete_protection  = true
   rebuild_protection = true
+}
 
+moved {
+  from = hcloud_server.mail
+  to   = module.mail.hcloud_server.this
 }
 
 # Create a new SSH key

--- a/terraform/hetzner/main.tf
+++ b/terraform/hetzner/main.tf
@@ -21,7 +21,6 @@ module "mail" {
   image       = "debian-10"
   location    = "nbg1"
   backups     = true
-  ssh_key_ids = [hcloud_ssh_key.default.id]
 
   delete_protection  = true
   rebuild_protection = true

--- a/terraform/modules/hetzner-server/main.tf
+++ b/terraform/modules/hetzner-server/main.tf
@@ -1,0 +1,18 @@
+resource "hcloud_server" "this" {
+  name        = var.name
+  server_type = var.server_type
+  image       = var.image
+  location    = var.location
+  backups     = var.backups
+
+  delete_protection  = var.delete_protection
+  rebuild_protection = var.rebuild_protection
+
+  ssh_keys = var.ssh_key_ids
+
+  labels = var.labels
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/terraform/modules/hetzner-server/outputs.tf
+++ b/terraform/modules/hetzner-server/outputs.tf
@@ -1,0 +1,24 @@
+output "id" {
+  description = "ID of the Hetzner Cloud server"
+  value       = hcloud_server.this.id
+}
+
+output "name" {
+  description = "Name of the Hetzner Cloud server"
+  value       = hcloud_server.this.name
+}
+
+output "ipv4_address" {
+  description = "Public IPv4 address of the server"
+  value       = hcloud_server.this.ipv4_address
+}
+
+output "ipv6_address" {
+  description = "Public IPv6 address of the server"
+  value       = hcloud_server.this.ipv6_address
+}
+
+output "status" {
+  description = "Status of the server (e.g. running)"
+  value       = hcloud_server.this.status
+}

--- a/terraform/modules/hetzner-server/variables.tf
+++ b/terraform/modules/hetzner-server/variables.tf
@@ -1,0 +1,52 @@
+variable "name" {
+  description = "Server hostname"
+  type        = string
+}
+
+variable "server_type" {
+  description = "Hetzner Cloud server type"
+  type        = string
+  default     = "cx23"
+}
+
+variable "image" {
+  description = "OS image to use"
+  type        = string
+  default     = "debian-10"
+}
+
+variable "location" {
+  description = "Hetzner Cloud datacenter location"
+  type        = string
+  default     = "nbg1"
+}
+
+variable "backups" {
+  description = "Enable automatic backups"
+  type        = bool
+  default     = true
+}
+
+variable "delete_protection" {
+  description = "Enable delete protection"
+  type        = bool
+  default     = true
+}
+
+variable "rebuild_protection" {
+  description = "Enable rebuild protection"
+  type        = bool
+  default     = true
+}
+
+variable "ssh_key_ids" {
+  description = "IDs of existing hcloud_ssh_key resources"
+  type        = list(string)
+  default     = []
+}
+
+variable "labels" {
+  description = "Labels to attach to the server"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/hetzner-server/versions.tf
+++ b/terraform/modules/hetzner-server/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    hcloud = {
+      source  = "hetznercloud/hcloud"
+      version = ">= 1.60.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Creates `terraform/modules/hetzner-server/` reusable module with configurable server type, image, location, protections, SSH keys, and labels
- Refactors `terraform/hetzner/main.tf` to use the module instead of inline resource
- Includes `moved` block for zero-downtime state migration — `terraform plan` should show zero changes

## Test plan
- [x] `terraform fmt -check` passes on module and caller
- [x] `terraform init` + `terraform validate` in `terraform/hetzner/`
- [x] `terraform plan` shows zero changes (moved block handles migration)
- [x] CI workflow `terraform.yml` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)