### PR TITLE
feat(ansible): add Falco host-level playbook for Debian 12/13

### DIFF
--- a/ansible/falco/README.md
+++ b/ansible/falco/README.md
@@ -1,0 +1,39 @@
+# Falco Host-Level Playbook
+
+Install and manage [Falco](https://falco.org/) on Debian 12 (bookworm) and 13 (trixie) hosts using the `modern_ebpf` driver.
+
+## Prerequisites
+
+- Debian 12 or 13
+- Kernel >= 5.8 (required by the modern_ebpf driver; the playbook asserts this)
+- SSH access with sudo privileges
+
+## Usage
+
+```bash
+ansible-playbook -i ../inventory -l falco ansible/falco/falco.yml
+```
+
+Or with a specific host:
+
+```bash
+ansible-playbook -i ../inventory -l some-host ansible/falco/falco.yml
+```
+
+## Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `falco_json_output` | `true` | Enable JSON-formatted output |
+| `falco_json_include_output` | `true` | Include the output field in JSON |
+| `falco_json_include_tags` | `true` | Include tags in JSON output |
+| `falco_log_level` | `info` | Log level (`emergency`, `alert`, `critical`, `error`, `warning`, `notice`, `info`, `debug`) |
+| `falco_priority` | `debug` | Minimum rule priority to load |
+
+## Service
+
+The playbook manages the `falco-modern-bpf` systemd service. This is the service unit installed by the Falco package when using the modern eBPF driver (no kernel module or separate probe required).
+
+## Custom Rules
+
+Place host-specific rule overrides in `files/falco_rules.local.yaml`. The file is deployed to `/etc/falco/falco_rules.local.yaml` on target hosts.

--- a/ansible/falco/falco.yml
+++ b/ansible/falco/falco.yml
@@ -1,0 +1,75 @@
+---
+- name: Install and manage Falco on Debian hosts
+  hosts: falco
+  become: true
+  gather_facts: true
+
+  tasks:
+    - name: Assert kernel version >= 5.8 for modern_ebpf driver
+      ansible.builtin.assert:
+        that:
+          - ansible_kernel is version('5.8', '>=')
+        fail_msg: >-
+          Kernel {{ ansible_kernel }} is too old. Falco modern_ebpf driver
+          requires kernel >= 5.8. Please upgrade the kernel first.
+        success_msg: "Kernel {{ ansible_kernel }} meets the >= 5.8 requirement."
+
+    - name: Install prerequisites
+      ansible.builtin.apt:
+        name:
+          - gnupg
+          - curl
+          - apt-transport-https
+        state: present
+        update_cache: true
+
+    - name: Add Falco GPG key
+      ansible.builtin.shell: |
+        curl -fsSL https://falcosecurity.github.io/falco/repo/rpm/FALCO-0F91612B.asc \
+          | gpg --dearmor -o /usr/share/keyrings/falco-archive-keyring.gpg
+      args:
+        creates: /usr/share/keyrings/falco-archive-keyring.gpg
+
+    - name: Add Falco APT repository
+      ansible.builtin.apt_repository:
+        repo: "deb [signed-by=/usr/share/keyrings/falco-archive-keyring.gpg] https://download.falco.org/packages/deb stable main"
+        filename: falcosecurity
+        state: present
+
+    - name: Install Falco
+      ansible.builtin.apt:
+        name: falco
+        state: latest
+        update_cache: true
+
+    - name: Deploy Falco configuration
+      ansible.builtin.template:
+        src: templates/falco.yaml.j2
+        dest: /etc/falco/falco.yaml
+        owner: root
+        group: root
+        mode: '0644'
+      notify: Restart Falco
+
+    - name: Deploy custom rules
+      ansible.builtin.copy:
+        src: files/falco_rules.local.yaml
+        dest: /etc/falco/falco_rules.local.yaml
+        owner: root
+        group: root
+        mode: '0644'
+      notify: Restart Falco
+
+    - name: Enable and start Falco service
+      ansible.builtin.systemd:
+        name: falco-modern-bpf
+        state: started
+        enabled: true
+        daemon_reload: true
+
+  handlers:
+    - name: Restart Falco
+      ansible.builtin.systemd:
+        name: falco-modern-bpf
+        state: restarted
+        daemon_reload: true

--- a/ansible/falco/files/falco_rules.local.yaml
+++ b/ansible/falco/files/falco_rules.local.yaml
@@ -1,0 +1,2 @@
+# Custom Falco rules for host-level monitoring
+# Add host-specific rule overrides here

--- a/ansible/falco/templates/falco.yaml.j2
+++ b/ansible/falco/templates/falco.yaml.j2
@@ -1,0 +1,37 @@
+# Falco configuration — managed by Ansible
+# Do not edit manually; changes will be overwritten.
+
+json_output: {{ falco_json_output | default(true) | lower }}
+json_include_output_property: {{ falco_json_include_output | default(true) | lower }}
+json_include_tags_property: {{ falco_json_include_tags | default(true) | lower }}
+
+log_stderr: false
+log_syslog: true
+log_level: {{ falco_log_level | default('info') }}
+
+rules_files:
+  - /etc/falco/falco_rules.yaml
+  - /etc/falco/falco_rules.local.yaml
+  - /etc/falco/rules.d
+
+priority: {{ falco_priority | default('debug') }}
+
+buffered_outputs: false
+
+outputs:
+  rate: 0
+  max_burst: 1000
+
+syslog_output:
+  enabled: true
+
+stdout_output:
+  enabled: false
+
+file_output:
+  enabled: false
+
+webserver:
+  enabled: true
+  listen_port: 8765
+  ssl_enabled: false

--- a/ansible/inventory
+++ b/ansible/inventory
@@ -9,3 +9,7 @@
 
 [hzmail]
 <ip>
+
+[falco]
+# Add Debian 12/13 hosts for Falco installation
+# example-host ansible_host=192.168.1.x


### PR DESCRIPTION
## Summary
- Creates `ansible/falco/` with playbook for installing Falco via APT on Debian 12/13 hosts
- Uses `modern_ebpf` driver (consistent with Kubernetes deployments), includes kernel >= 5.8 assertion
- Manages configuration via Jinja2 template and custom rules file with handler-based restarts
- Adds `[falco]` host group to inventory

## Test plan
- [ ] `ansible-playbook --syntax-check ansible/falco/falco.yml` passes
- [ ] `ansible-lint ansible/falco/falco.yml` passes
- [ ] Dry run with `--check --diff` against a Debian 12/13 host
- [ ] Full run installs Falco and starts `falco-modern-bpf` service

🤖 Generated with [Claude Code](https://claude.com/claude-code)