### PR TITLE
docs: update agent workspace layout and CLAUDE.md

### DIFF
--- a/.claude/agents/ansible-agent.md
+++ b/.claude/agents/ansible-agent.md
@@ -42,8 +42,9 @@ docker compose exec ansible-agent ansible-playbook \
 ## Workspace layout
 
 Ansible files mounted read-only at `/workspace/ansible/`:
-- `/workspace/ansible/inventory` — host groups: [web], [docker], [k8s], [hzmail]
+- `/workspace/ansible/inventory` — host groups: [web], [docker], [k8s], [hzmail], [falco]
 - `/workspace/ansible/iredmail/` — iRedMail deployment playbooks
+- `/workspace/ansible/falco/` — Falco host-level security deployment (Debian 12/13)
 - SSH keys from host `~/.ssh/` available for connections
 
 ## Migration from AWX

--- a/.claude/agents/terraform-agent.md
+++ b/.claude/agents/terraform-agent.md
@@ -34,13 +34,19 @@ docker compose exec terraform-agent sh -c "cd /workspace/terraform/hetzner && tf
 ## Workspace layout
 
 All Terraform environments are mounted read-only at `/workspace/terraform/`:
-- `/workspace/terraform/hetzner/`
-- `/workspace/terraform/ec200/`
-- `/workspace/terraform/gozzi-01-bio/`
-- `/workspace/terraform/oci/`
-- `/workspace/terraform/proxmox/`
-- `/workspace/terraform/rabbit-01-psp/`
-- `/workspace/terraform/DNS/`
+- `/workspace/terraform/DNS/`              — Cloudflare DNS records
+- `/workspace/terraform/ec200/`            — Legacy standalone ec200 (pre-module)
+- `/workspace/terraform/hetzner/`          — Hetzner Cloud mail server
+- `/workspace/terraform/modules/`          — Reusable modules
+  - `proxmox-vm/`       — Proxmox VM module
+  - `proxmox-lxc/`      — Proxmox LXC module
+  - `hetzner-server/`   — Hetzner Cloud server module
+  - `cloudflare-dns/`   — Cloudflare DNS records module
+- `/workspace/terraform/oci/`              — Oracle Cloud Infrastructure
+- `/workspace/terraform/proxmox/`          — Proxmox hosts (one workspace each)
+  - `ec200/`             — OVH EC200 (MXP)
+  - `gozzi-hpelvisor/`   — Gozzi-01 BIO + hpelvisor
+  - `rabbit/`            — Rabbit-01 PSP
 
 ## Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,7 @@ infra-cd/
 ├── .github/workflows/      # GitHub Actions CI/CD pipelines (8 workflows)
 ├── .claude/                # Claude Code configuration and permissions
 ├── ansible/                # Ansible playbooks for OS automation
+│   ├── falco/              # Falco host-level security (Debian 12/13)
 │   ├── iredmail/           # Mail server configuration
 │   └── ansible-os-updates/ # OS patching (git submodule)
 ├── apps/                   # Shared application definitions
@@ -44,7 +45,8 @@ infra-cd/
 │   ├── DNS/                # DNS records management
 │   ├── hetzner/            # Hetzner Cloud servers
 │   ├── oci/                # Oracle Cloud Infrastructure
-│   ├── modules/            # Reusable Terraform modules (proxmox-lxc, proxmox-vm)
+│   ├── ec200/              # Legacy standalone ec200 (pre-module)
+│   ├── modules/            # Reusable Terraform modules (proxmox-vm, proxmox-lxc, hetzner-server, cloudflare-dns)
 │   └── proxmox/            # Proxmox-managed infra, one workspace per host
 │       ├── ec200/          # OVH EC200 (Proxmox host, MXP workspace)
 │       ├── gozzi-hpelvisor/# Gozzi-01 BIO + hpelvisor Proxmox hosts
@@ -123,7 +125,7 @@ clusters/{cluster-name}/
 - **Format:** Always run `terraform fmt` before committing
 - CI will reject PRs with unformatted Terraform files
 - Each `terraform/{environment}/` (or `terraform/proxmox/{host}/`) is independent with its own backend config
-- Proxmox hosts share reusable modules under `terraform/modules/{proxmox-vm,proxmox-lxc}`
+- Reusable modules under `terraform/modules/`: `proxmox-vm`, `proxmox-lxc`, `hetzner-server`, `cloudflare-dns`
 - Sensitive values are sourced from 1Password provider — never hardcoded
 - Do not hand-pin provider versions managed by Renovate
 


### PR DESCRIPTION
## Summary
- Fixes `terraform-agent.md` workspace paths to match actual directory structure (was referencing `gozzi-01-bio` and `rabbit-01-psp` which don't exist)
- Adds new modules (`hetzner-server`, `cloudflare-dns`) and `ansible/falco/` to all documentation
- Updates `ansible-agent.md` with falco playbook and `[falco]` host group

## Test plan
- [ ] Verify listed paths match actual directory structure
- [ ] Pre-commit hooks pass (trailing whitespace, EOF newline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)