### PR TITLE
feat(sops): hide all FQDNs/IPs via SOPS-encrypted cluster-vars

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "terraform-skill@antonbabenko": true
+  }
+}

--- a/.github/workflows/validate-kubenuc.yml
+++ b/.github/workflows/validate-kubenuc.yml
@@ -234,6 +234,23 @@ jobs:
 
           kubectl -n flux-system wait kustomization/charts --for=condition=ready --timeout=10m
 
+      - name: Create SOPS age secret and cluster-vars
+        run: |
+          kubectl create secret generic sops-age \
+            --namespace=flux-system \
+            --from-literal=age.agekey='${{ secrets.SOPS_AGE_KEY_KUBENUC_TEST }}'
+
+          flux create kustomization cluster-vars \
+            --source=flux-system \
+            --path=./clusters/kubenuc-test/vars \
+            --interval=1h \
+            --prune=true \
+            --decryption-provider=sops \
+            --decryption-secret=sops-age \
+            --wait --timeout=5m
+
+          kubectl -n flux-system wait kustomization/cluster-vars --for=condition=ready --timeout=5m
+
       - name: Deploy 1password operator
         run: |
           flux create kustomization 1p-operator \
@@ -259,6 +276,10 @@ jobs:
                 --path="./$APP_PATH" \
                 --interval=5m \
                 --prune=true
+
+              # Inject postBuild.substituteFrom so ${TST_*} variables in patches get resolved
+              kubectl patch kustomization "app-${APP}" -n flux-system --type=merge -p \
+                '{"spec":{"postBuild":{"substituteFrom":[{"kind":"Secret","name":"cluster-vars","optional":false}]}}}'
             else
               echo "Skipping $APP — not found in kubenuc-test (may be kubenuc-only app)"
             fi

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@
 # SSH Keys
 *.pem
 
+# SOPS age private keys — never commit these
+*.agekey
+
 # Backup files
 *.bak
 

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,20 @@
+creation_rules:
+  # kubenuc production cluster — replace with actual age public key after `age-keygen`
+  - path_regex: clusters/kubenuc/vars/.*\.sops\.yaml$
+    age: age1REPLACE_WITH_KUBENUC_AGE_PUBLIC_KEY
+
+  # k8s-vms-daniele cluster — replace with actual age public key after `age-keygen`
+  - path_regex: clusters/k8s-vms-daniele/vars/.*\.sops\.yaml$
+    age: age1REPLACE_WITH_K8SVMS_AGE_PUBLIC_KEY
+
+  # k3s-rabbit cluster — replace with actual age public key after `age-keygen`
+  - path_regex: clusters/k3s-rabbit/vars/.*\.sops\.yaml$
+    age: age1REPLACE_WITH_K3SRABBIT_AGE_PUBLIC_KEY
+
+  # oc-ampere cluster — replace with actual age public key after `age-keygen`
+  - path_regex: clusters/oc-ampere/vars/.*\.sops\.yaml$
+    age: age1REPLACE_WITH_OCAMPERE_AGE_PUBLIC_KEY
+
+  # kubenuc-test cluster — replace with actual age public key after `age-keygen`
+  - path_regex: clusters/kubenuc-test/vars/.*\.sops\.yaml$
+    age: age1REPLACE_WITH_KUBENUCTEST_AGE_PUBLIC_KEY

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,20 +1,20 @@
 creation_rules:
   # kubenuc production cluster — replace with actual age public key after `age-keygen`
   - path_regex: clusters/kubenuc/vars/.*\.sops\.yaml$
-    age: age1REPLACE_WITH_KUBENUC_AGE_PUBLIC_KEY
+    age: age182k0gk669fkgkq697d86huftt94cfg7s9hq56jaj9qffwu9k648qyyx5dd
 
   # k8s-vms-daniele cluster — replace with actual age public key after `age-keygen`
   - path_regex: clusters/k8s-vms-daniele/vars/.*\.sops\.yaml$
-    age: age1REPLACE_WITH_K8SVMS_AGE_PUBLIC_KEY
+    age: age10zqzjdvku9q2qpq34pqjvss9jarc86wyqxe07x6f0qd8c2w9tvss03awl3
 
   # k3s-rabbit cluster — replace with actual age public key after `age-keygen`
   - path_regex: clusters/k3s-rabbit/vars/.*\.sops\.yaml$
-    age: age1REPLACE_WITH_K3SRABBIT_AGE_PUBLIC_KEY
+    age: age12tmgn4lmzp3u3ruzhzyghc7qzx3zk8nc0p44kryq88dfg72vufrsc4d0tw
 
   # oc-ampere cluster — replace with actual age public key after `age-keygen`
   - path_regex: clusters/oc-ampere/vars/.*\.sops\.yaml$
-    age: age1REPLACE_WITH_OCAMPERE_AGE_PUBLIC_KEY
+    age: age1tljmetrhlj3ep4l2sxqfa5dx8anqlearhpkjnmuzxtkve3wdu57skxfhq0
 
   # kubenuc-test cluster — replace with actual age public key after `age-keygen`
   - path_regex: clusters/kubenuc-test/vars/.*\.sops\.yaml$
-    age: age1REPLACE_WITH_KUBENUCTEST_AGE_PUBLIC_KEY
+    age: age1qwhpwjgw3c7trgrtjv7k309suma9l6qu8yrh4at80clrymrczvss8xq69u

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -13,7 +13,7 @@ creation_rules:
 
   # oc-ampere cluster — replace with actual age public key after `age-keygen`
   - path_regex: clusters/oc-ampere/vars/.*\.sops\.yaml$
-    age: age1tljmetrhlj3ep4l2sxqfa5dx8anqlearhpkjnmuzxtkve3wdu57skxfhq0
+    age: age13fpkwl74k6lttn534vthcq08mr2r684067e2p9yw9h0w5j967g3qlsydgm
 
   # kubenuc-test cluster — replace with actual age public key after `age-keygen`
   - path_regex: clusters/kubenuc-test/vars/.*\.sops\.yaml$

--- a/clusters/k3s-rabbit/apps/teleport-agent/deploy.yaml
+++ b/clusters/k3s-rabbit/apps/teleport-agent/deploy.yaml
@@ -19,6 +19,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
+    - name: cluster-vars
     - name: teleport-kube-agent-join-token
   interval: 5m
   sourceRef:
@@ -26,3 +27,7 @@ spec:
     name: flux-system
   path: ./clusters/k3s-rabbit/apps/teleport-agent/manifests
   prune: true
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-vars

--- a/clusters/k3s-rabbit/apps/teleport-agent/manifests/release.yml
+++ b/clusters/k3s-rabbit/apps/teleport-agent/manifests/release.yml
@@ -23,14 +23,14 @@ spec:
     remediation:
       retries: 6
   values:
-    proxyAddr: teleport.ddlns.net:443
+    proxyAddr: ${TELEPORT_HOST}:443
     kubeClusterName: "k3s-rabbit"
     joinTokenSecret:
       create: false
       name: "teleport-kube-agent-join-token"
     extraEnv:
     - name: HTTPS_PROXY
-      value: "http://squid.ddlns.net:3128"
+      value: "${SQUID_URL}"
     - name: NO_PROXY
       value: "10.43.0.0/24, svc.cluster.local"
 

--- a/clusters/k3s-rabbit/cluster-vars.yaml
+++ b/clusters/k3s-rabbit/cluster-vars.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-vars
+  namespace: flux-system
+spec:
+  interval: 1h
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./clusters/k3s-rabbit/vars
+  prune: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age

--- a/clusters/k3s-rabbit/vars/cluster-vars.sops.yaml
+++ b/clusters/k3s-rabbit/vars/cluster-vars.sops.yaml
@@ -1,20 +1,34 @@
----
-# This file must be encrypted with SOPS before committing.
-# Run: sops --encrypt --in-place clusters/k3s-rabbit/vars/cluster-vars.sops.yaml
+#ENC[AES256_GCM,data:l/sff4cxXsQLH3pl8HH1QzzlXeudhRtN5kBjfsHejxdzV/oSBt3j3Z2+sPkZ++IRM6bBJeqamFBz,iv:qoQ2p1TP0KQ1soRxfeboKfCn7vKibfNuVKcIMCuPfNQ=,tag:tZj7dpE35O2Fl1dVDOtQCQ==,type:comment]
+#ENC[AES256_GCM,data:Z6sr6yscLLvZrO3K8BePdmdut0dtXKDYGtaF80fa+Zq5Mr7iDbEPJowV9H0H4iIgfzO9Y/PhU/pH8v3srvIpzJlVkGfaXk35x5CvjikI6A==,iv:MiiMOgzIrBQLl7Sr3PKYMc+G8n8FXiyE5sm/4yPabw0=,tag:2hZbmfcuxE1wOy+HfLZPww==,type:comment]
 #
-# Bootstrap steps (one-time per cluster):
-#   age-keygen -o age-k3srabbit.agekey
-#   kubectl create secret generic sops-age \
-#     --namespace=flux-system \
-#     --from-file=age.agekey=age-k3srabbit.agekey \
-#     --context=<k3s-rabbit-context>
-#   Update .sops.yaml with the age public key printed by age-keygen.
-#   Store the private key in 1Password — never commit it.
-apiVersion: v1
-kind: Secret
+#ENC[AES256_GCM,data:fuKaN/gaXK7/U1KZXzwoCBLpHb8E7pTQCy0YgLsjyOaPfqfvnnwjgQ==,iv:156r8MQRDT7b07SIXonygG/98gayCv2xncTgUyYQros=,tag:bOYadZ6DUTZ0Di+ASL2axw==,type:comment]
+#ENC[AES256_GCM,data:KhdnA6/X34tMYDrbBZQ0AKpqrkz4es4bj7hHyJy8+kBZrcMW4A==,iv:4RpN4k1gxSuZLGqMV6s41V0bhxj614C9Xp/Lc1gux44=,tag:CFZumDjbufxP7NWY6Tb0Ag==,type:comment]
+#ENC[AES256_GCM,data:xK006aIhmiQKbLec24ypeuplenB1BOHH6P51cMPJMx8YUgDTxdQBz0vx2A==,iv:xSvDNQNLMHilCNHAFz5/jpa8Q1ZZuzzj2JX/AoS0NVk=,tag:sX9CIYdBjkVc61d71mdkVw==,type:comment]
+#ENC[AES256_GCM,data:vU8F05ajlkyPVllmd417k+41AeCWIrIjtUjLb5B5,iv:slLtedZKqVL6noskeySXyiEReMScTylwJKIeEW/GZHA=,tag:VdRFox1yp5Tg6Uy6K+ZePQ==,type:comment]
+#ENC[AES256_GCM,data:vpodM459gFkrjt9dNv6V+sR3S1u/SJ2RJfVeMi6ux5CdX+U/5pxgly5FaDlhSPb32DI=,iv:L6qIGLKNU/S05JXE2W1/BqsYMoXOwBTa9vi1JYI9t84=,tag:Us1+zVqXKvL5Pw+EaZkamw==,type:comment]
+#ENC[AES256_GCM,data:SZAZ8PjFO1TIBXqPVRxOhUhVp/0lhTTMqZ2xM850Ijh4+P4=,iv:91m+uuS420fokP0VryKmEvVPLMnETDkPIqLifLVP65Q=,tag:huzEQp+STcD+NyrA9SON/w==,type:comment]
+#ENC[AES256_GCM,data:d3qwPUq8cFVbTSEEhvmAh6mXIFBzz4Tok/ohlZcbRk45QToPPEHjqREw/7CQvyEI5wD6ug4H3Ri72ZS27UpWzb5MVQ==,iv:O2Y6ANsuTp7ItLx0FTt0d7s/BkMp4MsJPlFVRsVTXTg=,tag:RJy0krqEs/42yDq0AcJMHQ==,type:comment]
+#ENC[AES256_GCM,data:83fjXbqaCt/F1mf4paVzBg4K58l4Ixu8LNgvhfurhZ3G025yrsieuix4IR5u2ScJvRxh/wmKSEPZEg==,iv:NCDLbyK6cIh81CDMd2lFu+VJKw07ix3Rmy/vfVui768=,tag:AmSEoPSNsDvPgkZP4qtfcA==,type:comment]
+apiVersion: ENC[AES256_GCM,data:0ZA=,iv:tI5GstWc4dqL1ARm79wyJ45BxXbxyenfigEjJCk+9nU=,tag:l/8hsfAGLad9QuGafPNS4Q==,type:str]
+kind: ENC[AES256_GCM,data:lokfwUZw,iv:YEbAun3r01WnuuCyaXiCcp1HeRjJxlcRxGQtXbm+o9s=,tag:mS0D1e/Ljwe+ycrJj3p8CQ==,type:str]
 metadata:
-  name: cluster-vars
-  namespace: flux-system
+    name: ENC[AES256_GCM,data:n+hFys9yEMEcSF9N,iv:deioc2BMppHcjLQCISxfX9E0F7FFARzhl3JvEngxw8Q=,tag:N6zofNt1Yr9hY+5oP1/aFQ==,type:str]
+    namespace: ENC[AES256_GCM,data:wEfPnVuQHFUn9BM=,iv:2tOLdKUgj+qjrStlPU9sT2mIqfN8djbzncZ/ZsJexQY=,tag:Zk0dtOfi4NEOwogXST3+Dg==,type:str]
 stringData:
-  TELEPORT_HOST: "teleport.ddlns.net"
-  SQUID_URL: "http://squid.ddlns.net:3128"
+    TELEPORT_HOST: ENC[AES256_GCM,data:nnFzeJ3eYa7jOLw+uUdUvj01,iv:wjQlf0QDKJImMxUBZ4KzoR1slE+WZlpxVPQL40uB9Ls=,tag:RYy5Kw5B1sKdlsZXtcCIBw==,type:str]
+    SQUID_URL: ENC[AES256_GCM,data:wsP9ONVgaEPhkQW4PVT5KmqVKvBs1Ir+vE5K,iv:2xixE67RhildO/q8ev/dhFA7ogVPRL2Pr6fZh18hbiE=,tag:OHzCH1mKtqSM54Wk0GplKg==,type:str]
+sops:
+    age:
+        - recipient: age12tmgn4lmzp3u3ruzhzyghc7qzx3zk8nc0p44kryq88dfg72vufrsc4d0tw
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBySm9qb0M1YlQwRHNCWTRq
+            NXQrYjA0QzRMaVJFS2RjRGVTTUpjNGE2VEVNCjNTQTZXZG1WYlhMeXBFZEpSc3lB
+            YTlJT0FLTDBXa1lJcUNPdDg1M012QWcKLS0tIHpVVVNmTkRRckwvOEMzeWFhb0tG
+            NGtmZWg0VGMxdDliYjNJeWdmMURsd2MKS90RP5GQZqb6EE4ZNih5rAN0gqOxqINA
+            wY7dQmrnHC4TxAkv4KzF8BMW5WXZ+DUb18vUDxCDjCS61e6nWxmNEw==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-04-11T18:36:28Z"
+    mac: ENC[AES256_GCM,data:W3RkhbyeRXDSQep1Io8mT2XQbfY7j48AD7du5LWuw+X7LAnNGaoNN9T7jAdsDjpIFeXeSq+PS1gnhJ+O1Yni14vDa9iLok7pNMrGGeBM5f6WMdZs4LPu7aNJPAH2LD09R/ebUiDyrSPp5c2Eu/zC9Wi9oc77sO0N4JXFdVS0Yvs=,iv:ZHPU30EYjSw2yOkBqLV0QXM3K/vn7dY1llcykSpubmk=,tag:IN0TBaxdM81g8Zkpx3utqA==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.12.2

--- a/clusters/k3s-rabbit/vars/cluster-vars.sops.yaml
+++ b/clusters/k3s-rabbit/vars/cluster-vars.sops.yaml
@@ -1,0 +1,20 @@
+---
+# This file must be encrypted with SOPS before committing.
+# Run: sops --encrypt --in-place clusters/k3s-rabbit/vars/cluster-vars.sops.yaml
+#
+# Bootstrap steps (one-time per cluster):
+#   age-keygen -o age-k3srabbit.agekey
+#   kubectl create secret generic sops-age \
+#     --namespace=flux-system \
+#     --from-file=age.agekey=age-k3srabbit.agekey \
+#     --context=<k3s-rabbit-context>
+#   Update .sops.yaml with the age public key printed by age-keygen.
+#   Store the private key in 1Password — never commit it.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cluster-vars
+  namespace: flux-system
+stringData:
+  TELEPORT_HOST: "teleport.ddlns.net"
+  SQUID_URL: "http://squid.ddlns.net:3128"

--- a/clusters/k8s-vms-daniele/apps/awx/deploy.yaml
+++ b/clusters/k8s-vms-daniele/apps/awx/deploy.yaml
@@ -19,6 +19,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
+    - name: cluster-vars
     - name: awx-secrets
   interval: 1m
   sourceRef:
@@ -26,3 +27,7 @@ spec:
     name: flux-system
   path: ./clusters/k8s-vms-daniele/apps/awx/manifests
   prune: true
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-vars

--- a/clusters/k8s-vms-daniele/apps/awx/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/awx/manifests/release.yml
@@ -31,7 +31,7 @@ spec:
       spec:
         ingress_type: ingress
         ingress_class_name: traefik
-        hostname: ansible.fastnetserv.net
+        hostname: ${AWX_HOST}
         secret_key_secret: custom-awx-secret-key
         projects_persistence: true
         projects_storage_class: local-path
@@ -41,7 +41,7 @@ spec:
         - setting: CSRF_TRUSTED_ORIGINS
           value:
           - https://localhost:3001
-          - https://ansible.fastnetserv.net
+          - https://${AWX_HOST}
         web_resource_requirements:
           requests:
             cpu: 200m

--- a/clusters/k8s-vms-daniele/apps/cloudflare/deploy.yml
+++ b/clusters/k8s-vms-daniele/apps/cloudflare/deploy.yml
@@ -6,6 +6,8 @@ metadata:
   name: cloudflared
   namespace: flux-system
 spec:
+  dependsOn:
+    - name: cluster-vars
   targetNamespace: cloudflare
   path: ./clusters/k8s-vms-daniele/apps/cloudflare/manifests
   prune: true
@@ -13,3 +15,7 @@ spec:
     kind: GitRepository
     name: flux-system
   interval: 15m
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-vars

--- a/clusters/k8s-vms-daniele/apps/cloudflare/manifests/cloudflared.yml
+++ b/clusters/k8s-vms-daniele/apps/cloudflare/manifests/cloudflared.yml
@@ -99,10 +99,10 @@ data:
     # from the internet to cloudflared, run `cloudflared tunnel route dns <tunnel> <hostname>`.
     # E.g. `cloudflared tunnel route dns example-tunnel tunnel.example.com`.
     ingress:
-    - hostname: "*.ddlns.net"
+    - hostname: "*.${CLOUDFLARE_DOMAIN}"
       service: https://traefik.kube-system.svc.cluster.local:443
       originRequest:
-        originServerName: ddlns.net
+        originServerName: ${CLOUDFLARE_DOMAIN}
     #- hostname: "*.example.dev"
     #  service: https://traefik.ingress.svc.cluster.local:443
     #  originRequest:

--- a/clusters/k8s-vms-daniele/apps/falco/deploy.yaml
+++ b/clusters/k8s-vms-daniele/apps/falco/deploy.yaml
@@ -20,6 +20,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
+    - name: cluster-vars
     - name: falco-secrets
   targetNamespace: falco
   interval: 15m
@@ -28,6 +29,10 @@ spec:
     name: flux-system
   path: ./clusters/k8s-vms-daniele/apps/falco/manifests
   prune: true
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-vars
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease

--- a/clusters/k8s-vms-daniele/apps/falco/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/falco/manifests/release.yml
@@ -88,7 +88,7 @@ spec:
       replicaCount: 1
       config:
         loki:
-          hostport: "https://logs-prod-039.grafana.net"
+          hostport: "${GRAFANA_LOKI_HOST}"
           endpoint: "/loki/api/v1/push"
           extralabels: "source:falco,cluster:k8s-vms-daniele"
         slack:

--- a/clusters/k8s-vms-daniele/apps/grafana-alloy/deploy.yaml
+++ b/clusters/k8s-vms-daniele/apps/grafana-alloy/deploy.yaml
@@ -20,6 +20,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
+    - name: cluster-vars
     - name: grafana-alloy-secrets
   targetNamespace: grafana-alloy
   interval: 15m
@@ -28,6 +29,10 @@ spec:
     name: flux-system
   path: ./clusters/k8s-vms-daniele/apps/grafana-alloy/manifests
   prune: true
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-vars
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease

--- a/clusters/k8s-vms-daniele/apps/grafana-alloy/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/grafana-alloy/manifests/release.yml
@@ -51,12 +51,12 @@ spec:
     destinations:
       - name: grafana-cloud-metrics
         type: prometheus
-        url: https://prometheus-prod-58-prod-eu-central-0.grafana.net/api/prom/push
+        url: ${GRAFANA_PROMETHEUS_URL}
         auth:
           type: basic
       - name: grafana-cloud-logs
         type: loki
-        url: https://logs-prod-039.grafana.net/loki/api/v1/push
+        url: ${GRAFANA_LOKI_URL}
         auth:
           type: basic
 

--- a/clusters/k8s-vms-daniele/apps/semaphore/deploy.yaml
+++ b/clusters/k8s-vms-daniele/apps/semaphore/deploy.yaml
@@ -21,6 +21,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
+    - name: cluster-vars
     - name: semaphore-secrets
   interval: 15m
   sourceRef:
@@ -28,6 +29,10 @@ spec:
     name: flux-system
   path: ./clusters/k8s-vms-daniele/apps/semaphore/manifests
   prune: true
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-vars
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease

--- a/clusters/k8s-vms-daniele/apps/semaphore/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/semaphore/manifests/release.yml
@@ -76,14 +76,14 @@ spec:
       annotations:
         cert-manager.io/cluster-issuer: "letsencrypt"
       hosts:
-        - host: semaphore.fastnetserv.net
+        - host: ${SEMAPHORE_HOST}
           paths:
             - path: /
               pathType: Prefix
       tls:
         - secretName: semaphore-tls
           hosts:
-            - semaphore.fastnetserv.net
+            - ${SEMAPHORE_HOST}
 
     resources:
       requests:

--- a/clusters/k8s-vms-daniele/apps/teleport-agent/deploy.yaml
+++ b/clusters/k8s-vms-daniele/apps/teleport-agent/deploy.yaml
@@ -18,9 +18,15 @@ metadata:
   name: teleport-kube-agent
   namespace: flux-system
 spec:
+  dependsOn:
+    - name: cluster-vars
   interval: 5m
   sourceRef:
     kind: GitRepository
     name: flux-system
   path: ./clusters/k8s-vms-daniele/apps/teleport-agent/manifests
   prune: true
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-vars

--- a/clusters/k8s-vms-daniele/apps/teleport-agent/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/teleport-agent/manifests/release.yml
@@ -23,7 +23,7 @@ spec:
     remediation:
       retries: 6
   values:
-    proxyAddr: teleport.ddlns.net:443
+    proxyAddr: ${TELEPORT_HOST}:443
     kubeClusterName: "k8s-vms-daniele"
     joinTokenSecret:
       create: false

--- a/clusters/k8s-vms-daniele/charts/semaphoreui.yml
+++ b/clusters/k8s-vms-daniele/charts/semaphoreui.yml
@@ -5,6 +5,6 @@ metadata:
   name: semaphoreui
   namespace: flux-system
 spec:
-  url: https://semaphoreui.github.io/semaphore
+  url: https://semaphoreui.github.io/charts
   interval: 1h
   timeout: 3m

--- a/clusters/k8s-vms-daniele/cluster-vars.yaml
+++ b/clusters/k8s-vms-daniele/cluster-vars.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-vars
+  namespace: flux-system
+spec:
+  interval: 1h
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./clusters/k8s-vms-daniele/vars
+  prune: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age

--- a/clusters/k8s-vms-daniele/vars/cluster-vars.sops.yaml
+++ b/clusters/k8s-vms-daniele/vars/cluster-vars.sops.yaml
@@ -1,25 +1,39 @@
----
-# This file must be encrypted with SOPS before committing.
-# Run: sops --encrypt --in-place clusters/k8s-vms-daniele/vars/cluster-vars.sops.yaml
+#ENC[AES256_GCM,data:Do+jhvwAxfoyWPSgEsl4BBSIvm0pjiu/DG8gHD/FwoSEA6He0sKX/7wbuIKUVfXYW5ed4XIHS+UP,iv:HoM7r6HDX69y41uXhRUncLFyoqdAxA3AZCEs0YaZmS4=,tag:CRi9aesDfQfwwK4CSabbfA==,type:comment]
+#ENC[AES256_GCM,data:yRjfoMeaOqaJRqYNf1DAThcejAJnFZx4xUdKC2dpcNEZcR6kTybLEUshssdCX/pYh+CDolSAtvrQYmLOwRvMc88K15p/Wg0gpxbMgHTZv2Q0X+V8,iv:j/+4B5FcFBHD+NzcPUwQXFLOErrXc4EKqTOqIkF1GnY=,tag:1P3cPpVx6uXhrhcZxHLdlg==,type:comment]
 #
-# Bootstrap steps (one-time per cluster):
-#   age-keygen -o age-k8svms.agekey
-#   kubectl create secret generic sops-age \
-#     --namespace=flux-system \
-#     --from-file=age.agekey=age-k8svms.agekey \
-#     --context=<k8s-vms-daniele-context>
-#   Update .sops.yaml with the age public key printed by age-keygen.
-#   Store the private key in 1Password — never commit it.
-apiVersion: v1
-kind: Secret
+#ENC[AES256_GCM,data:9iChQWqD+X8ke1oVctqRTKUHvYQFCcgy8k7aV5yKdWrFWPKNF+P08A==,iv:RhWge5f5o2jlRMPZI+io5AuFNSg9ANUmsAaXMoyxpYY=,tag:ka8Qz974Q/ezN3s6NMQmEQ==,type:comment]
+#ENC[AES256_GCM,data:Z8KFqYbfgh9cf9vdvScoKOSiKg7Kevv5vrX2IvwkxyeQPg==,iv:r/KxH0c8JYatx19IuqghzD2aJ45zZdGiafwLurvUhv8=,tag:zb8fxzi066Xx/6WUexO7Cw==,type:comment]
+#ENC[AES256_GCM,data:t59G6jnoM/nnQGVBl5JoWk2xqdkteIk2ub43pQS+wn0cWiNpNfjOiAVqxQ==,iv:wMIIKfqaxfq1MXHXwDzDMBibuagfobVzx8F+4EAPFNs=,tag:kW1pnYPuvCxs90VrGKy1sQ==,type:comment]
+#ENC[AES256_GCM,data:u8OkhQoogENc7Vn4H9zgE02ofP1X5VUn0vA5Y4ta,iv:lwjXaHKd4kvvKkejFx3ZpZyoB0d5NcPHVswz7LbKUu4=,tag:NHVDcFViQBLSq5tlFgP5Eg==,type:comment]
+#ENC[AES256_GCM,data:V+Q+2jNp2+qsRrMBemDvKm+yfnx83xf83DgkGJ+c42jtFhRD21lAoVSi1c6z5Tw=,iv:n36eXzzZU7J2oXPJ2MVrSXIx5QM8WaXATuydYJAsPHw=,tag:GWUhyJh4oEz3YXeYzE8DSA==,type:comment]
+#ENC[AES256_GCM,data:XsmqusuVMVZ99YzZ/CF3jjWLctAOClcLjnOr4jQClCUMNz87tD5OxA==,iv:d3EXKGCcqYQ+lhz8XQ6qlWlEkXUfWT9tzMMcH7n//NA=,tag:a7CaGAFrKWdN3UgIoHS1cw==,type:comment]
+#ENC[AES256_GCM,data:MPO/l41pdlWLFH7Qs/s3iECGJEatSpY0U3Lg9cTUtmZ71fY5IEL6XEfwVTW1Bgu0FZaXSMOdGBPqmBQWXAp/OmcGNw==,iv:7KEfdOhol3qmKCIcy1epXWxAzX26BAG/sc1HHhHMUj0=,tag:2qlzipt57BlCp7VjQn/okA==,type:comment]
+#ENC[AES256_GCM,data:UcaZFbUm/8PNdnGaFsPf6i5x5aiyegmFvKx+Gw4eOKtkEqNbkdfXoe8yy5B1w250+giizcSt2+VANw==,iv:dNpmhKqxJejzxRh71y0IQ9ty1qgDyL2mmzQ+FJyHtjQ=,tag:6JXPBWDkyOY0MwStHwgZGQ==,type:comment]
+apiVersion: ENC[AES256_GCM,data:MWc=,iv:6DtiPArlOBuj7i72sYQiEHtiyjYJyngoqOtwTgmd9Dk=,tag:XeYfyeHc0WIB1tt/EMSVuQ==,type:str]
+kind: ENC[AES256_GCM,data:MsY3sbiT,iv:l1rdSxj/Zp/gvWm1oiNVmzpPdYpw03mech3rkkG4r/M=,tag:MltvGv8/UTRm773WXFG4xA==,type:str]
 metadata:
-  name: cluster-vars
-  namespace: flux-system
+    name: ENC[AES256_GCM,data:Lomg7+WZSpH2lqdQ,iv:nHAQOx+fjFqS+2pTQK6LcvCA9u52bsCkbFk2K8suPsk=,tag:ZK7cHPwD09hqM4kHSJkCGQ==,type:str]
+    namespace: ENC[AES256_GCM,data:l4UUgpP1p8onCrs=,iv:kg4mFzAxf43QIJrWzuWnKrYBXWcMTZ5yGo7F0ilQf0I=,tag:I4ik1RpDjU3WRHXARGdXbg==,type:str]
 stringData:
-  SEMAPHORE_HOST: "semaphore.fastnetserv.net"
-  GRAFANA_PROMETHEUS_URL: "https://prometheus-prod-58-prod-eu-central-0.grafana.net/api/prom/push"
-  GRAFANA_LOKI_URL: "https://logs-prod-039.grafana.net/loki/api/v1/push"
-  GRAFANA_LOKI_HOST: "https://logs-prod-039.grafana.net"
-  AWX_HOST: "ansible.fastnetserv.net"
-  TELEPORT_HOST: "teleport.ddlns.net"
-  CLOUDFLARE_DOMAIN: "ddlns.net"
+    SEMAPHORE_HOST: ENC[AES256_GCM,data:XqkIFagfY+BSMbtkZeRD6ypS7+NRnBlHMw==,iv:SbyvpnB9FA1EMZ47nGaGGxVLUmOF9gHKR2RlF4J0Ftw=,tag:lWktYzKx0gtby/ygsCRWIg==,type:str]
+    GRAFANA_PROMETHEUS_URL: ENC[AES256_GCM,data:KaEjI3epDiyKLNHH35LpnEemVG11KuUukxcS8HpFHoc640wRxFKxmsW8GnnAAtLDAzLtTL1EuLLI1Dw5FsNGho3OABAu+Q==,iv:ppRPpGizsSKuH/AM3AsOlArO1SL6TD9JNlAkQZ8h4Zc=,tag:lTHL27Go5wdSjl6gD4rCvQ==,type:str]
+    GRAFANA_LOKI_URL: ENC[AES256_GCM,data:tRZAT++WZ7+BbkGk+gmiYzt78Pkeq2QQaz6ksEQrFl07ro/ryyTsHkN46ZIZ2mxbzDg=,iv:H9TzN/Q3ReoyqIfVigYqPetcCaub+S1ntUMtM0zG5hc=,tag:zoj6EF7ogTsA7VJ5Ao/D6A==,type:str]
+    GRAFANA_LOKI_HOST: ENC[AES256_GCM,data:GCIlBn2jDem3fyyec2Ygyn+MpwtKN1EbnC/stMmxPYSM,iv:SH7Vhe4YjOnv4vwodqf+vGh3BHwog6DOqf4al+kZKNs=,tag:cn/uTx87pVd/afW3Z+meuA==,type:str]
+    AWX_HOST: ENC[AES256_GCM,data:gkN52jP9aPY9gT18CzgvwdjXLxHQQyE=,iv:HMET3zD7ZJJl+ZdaaO+9RUDAblsgwWhyQsrwRgMlhAA=,tag:zXilO1+aKEqzmZqxwVUyTA==,type:str]
+    TELEPORT_HOST: ENC[AES256_GCM,data:NuNO5uwd4CGuKkDILx56VPXc,iv:l2aO5waJ2tCfk/3jm8XthpADCMam+7MU2McsQMvr8H0=,tag:9ktJ1aZJpA+Lo0EmKg3gcg==,type:str]
+    CLOUDFLARE_DOMAIN: ENC[AES256_GCM,data:83EpnEbqQFkn,iv:XImScuHda046xF/gce7ngtEpRmIsCMc8wuoInZboejk=,tag:YxPDOATqP713eLVyUkcEcg==,type:str]
+sops:
+    age:
+        - recipient: age10zqzjdvku9q2qpq34pqjvss9jarc86wyqxe07x6f0qd8c2w9tvss03awl3
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6dHlwSzltUUJweTcvQWZl
+            bkpNZWl4dzVmYjI4aWZZZXU1VCtsNnBBZDFFCkIrRDE2VWtwQXpPUkJnTW92dFpP
+            OEtsV0JDamxNeDVQdnJRdEpDL2FiYVEKLS0tIFFMZWVsaFFtZ09yaURZc25STkpv
+            VlBvN01TenkvK2NodEhieGhJNFhMSUEK5UjGaIxF7FPtLCXvDvWxQXJzrYZzry1W
+            erWwzhcG2HzE7ZZ/r0YNtbvlksYUYfBIurpPHaAQnx2eAi3pK2eMPg==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-04-11T18:37:02Z"
+    mac: ENC[AES256_GCM,data:IlR8r85gKrBHWId74L2PPZ1rsvIEhpKSlXfYJJ0IpR7r7JlsTpLnBejKFr9gv1aklIZP4vNqA53EFpxMe+BwWCjojMLVNvuTMEklJbcn5gKeWlapT9Tujz3Xe37oOmX4VrOIb9MoQ15Skbs0ZO6XtfozoNf1RS+Dx5Um1hiVPrs=,iv:n7qdC+G+uWmycDt5bPycVQYqJWuZyMczDwAZf0P+KyA=,tag:q5E1MuB+rdUxCgJYllTvKQ==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.12.2

--- a/clusters/k8s-vms-daniele/vars/cluster-vars.sops.yaml
+++ b/clusters/k8s-vms-daniele/vars/cluster-vars.sops.yaml
@@ -1,0 +1,25 @@
+---
+# This file must be encrypted with SOPS before committing.
+# Run: sops --encrypt --in-place clusters/k8s-vms-daniele/vars/cluster-vars.sops.yaml
+#
+# Bootstrap steps (one-time per cluster):
+#   age-keygen -o age-k8svms.agekey
+#   kubectl create secret generic sops-age \
+#     --namespace=flux-system \
+#     --from-file=age.agekey=age-k8svms.agekey \
+#     --context=<k8s-vms-daniele-context>
+#   Update .sops.yaml with the age public key printed by age-keygen.
+#   Store the private key in 1Password — never commit it.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cluster-vars
+  namespace: flux-system
+stringData:
+  SEMAPHORE_HOST: "semaphore.fastnetserv.net"
+  GRAFANA_PROMETHEUS_URL: "https://prometheus-prod-58-prod-eu-central-0.grafana.net/api/prom/push"
+  GRAFANA_LOKI_URL: "https://logs-prod-039.grafana.net/loki/api/v1/push"
+  GRAFANA_LOKI_HOST: "https://logs-prod-039.grafana.net"
+  AWX_HOST: "ansible.fastnetserv.net"
+  TELEPORT_HOST: "teleport.ddlns.net"
+  CLOUDFLARE_DOMAIN: "ddlns.net"

--- a/clusters/kubenuc-test/apps.yaml
+++ b/clusters/kubenuc-test/apps.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   interval: 10m
   dependsOn:
+    - name: cluster-vars
     - name: charts
     - name: charts-test
   sourceRef:
@@ -15,3 +16,7 @@ spec:
   prune: true
   timeout: 5m0s
   wait: true
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-vars

--- a/clusters/kubenuc-test/apps/harbor/deploy.yaml
+++ b/clusters/kubenuc-test/apps/harbor/deploy.yaml
@@ -69,10 +69,10 @@ spec:
           value: "PGPASSWORDTEST"
         - op: replace
           path: /spec/values/externalURL
-          value: https://harbor.tst.ddlns.net
+          value: ${TST_HARBOR_URL}
         - op: replace
           path: /spec/values/expose/ingress/hosts/core
-          value: harbor.tst.ddlns.net
+          value: ${TST_HARBOR_HOST}
     - target:
         kind: HelmRelease
         name: redis

--- a/clusters/kubenuc-test/apps/jellyfin/deploy.yaml
+++ b/clusters/kubenuc-test/apps/jellyfin/deploy.yaml
@@ -32,10 +32,10 @@ spec:
       patch: |
         - op: replace
           path: /spec/values/ingress/main/hosts/0/host
-          value: tv.tst.ddlns.net
+          value: ${TST_JELLYFIN_HOST}
         - op: replace
           path: /spec/values/ingress/main/tls/0/hosts/0
-          value: tv.tst.ddlns.net
+          value: ${TST_JELLYFIN_HOST}
         - op: replace
           path: /spec/values/ingress/main/tls/0/secretName
           value: jellyfin-tst-tls

--- a/clusters/kubenuc-test/apps/jenkins/deploy.yaml
+++ b/clusters/kubenuc-test/apps/jenkins/deploy.yaml
@@ -39,10 +39,10 @@ spec:
           path: /spec/values/agent/resources
         - op: replace
           path: /spec/values/controller/ingress/hostName
-          value: jenkins.tst.ddlns.net
+          value: ${TST_JENKINS_HOST}
         - op: replace
           path: /spec/values/controller/ingress/tls/0/hosts/0
-          value: jenkins.tst.ddlns.net
+          value: ${TST_JENKINS_HOST}
         - op: replace
           path: /spec/values/controller/ingress/tls/0/secretName
           value: jenkins-tst-tls

--- a/clusters/kubenuc-test/apps/jfrog-acr/deploy.yaml
+++ b/clusters/kubenuc-test/apps/jfrog-acr/deploy.yaml
@@ -40,5 +40,5 @@ spec:
           path: /spec/values/artifactory/ingress
           value:
             hosts:
-            - artifactory.tst.ddlns.net
+            - ${TST_ARTIFACTORY_HOST}
 

--- a/clusters/kubenuc-test/apps/nextcloud/deploy.yaml
+++ b/clusters/kubenuc-test/apps/nextcloud/deploy.yaml
@@ -70,13 +70,13 @@ spec:
         - op: replace
           path: /spec/values/nextcloud
           value:
-            host: cloud.tst.ddlns.net
+            host: ${TST_NEXTCLOUD_HOST}
         - op: replace
           path: /spec/values/ingress/tls
           value:
             - secretName: nx-fastnet-tls
               hosts:
-              - cloud.tst.ddlns.net
+              - ${TST_NEXTCLOUD_HOST}
     - target:
         kind: CronJob
         name: nextcloud-db-backup

--- a/clusters/kubenuc-test/apps/portainer/deploy.yaml
+++ b/clusters/kubenuc-test/apps/portainer/deploy.yaml
@@ -30,10 +30,10 @@ spec:
           path: /spec/values/resources
         - op: replace
           path: /spec/values/ingress/hosts/0/host
-          value: portainer.tst.ddlns.net
+          value: ${TST_PORTAINER_HOST}
         - op: replace
           path: /spec/values/ingress/tls/0/hosts/0
-          value: portainer.tst.ddlns.net
+          value: ${TST_PORTAINER_HOST}
         - op: replace
           path: /spec/values/ingress/tls/0/secretName
           value: portainer-tst-tls

--- a/clusters/kubenuc-test/apps/s3/deploy.yaml
+++ b/clusters/kubenuc-test/apps/s3/deploy.yaml
@@ -31,7 +31,7 @@ spec:
         - op: replace
           path: /spec/values/ingress/s3/api/hosts
           value:
-            - host: s3-api.tst.ddlns.net
+            - host: ${TST_S3_API_HOST}
               paths:
                 - path: /
                   pathType: Prefix
@@ -40,11 +40,11 @@ spec:
           value:
             - secretName: garage-ingress-cert
               hosts:
-                - s3-api.tst.ddlns.net
+                - ${TST_S3_API_HOST}
         - op: replace
           path: /spec/values/ingress/s3/web/hosts
           value:
-            - host: nx.s3.tst.ddlns.net
+            - host: ${TST_S3_WEB_HOST}
               paths:
                 - path: /
                   pathType: Prefix
@@ -53,4 +53,4 @@ spec:
           value:
             - secretName: garage-web-ingress-cert
               hosts:
-                - nx.s3.tst.ddlns.net
+                - ${TST_S3_WEB_HOST}

--- a/clusters/kubenuc-test/apps/sso/deploy.yaml
+++ b/clusters/kubenuc-test/apps/sso/deploy.yaml
@@ -69,13 +69,13 @@ spec:
           value: "PGPASSWORDTEST"
         - op: replace
           path: /spec/values/server/ingress/hosts
-          value: https://sso.tst.ddlns.net
+          value: ${TST_SSO_URL}
         - op: replace
           path: /spec/values/server/ingress/tls
           value:
             - secretName: sso-tst-tls
               hosts:
-                - sso.tst.ddlns.net
+                - ${TST_SSO_HOST}
     - target:
         kind: HelmRelease
         name: zitadel

--- a/clusters/kubenuc-test/cluster-vars.yaml
+++ b/clusters/kubenuc-test/cluster-vars.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-vars
+  namespace: flux-system
+spec:
+  interval: 1h
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./clusters/kubenuc-test/vars
+  prune: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age

--- a/clusters/kubenuc-test/vars/cluster-vars.sops.yaml
+++ b/clusters/kubenuc-test/vars/cluster-vars.sops.yaml
@@ -1,29 +1,43 @@
----
-# This file must be encrypted with SOPS before committing.
-# Run: sops --encrypt --in-place clusters/kubenuc-test/vars/cluster-vars.sops.yaml
+#ENC[AES256_GCM,data:yvtazuvfMQnqLRNovDKC1BKVzobw+sUT/F2F0zpk2PUUurxS/p8AUREefjEa3WMB549Ti3PgGKCO,iv:9RcoCVPqPov97qF9RD7YuzCl4xJc9qHjHVLN3VOeo9s=,tag:p24IONHa1lkMbZsq9XqSVg==,type:comment]
+#ENC[AES256_GCM,data:T8aPpLRADSIMxayMrcxXeET8F9LHHAJcT+P9miFtHM+KcUODUMIRBKareX10XrbgV2ITQ/EtTXeWIzktMAPRNMIG4KARKJRJINLaiPnl2MRf,iv:L1/iF6Nr9eova/lRTl9HE7GaSeKo6PXux4feYN8mvSg=,tag:+8W6I3qJBTgqcc5+1hI+SA==,type:comment]
 #
-# Bootstrap steps (one-time per cluster):
-#   age-keygen -o age-kubenuctest.agekey
-#   kubectl create secret generic sops-age \
-#     --namespace=flux-system \
-#     --from-file=age.agekey=age-kubenuctest.agekey \
-#     --context=<kubenuc-test-context>
-#   Update .sops.yaml with the age public key printed by age-keygen.
-#   Store the private key in 1Password — never commit it.
-apiVersion: v1
-kind: Secret
+#ENC[AES256_GCM,data:k9YHdqtbx5vtv+LSfQG/m8u8qSkUNEulHOG6mTwJ3PrZ+bQyAVp2xw==,iv:RkxScMs09Q56Fm0vXNUzxfNmIfLjYWmL2P3tGlYZ82Q=,tag:JVFs/3p+TAfs/hWs/rLJ4g==,type:comment]
+#ENC[AES256_GCM,data:5gHLJd8AyrYJVzUxNmSy1dwuHEEqJsTjWQ/Xp+l+j5tIW2Ge14U0,iv:WuEjt0NMpA9Ho6VG8FPdHZ1Qwubijv8mZD82mMLblmI=,tag:03nKKkrCtfeJ5yjaahQ03w==,type:comment]
+#ENC[AES256_GCM,data:BhXzJakEUnjhHmGdgpTld+Mzg+xESJcPCQdi9+U2SQM3ThdShZfyJzmWWw==,iv:4b0a/F/fHtZTe1kRE5mNvk0c50rtNYk/j7OtBFI2vwU=,tag:1+2TanqMZEjLuUPMaisS+A==,type:comment]
+#ENC[AES256_GCM,data:efDSY7VZxYdJXc/kJp5ak2DsOyQoUI+MoIJ+NULL,iv:qEfHzDwQ0cKXw9uWwCo/YOvMz98Zb2fjeiHjxt00X/k=,tag:39zfJQ9JLLi8jDM1vMQoBw==,type:comment]
+#ENC[AES256_GCM,data:NvqcZApf0PNvrz9EUtqSt9pCK41dCJ/KJzApM/7mRrYU6fHw8N2szxf6ZRQRKFTLaJFlrw==,iv:Xr+G8jMltYTOUS0A/4O06T9Dcfv5/ikvOV52WUfGq8U=,tag:Akws6KYwVyW2p4m7TaOhNw==,type:comment]
+#ENC[AES256_GCM,data:DAFxp0jbit/d+eGMkES57ZKzm2A6UXgBtvydum3JafEnVeT+cQ==,iv:kAD9bB2cI1ucqQ9EI8AbSaNjjuO6wRYa1tt4x0XVdaI=,tag:OneTv3A/X1yfSlJFlTbUiQ==,type:comment]
+#ENC[AES256_GCM,data:iREQ1H2mYp8MG/1szxUVy7IzRWF2Wb3/JN10MK23NlBM2OPgXD39UUrf2RbRo2KibXDiGtPxjMjuHAyhDYWuxGToqg==,iv:pix7jj3Uu5lUenj9cBn6I8MIWdlx2CpigrhVU3aE8Es=,tag:NUsUZq/PH1gq4V/iecxUBA==,type:comment]
+#ENC[AES256_GCM,data:NnMJteuwEAk5iQxY+n4CbIztcU6DBE2j1TlGwe4S0B5dmNt9MXULFmbPPcvCFEm8SAT7azfHnsjlRQ==,iv:sPGeX8fhmpD8Of/zKDvLDXN16L+rwpxc+TB2TxPq11s=,tag:IzFyLfeLdrrj7TKIoGZm6Q==,type:comment]
+apiVersion: ENC[AES256_GCM,data:cfA=,iv:5NgrSR9/cRB8X9qK9TCis8NLJEiZfER51wiwtf1M2iY=,tag:uO56XganMY5UpfIIM6ZTkA==,type:str]
+kind: ENC[AES256_GCM,data:tGZ1OW98,iv:gc3+sdn144DA26kK9NUVM5YmdJB6CMZg2VKKztRKrSo=,tag:aFpFSnH4CHTOP5iz0GR/hg==,type:str]
 metadata:
-  name: cluster-vars
-  namespace: flux-system
+    name: ENC[AES256_GCM,data:KeBdCTOQd61i4MXo,iv:WPSKPmms/R8QE8p+M1aXar89pGh+O+xNA8V+Wn+60GI=,tag:cjpXhxi5nqa8KnOGOwGx3A==,type:str]
+    namespace: ENC[AES256_GCM,data:Kusjc7Zg1r4OZNI=,iv:06Bks0qgHCymG5jiSx7SPPDOteLOrW24MTJ/Q3Cu8uo=,tag:rmq/wsC3RlC6O8KXK0xx8w==,type:str]
 stringData:
-  TST_NEXTCLOUD_HOST: "cloud.tst.ddlns.net"
-  TST_S3_API_HOST: "s3-api.tst.ddlns.net"
-  TST_S3_WEB_HOST: "nx.s3.tst.ddlns.net"
-  TST_JELLYFIN_HOST: "tv.tst.ddlns.net"
-  TST_HARBOR_HOST: "harbor.tst.ddlns.net"
-  TST_HARBOR_URL: "https://harbor.tst.ddlns.net"
-  TST_PORTAINER_HOST: "portainer.tst.ddlns.net"
-  TST_SSO_HOST: "sso.tst.ddlns.net"
-  TST_SSO_URL: "https://sso.tst.ddlns.net"
-  TST_JENKINS_HOST: "jenkins.tst.ddlns.net"
-  TST_ARTIFACTORY_HOST: "artifactory.tst.ddlns.net"
+    TST_NEXTCLOUD_HOST: ENC[AES256_GCM,data:s/uZFpfsLuaoLjuIi0t2Fx1dag==,iv:A0mKB9nZHtlUppeGfP+8d5G0f87hMkqHyayjN01MbE4=,tag:hQ0wtRJa4zj+12EoCcHSFw==,type:str]
+    TST_S3_API_HOST: ENC[AES256_GCM,data:hKX34ZFCIHbV9k95XIgW0Qpb6pE=,iv:QihWUYSTSO0qpxO4deUCeDICnvi7sGedkN9448Lwm+s=,tag:np9/AeHJwi8EqJmupq9NwA==,type:str]
+    TST_S3_WEB_HOST: ENC[AES256_GCM,data:fFiBuUayJ3AY+V5qkgJkSFa2TA==,iv:xYKYHYGAMO2ODhWj9hWET6RrVVvpB07IQ8GQqyfduKg=,tag:J36KiJXgSEmHcy9ggjqdFQ==,type:str]
+    TST_JELLYFIN_HOST: ENC[AES256_GCM,data:0yCODfifY8tCdcP2ycn2BQ==,iv:lxAjNYCRc1O/Wbi4Hf6YdyOkCxPm92pzc4u3hgOHTZc=,tag:RiBUToeX/3jQt23b1cyCOQ==,type:str]
+    TST_HARBOR_HOST: ENC[AES256_GCM,data:4dnz1xNfcOaWeuHNZldKBND/EgU=,iv:eZZYzHvzno0cC1Nv7FQGHqWpJDdp1x2XtIV+n1JscLc=,tag:AE59hsiyxz2Rf8m4qi0CAQ==,type:str]
+    TST_HARBOR_URL: ENC[AES256_GCM,data:oKB7z0XNuRn+aYvJ8yFPwrlgl7nRKIyYuB1HzQ==,iv:qOmy8x1ThfNjY2Z40WJGfi5FpavqSSfL6cC4fxj5B/o=,tag:MMLdtCFJo+J8tC084MaOmw==,type:str]
+    TST_PORTAINER_HOST: ENC[AES256_GCM,data:0E1ZIbYB3xDMxlKnZGfNSY29QXd4AOo=,iv:BmWL2iDIbtDcL8QDtBOmq5UJBb+RagaxUqKozzolEF4=,tag:ERc8JVjsifwwmK/nGYrDKw==,type:str]
+    TST_SSO_HOST: ENC[AES256_GCM,data:9xDh4z1wfvfJKmKs+6OyuOE=,iv:Tr0zmGTkrPED5gFGHyoBbxq60PD70BpxXgrxoNj3XVk=,tag:xQZS5FIlObHWtwkk7EreCw==,type:str]
+    TST_SSO_URL: ENC[AES256_GCM,data:Lx7QZh2H3752gO5KFMIj2MeqvTTLcxexLg==,iv:/pekLXtckMG/MUTbwTr7kJiGboG6kyjkfwy5980FMik=,tag:SwB9EHdgsYthpOHLV0FpSw==,type:str]
+    TST_JENKINS_HOST: ENC[AES256_GCM,data:0OWnGuydZ/fxnsehNsDPGSqpavg3,iv:5jFfyq0aJr0GDrIJauUXESh2lYuKYeh1uvdp8eDERzA=,tag:PkEhy8AxJCjUVC8P3ffSIA==,type:str]
+    TST_ARTIFACTORY_HOST: ENC[AES256_GCM,data:Orw46rfX/YnFKtP2NPio0IuOlGYriH01hA==,iv:nRfLgtlePmPGcoIdR1Hj7s/jHTvI7UuCMnnxJpHVyCM=,tag:Q/1ylWBVPT3kvnz8YPTZwg==,type:str]
+sops:
+    age:
+        - recipient: age1qwhpwjgw3c7trgrtjv7k309suma9l6qu8yrh4at80clrymrczvss8xq69u
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSbGFKNTExSW5VVVJ2QTgx
+            NEVZVUVUK1Q2ZHhZUHdzTSs2ak1kenhhWWc4CkNtYjlkc3B0TVNoM0NQNVkveUxt
+            R2tpYkFXMXBuWFpkVlhvU0w1Z3IvL2cKLS0tIHNzRTlNTFFxT3ZKeTlheUNvc2tx
+            QWxoUVR2T2I1eVI4VGpkcVFaU0Z6ODgKAfoGt6uWt4qhWZNTzCXHrT3Ug3v7Z7O6
+            4bLABfBsmTc6Q2GokDnefpxO/6J2LODUrIiX3qXT4JH0BqKhmi8L9A==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-04-11T18:37:31Z"
+    mac: ENC[AES256_GCM,data:nPkoo2Sl8svcP7TVz7eCzKS/xSPTZ1heQhmsTlvag0Yi1YLDoJmfTniIvbsCvtWp18vW7+mVvli4QjanBPKCe1jLKuRuorkwIbKlF68Cr4GNZntUIxOCXJu96yE0Ef5oDLg7wfrW8xkb7EitilCyqFCLXOVM7JNEwXSr4A6lsyE=,iv:PHwREDLNxFqvZTlUiS5JcWFgYXqdTKkvsd7C6AlkqqM=,tag:sX402ZCLQogxagGqqUq+DA==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.12.2

--- a/clusters/kubenuc-test/vars/cluster-vars.sops.yaml
+++ b/clusters/kubenuc-test/vars/cluster-vars.sops.yaml
@@ -1,0 +1,29 @@
+---
+# This file must be encrypted with SOPS before committing.
+# Run: sops --encrypt --in-place clusters/kubenuc-test/vars/cluster-vars.sops.yaml
+#
+# Bootstrap steps (one-time per cluster):
+#   age-keygen -o age-kubenuctest.agekey
+#   kubectl create secret generic sops-age \
+#     --namespace=flux-system \
+#     --from-file=age.agekey=age-kubenuctest.agekey \
+#     --context=<kubenuc-test-context>
+#   Update .sops.yaml with the age public key printed by age-keygen.
+#   Store the private key in 1Password — never commit it.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cluster-vars
+  namespace: flux-system
+stringData:
+  TST_NEXTCLOUD_HOST: "cloud.tst.ddlns.net"
+  TST_S3_API_HOST: "s3-api.tst.ddlns.net"
+  TST_S3_WEB_HOST: "nx.s3.tst.ddlns.net"
+  TST_JELLYFIN_HOST: "tv.tst.ddlns.net"
+  TST_HARBOR_HOST: "harbor.tst.ddlns.net"
+  TST_HARBOR_URL: "https://harbor.tst.ddlns.net"
+  TST_PORTAINER_HOST: "portainer.tst.ddlns.net"
+  TST_SSO_HOST: "sso.tst.ddlns.net"
+  TST_SSO_URL: "https://sso.tst.ddlns.net"
+  TST_JENKINS_HOST: "jenkins.tst.ddlns.net"
+  TST_ARTIFACTORY_HOST: "artifactory.tst.ddlns.net"

--- a/clusters/kubenuc/apps/cloudflare/deploy.yml
+++ b/clusters/kubenuc/apps/cloudflare/deploy.yml
@@ -6,6 +6,8 @@ metadata:
   name: cloudflared
   namespace: flux-system
 spec:
+  dependsOn:
+    - name: cluster-vars
   targetNamespace: cloudflare
   path: ./clusters/kubenuc/apps/cloudflare/manifests
   prune: true
@@ -13,3 +15,7 @@ spec:
     kind: GitRepository
     name: flux-system
   interval: 15m
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-vars

--- a/clusters/kubenuc/apps/cloudflare/manifests/cloudflared.yml
+++ b/clusters/kubenuc/apps/cloudflare/manifests/cloudflared.yml
@@ -119,10 +119,10 @@ data:
     # from the internet to cloudflared, run `cloudflared tunnel route dns <tunnel> <hostname>`.
     # E.g. `cloudflared tunnel route dns example-tunnel tunnel.example.com`.
     ingress:
-    - hostname: "*.ddlns.net"
+    - hostname: "*.${CLOUDFLARE_DOMAIN}"
       service: https://haproxy-ingress-kubernetes-ingress.haproxy-ingress.svc.cluster.local:443
       originRequest:
-        originServerName: ddlns.net
+        originServerName: ${CLOUDFLARE_DOMAIN}
     #- hostname: "*.example.dev"
     #  service: https://traefik.ingress.svc.cluster.local:443
     #  originRequest:

--- a/clusters/kubenuc/apps/falco/deploy.yaml
+++ b/clusters/kubenuc/apps/falco/deploy.yaml
@@ -20,6 +20,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
+    - name: cluster-vars
     - name: falco-secrets
   targetNamespace: falco
   interval: 15m
@@ -28,6 +29,10 @@ spec:
     name: flux-system
   path: ./clusters/kubenuc/apps/falco/manifests
   prune: true
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-vars
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease

--- a/clusters/kubenuc/apps/falco/manifests/release.yml
+++ b/clusters/kubenuc/apps/falco/manifests/release.yml
@@ -123,7 +123,7 @@ spec:
                       - kubenuc-w1
       config:
         loki:
-          hostport: "https://logs-prod-039.grafana.net"
+          hostport: "${GRAFANA_LOKI_HOST}"
           endpoint: "/loki/api/v1/push"
           extralabels: "source:falco,cluster:kubenuc"
         slack:

--- a/clusters/kubenuc/apps/grafana-alloy/deploy.yaml
+++ b/clusters/kubenuc/apps/grafana-alloy/deploy.yaml
@@ -20,6 +20,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
+    - name: cluster-vars
     - name: grafana-alloy-secrets
   targetNamespace: grafana-alloy
   interval: 15m
@@ -28,6 +29,10 @@ spec:
     name: flux-system
   path: ./clusters/kubenuc/apps/grafana-alloy/manifests
   prune: true
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-vars
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease

--- a/clusters/kubenuc/apps/grafana-alloy/manifests/release.yml
+++ b/clusters/kubenuc/apps/grafana-alloy/manifests/release.yml
@@ -112,7 +112,7 @@ spec:
     destinations:
       - name: grafana-cloud-metrics
         type: prometheus
-        url: https://prometheus-prod-58-prod-eu-central-0.grafana.net/api/prom/push
+        url: ${GRAFANA_PROMETHEUS_URL}
         auth:
           type: basic
           # username and password injected via valuesFrom
@@ -124,12 +124,12 @@ spec:
           }
       - name: grafana-cloud-logs
         type: loki
-        url: https://logs-prod-039.grafana.net/loki/api/v1/push
+        url: ${GRAFANA_LOKI_URL}
         auth:
           type: basic
       - name: gc-otlp-endpoint
         type: otlp
-        url: https://otlp-gateway-prod-eu-central-0.grafana.net/otlp
+        url: ${GRAFANA_OTLP_URL}
         protocol: http
         auth:
           type: basic
@@ -287,7 +287,7 @@ spec:
             value: grafana-k8s-monitoring-$(CLUSTER_NAME)-$(NAMESPACE)-$(POD_NAME)
       remoteConfig:
         enabled: true
-        url: https://fleet-management-prod-024.grafana.net
+        url: ${GRAFANA_FLEET_URL}
         auth:
           type: basic
           # username and password injected via valuesFrom
@@ -328,7 +328,7 @@ spec:
             value: grafana-k8s-monitoring-$(CLUSTER_NAME)-$(NAMESPACE)-$(POD_NAME)
       remoteConfig:
         enabled: true
-        url: https://fleet-management-prod-024.grafana.net
+        url: ${GRAFANA_FLEET_URL}
         auth:
           type: basic
 
@@ -372,7 +372,7 @@ spec:
             value: grafana-k8s-monitoring-$(CLUSTER_NAME)-$(NAMESPACE)-alloy-logs-$(NODE_NAME)
       remoteConfig:
         enabled: true
-        url: https://fleet-management-prod-024.grafana.net
+        url: ${GRAFANA_FLEET_URL}
         auth:
           type: basic
 
@@ -429,6 +429,6 @@ spec:
             value: grafana-k8s-monitoring-$(CLUSTER_NAME)-$(NAMESPACE)-alloy-receiver-$(NODE_NAME)
       remoteConfig:
         enabled: true
-        url: https://fleet-management-prod-024.grafana.net
+        url: ${GRAFANA_FLEET_URL}
         auth:
           type: basic

--- a/clusters/kubenuc/apps/harbor/deploy.yaml
+++ b/clusters/kubenuc/apps/harbor/deploy.yaml
@@ -20,6 +20,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
+    - name: cluster-vars
     - name: openebs
     - name: harbor-secrets
     - name: postgresql-db
@@ -29,6 +30,10 @@ spec:
     name: flux-system
   path: ./clusters/kubenuc/apps/harbor/manifests
   prune: true
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-vars
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease

--- a/clusters/kubenuc/apps/harbor/manifests/release.yml
+++ b/clusters/kubenuc/apps/harbor/manifests/release.yml
@@ -29,7 +29,7 @@ spec:
     enableMigrateHelmHook: true
     updateStrategy:
       type: Recreate
-    externalURL: https://harbor.ddlns.net
+    externalURL: ${HARBOR_URL}
     core:
       replicas: 2
       resources:
@@ -111,7 +111,7 @@ spec:
           cert-manager.io/cluster-issuer: letsencrypt
           haproxy.org/request-body-size: "0"
         hosts:
-          core: "harbor.ddlns.net"
+          core: "${HARBOR_HOST}"
       tls:
         enabled: true
         secretName: "harbor-ingress-certificate"

--- a/clusters/kubenuc/apps/jellyfin/deploy.yaml
+++ b/clusters/kubenuc/apps/jellyfin/deploy.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
+    - name: cluster-vars
     - name: openebs
   interval: 15m
   sourceRef:
@@ -13,6 +14,10 @@ spec:
     name: flux-system
   path: ./clusters/kubenuc/apps/jellyfin/manifests
   prune: true
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-vars
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease

--- a/clusters/kubenuc/apps/jellyfin/manifests/release.yml
+++ b/clusters/kubenuc/apps/jellyfin/manifests/release.yml
@@ -42,14 +42,14 @@ spec:
           cert-manager.io/cluster-issuer: letsencrypt
         enabled: true
         hosts:
-          - host: tv.ddlns.net
+          - host: ${JELLYFIN_HOST}
             paths:
               - path: /
                 pathType: Prefix
         tls:
           - secretName: mydomain-production
             hosts:
-              - tv.ddlns.net
+              - ${JELLYFIN_HOST}
     persistence:
       config:
         enabled: true

--- a/clusters/kubenuc/apps/jenkins/deploy.yaml
+++ b/clusters/kubenuc/apps/jenkins/deploy.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
+    - name: cluster-vars
     - name: openebs
   interval: 15m
   sourceRef:
@@ -13,6 +14,10 @@ spec:
     name: flux-system
   path: ./clusters/kubenuc/apps/jenkins/manifests
   prune: true
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-vars
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease

--- a/clusters/kubenuc/apps/jenkins/manifests/release.yml
+++ b/clusters/kubenuc/apps/jenkins/manifests/release.yml
@@ -41,11 +41,11 @@ spec:
           haproxy.org/request-body-size: "100m"
         ingressClassName: haproxy
     
-        hostName: jenkins.ddlns.net
+        hostName: ${JENKINS_HOST}
         tls:
-        - secretName: jenkins.ddlns.net-tls
+        - secretName: ${JENKINS_HOST}-tls
           hosts:
-            - jenkins.ddlns.net
+            - ${JENKINS_HOST}
     
     agent:
       resources:

--- a/clusters/kubenuc/apps/jfrog-acr/deploy.yaml
+++ b/clusters/kubenuc/apps/jfrog-acr/deploy.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
+    - name: cluster-vars
     - name: openebs
   interval: 15m
   sourceRef:
@@ -13,6 +14,10 @@ spec:
     name: flux-system
   path: ./clusters/kubenuc/apps/jfrog-acr/manifests
   prune: true
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-vars
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease

--- a/clusters/kubenuc/apps/jfrog-acr/manifests/release.yml
+++ b/clusters/kubenuc/apps/jfrog-acr/manifests/release.yml
@@ -49,7 +49,7 @@ spec:
         enabled: true
         ## Used to create an Ingress record.
         hosts:
-        - artifactory.ddlns.net
+        - ${ARTIFACTORY_HOST}
         className: "haproxy"
         annotations:
           cert-manager.io/cluster-issuer: letsencrypt
@@ -57,4 +57,4 @@ spec:
         tls:
         - secretName: artifactory-tls
           hosts:
-            - artifactory.ddlns.net
+            - ${ARTIFACTORY_HOST}

--- a/clusters/kubenuc/apps/nextcloud/deploy.yaml
+++ b/clusters/kubenuc/apps/nextcloud/deploy.yaml
@@ -20,6 +20,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
+    - name: cluster-vars
     - name: openebs
     - name: nextcloud-secrets
     - name: postgresql-db
@@ -30,6 +31,10 @@ spec:
     name: flux-system
   path: ./clusters/kubenuc/apps/nextcloud/manifests
   prune: true
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-vars
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease

--- a/clusters/kubenuc/apps/nextcloud/manifests/release.yml
+++ b/clusters/kubenuc/apps/nextcloud/manifests/release.yml
@@ -44,9 +44,9 @@ spec:
       tls:
         - secretName: nx-fastnet-tls
           hosts:
-            - cloud.ddlns.net
+            - ${NEXTCLOUD_HOST}
     nextcloud:
-      host: cloud.ddlns.net
+      host: ${NEXTCLOUD_HOST}
       ## Use an existing secret
       existingSecret:
         enabled: true

--- a/clusters/kubenuc/apps/portainer/deploy.yaml
+++ b/clusters/kubenuc/apps/portainer/deploy.yaml
@@ -19,6 +19,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
+    - name: cluster-vars
     - name: openebs
     - name: portainer-secrets
   interval: 15m
@@ -27,6 +28,10 @@ spec:
     name: flux-system
   path: ./clusters/kubenuc/apps/portainer/manifests
   prune: true
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-vars
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease

--- a/clusters/kubenuc/apps/portainer/manifests/release.yml
+++ b/clusters/kubenuc/apps/portainer/manifests/release.yml
@@ -41,13 +41,13 @@ spec:
         haproxy.org/timeout-server: "240s"
         haproxy.org/server-ssl: "true"
       hosts:
-        - host: portainer.ddlns.net
+        - host: ${PORTAINER_HOST}
           paths:
             - path: /
       tls:
         - secretName: portainer-tls
           hosts:
-            - portainer.ddlns.net
+            - ${PORTAINER_HOST}
 
     persistence:
       enabled: true

--- a/clusters/kubenuc/apps/s3/deploy.yaml
+++ b/clusters/kubenuc/apps/s3/deploy.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
+    - name: cluster-vars
     - name: openebs
   targetNamespace: nextcloud-fastnetserv
   interval: 15m
@@ -13,6 +14,10 @@ spec:
     name: flux-system
   path: ./clusters/kubenuc/apps/s3/manifests
   prune: true
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-vars
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease

--- a/clusters/kubenuc/apps/s3/manifests/release.yml
+++ b/clusters/kubenuc/apps/s3/manifests/release.yml
@@ -45,14 +45,14 @@ spec:
             cert-manager.io/cluster-issuer: "letsencrypt-prod"
             haproxy.org/request-body-size: "500m"
           hosts:
-            - host: s3-api.ddlns.net
+            - host: ${S3_API_HOST}
               paths:
                 - path: /
                   pathType: Prefix
           tls:
             - secretName: garage-ingress-cert
               hosts:
-                - s3-api.ddlns.net
+                - ${S3_API_HOST}
         web:
           enabled: true
           className: "haproxy"
@@ -60,12 +60,12 @@ spec:
             cert-manager.io/cluster-issuer: "letsencrypt-prod"
             haproxy.org/request-body-size: "500m"
           hosts:
-            - host: nx.s3.ddlns.net
+            - host: ${S3_WEB_HOST}
               paths:
                 - path: /
                   pathType: Prefix
           tls:
             - secretName: garage-web-ingress-cert
               hosts:
-                - nx.s3.ddlns.net
+                - ${S3_WEB_HOST}
 

--- a/clusters/kubenuc/apps/sso/deploy.yaml
+++ b/clusters/kubenuc/apps/sso/deploy.yaml
@@ -19,6 +19,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
+    - name: cluster-vars
     - name: openebs
     - name: sso-secrets
     - name: postgresql-db
@@ -29,6 +30,10 @@ spec:
     name: flux-system
   path: ./clusters/kubenuc/apps/sso/manifests
   prune: true
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-vars
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease

--- a/clusters/kubenuc/apps/sso/manifests/release.yml
+++ b/clusters/kubenuc/apps/sso/manifests/release.yml
@@ -90,13 +90,13 @@ spec:
         ingressClassName: haproxy
         enabled: true
         hosts:
-          - sso.ddlns.net
+          - ${SSO_AUTHENTIK_HOST}
         annotations:
           cert-manager.io/cluster-issuer: "letsencrypt"
         tls:
           - secretName: sso-tls
             hosts:
-              - sso.ddlns.net
+              - ${SSO_AUTHENTIK_HOST}
 
     global:
       topologySpreadConstraints:

--- a/clusters/kubenuc/apps/sso/manifests/zitadel.yml
+++ b/clusters/kubenuc/apps/sso/manifests/zitadel.yml
@@ -32,14 +32,14 @@ spec:
       annotations:
         cert-manager.io/cluster-issuer: "letsencrypt"
       hosts:
-        - host: test-sso.ddlns.net
+        - host: ${SSO_HOST}
           paths:
             - path: /
               pathType: Prefix
       tls:
         - secretName: zitadel-tls
           hosts:
-            - test-sso.ddlns.net
+            - ${SSO_HOST}
     zitadel:
       initContainers:
         - name: check-db-ready
@@ -111,7 +111,7 @@ spec:
       masterkeySecretName: zitadel-master-secrets
       configmapConfig:
         ExternalSecure: true
-        ExternalDomain: test-sso.ddlns.net
+        ExternalDomain: ${SSO_HOST}
         TLS:
           Enabled: false
         Database:

--- a/clusters/kubenuc/apps/zabbix/deploy.yaml
+++ b/clusters/kubenuc/apps/zabbix/deploy.yaml
@@ -5,6 +5,8 @@ metadata:
   name: zabbix-proxy
   namespace: flux-system
 spec:
+  dependsOn:
+    - name: cluster-vars
   targetNamespace: zabbix
   interval: 15m
   sourceRef:
@@ -12,3 +14,7 @@ spec:
     name: flux-system
   path: ./clusters/kubenuc/apps/zabbix/manifests
   prune: true
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-vars

--- a/clusters/kubenuc/apps/zabbix/manifests/release.yml
+++ b/clusters/kubenuc/apps/zabbix/manifests/release.yml
@@ -46,7 +46,7 @@ spec:
       ZBX_PROXYMODE: 0
       # This variable is unique, case sensitive hostname.
       ZBX_HOSTNAME: zabbix-proxy-sqlite3
-      ZBX_SERVER_HOST: zabbix.ddlns.net
+      ZBX_SERVER_HOST: ${ZABBIX_HOST}
       ZBX_SERVER_PORT: 10051
       # ZBX_LOADMODULE: dummy1.so,dummy2.so # The variable is list of comma separated loadable Zabbix modules. It works with volume /var/lib/zabbix/modules.
       # ZBX_DEBUGLEVEL: 4 # The variable is used to specify debug level, from 0 to 5

--- a/clusters/kubenuc/cluster-vars.yaml
+++ b/clusters/kubenuc/cluster-vars.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-vars
+  namespace: flux-system
+spec:
+  interval: 1h
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./clusters/kubenuc/vars
+  prune: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age

--- a/clusters/kubenuc/vars/cluster-vars.sops.yaml
+++ b/clusters/kubenuc/vars/cluster-vars.sops.yaml
@@ -1,35 +1,49 @@
----
-# This file must be encrypted with SOPS before committing.
-# Run: sops --encrypt --in-place clusters/kubenuc/vars/cluster-vars.sops.yaml
+#ENC[AES256_GCM,data:phwdz8tLCyXwKrwTApWCKS76cyM0xOsc6mOTvalgfIPPgrKEi1NWrQECwTgTp+ywbQ6TzlCxdi3I,iv:IaRPGpfRQ5gc8CM8zvPekSXr89DpsWBPdMW7zaD6TiA=,tag:DnVglgHD7CWv5TqAdkxQbw==,type:comment]
+#ENC[AES256_GCM,data:7dv7md79UB0CcW7b/RWdsEIUFRC851LRJNEz9KGrrOa9I8o1iAXjKWD31jCzGLsxplSRpiYhCNpyo8mFJhnx95bG+ZGEkThV/R+FaQ==,iv:ZxOSCLUhtcU0Y4o/l6VRzTzmpOyOvplotiS+fAfIOHc=,tag:HkOsGMVY8rLzMa/oi21bag==,type:comment]
 #
-# Bootstrap steps (one-time per cluster):
-#   age-keygen -o age-kubenuc.agekey
-#   kubectl create secret generic sops-age \
-#     --namespace=flux-system \
-#     --from-file=age.agekey=age-kubenuc.agekey
-#   Update .sops.yaml with the age public key printed by age-keygen.
-#   Store the private key in 1Password — never commit it.
-apiVersion: v1
-kind: Secret
+#ENC[AES256_GCM,data:wQ5QSWjpFTzjVKd6RMc/SNCmnxLk2x0MwsF5DE1VRu+F88UGGvnD6g==,iv:iwFcYuKDUch8np8oAQ32/ZPMoDQO+yt3A9LVlB1OMOU=,tag:il8YcE+VOgwP7nsoZTQSGw==,type:comment]
+#ENC[AES256_GCM,data:cTHs+qFecB7yTzWojLbyLN8g5sLHFvAhUS7CW0uWW/qQlaM=,iv:KwH5yiTkWTlTqTqP0eJtiY9Gq4z/IHOzxM0sJo9qsJQ=,tag:LcDSKwa/BxsRnju7I1SbGA==,type:comment]
+#ENC[AES256_GCM,data:fLZk5jllvzgcBa3UzmRHr2hFCZQuDQaWOMPirnLEjM8GqWO5AbTDPy81qg==,iv:sSr2+QN5TsPj0mnkoi0F0UTESNYY6eBDdfoSCd3MrMI=,tag:3qq7yfHKVf2pYKDbrJCJ8A==,type:comment]
+#ENC[AES256_GCM,data:oL2ikTOtrRfyWevZNLBRivSldpGmdJ+XnCWaOZiD,iv:4wiYMfkYc6ZgzG99iQA+ewWPxkSc8IWUudQZQQuvGy8=,tag:DrML1raCUmzV0dIuVNIw/g==,type:comment]
+#ENC[AES256_GCM,data:slxjU2dkDJnn3aHGZ16l8R5RDgHi3WiL/ro7iEFqzG8xF/h8g/qnsXO+QGL3dw==,iv:hKtE2VYajGzGozlNhk75JCt52sV0d7mDoKAoKoWIlP8=,tag:v6m6kF/RuZutrVqYUoqfuQ==,type:comment]
+#ENC[AES256_GCM,data:K33rATVgMtq1/ZFNRZXiI0mn4GLWs9mqV5l1MQ16pTCMZJ+Lb6+BMNABsmadm4CZGHD3lIZYhjZBrr/SM9ewX0McdQ==,iv:JZyDK3PuqP5EBm3r5V4nEiSztGuoJTVEJA/n0b71BT8=,tag:HDSo+DglmQEyIYwkJT9Zig==,type:comment]
+#ENC[AES256_GCM,data:kkOeCJE2DP+ximY/8niR4eIjvhmwBl86J5UvbO+8Yc36zD3AzZ22eKczSSQGuSxBboMy7lcllYBFTQ==,iv:nZwjT7LQR1s4Iz4oLV2IxAs/C69cmgcuUuv6StQPzbs=,tag:ck4PhxrPWdiG0y+GRhGZWw==,type:comment]
+apiVersion: ENC[AES256_GCM,data:0w4=,iv:MT/78lmzVCGteMA/XjIqOkz2RnWPhi3oC3wSVhRIyCc=,tag:A07U9ncuOYf/QZzuTqvk4Q==,type:str]
+kind: ENC[AES256_GCM,data:hARpb3Ad,iv:h8GfqBoIxJKjiXqYvWQaiQDuq0zBfGCBFLzFFaYtBLc=,tag:VSFseOcadz8d9l0Mns/rxA==,type:str]
 metadata:
-  name: cluster-vars
-  namespace: flux-system
+    name: ENC[AES256_GCM,data:R4IiIhE0GCftCiU1,iv:Umx07P4AjJMGlpYRsLb1ChfNipP3kQoVTsgWdfp8YZY=,tag:5iMDK01bfg3aDnxq8XoI8Q==,type:str]
+    namespace: ENC[AES256_GCM,data:toSIlBOWl5Z2VcI=,iv:T738YywsbupZPL+Nbn40A2i0L6EyLE9JBsSMdGYd9oo=,tag:pOFVV3qvsNZTv8G+Fk4DaQ==,type:str]
 stringData:
-  NEXTCLOUD_HOST: "cloud.ddlns.net"
-  HARBOR_HOST: "harbor.ddlns.net"
-  HARBOR_URL: "https://harbor.ddlns.net"
-  JELLYFIN_HOST: "tv.ddlns.net"
-  PORTAINER_HOST: "portainer.ddlns.net"
-  JENKINS_HOST: "jenkins.ddlns.net"
-  SSO_HOST: "test-sso.ddlns.net"
-  S3_API_HOST: "s3-api.ddlns.net"
-  S3_WEB_HOST: "nx.s3.ddlns.net"
-  GRAFANA_PROMETHEUS_URL: "https://prometheus-prod-58-prod-eu-central-0.grafana.net/api/prom/push"
-  GRAFANA_LOKI_URL: "https://logs-prod-039.grafana.net/loki/api/v1/push"
-  GRAFANA_OTLP_URL: "https://otlp-gateway-prod-eu-central-0.grafana.net/otlp"
-  GRAFANA_FLEET_URL: "https://fleet-management-prod-024.grafana.net"
-  GRAFANA_LOKI_HOST: "https://logs-prod-039.grafana.net"
-  SSO_AUTHENTIK_HOST: "sso.ddlns.net"
-  ZABBIX_HOST: "zabbix.ddlns.net"
-  ARTIFACTORY_HOST: "artifactory.ddlns.net"
-  CLOUDFLARE_DOMAIN: "ddlns.net"
+    NEXTCLOUD_HOST: ENC[AES256_GCM,data:Agtehlm+A/9cHwhVW+Lr,iv:Jk7586/NCqLaIoKr4kqTWkHxoATHTTgL09yFiWxlme0=,tag:I4a/KNXNS36ErFHiwO62Jw==,type:str]
+    HARBOR_HOST: ENC[AES256_GCM,data:pcVnyFu3c95EDu0QAkuzHA==,iv:cIEbG44+SrnMjbzrsd0bLAgnOEBKW02x1E2hCjQ8y5M=,tag:WV/qHXoJj5miFnEjq0N47g==,type:str]
+    HARBOR_URL: ENC[AES256_GCM,data:YE6jsHiSfTIz3IHVNeXD17qIsxYAeu3m,iv:b/UmVAjDoW9sKaFE6UmNN3CJvb8hrnb/6qNsJ83sAD4=,tag:pxsqdLF8uUUEnebztnZ3dg==,type:str]
+    JELLYFIN_HOST: ENC[AES256_GCM,data:YFoP58KxAF4swfzQ,iv:V8YpvsCVjwS5JYD92/TJS+vRNm/WYOGbJyUv/6ynp+g=,tag:zI2Mu9s2y4vubfhlmOln5w==,type:str]
+    PORTAINER_HOST: ENC[AES256_GCM,data:/LiTGlDmEUGrKjcio3xRcA74mQ==,iv:Nv9jeSb8FZNupdKROvLIoJyBhud3q9lE7BBXHuLQ1+Y=,tag:m3qzBEOOcVpmI9oIkeuJCQ==,type:str]
+    JENKINS_HOST: ENC[AES256_GCM,data:vQs8pkfKXKFdZV87mTE4VlI=,iv:sivOQ3rikTRK9NSgiD/Oe+VQpgrT84w7DL7IJUfYLWA=,tag:FzO7XEY/JIM+jZIikdR+eQ==,type:str]
+    SSO_HOST: ENC[AES256_GCM,data:JA52b9K0pc1xd9Ralhcc6m6u,iv:Nd6KeJuZuSg9I81usCILm6960pTaPq56NzerTJXdQ9Y=,tag:ARmrjTTPXGsCCy11kGtGCA==,type:str]
+    S3_API_HOST: ENC[AES256_GCM,data:lMYO+creyrGZdTIW8ihBMQ==,iv:Yg3Ffnk/p1VZQkq6uNvNbaA1XXFxV/9YqmJQZcPQW7s=,tag:KZJergoMjtywGVpKbcRWlQ==,type:str]
+    S3_WEB_HOST: ENC[AES256_GCM,data:Eo3RF7QtrXvjhXYJczTH,iv:htRTF0JTmdJ1z7wbiU4B1usUDCQv5m6SfdUbqOy5AGM=,tag:dsOijx2GN4+EfWbKQ4P2Hw==,type:str]
+    GRAFANA_PROMETHEUS_URL: ENC[AES256_GCM,data:xb33Yia/14JTO0QkW68saPWLVgoUN9YxhUC8uuWR4wy5eRQc7hzEkHzlqcVRjc6x1gGqqGEss32xZ4nScG8GE+QYhQuj4A==,iv:EkRH1xP3JzvUGZ8kpwvjMQAb/GiVKzXO8Vw6iW0WRtQ=,tag:3bex4BUvKMf5JhXZ1/RPaA==,type:str]
+    GRAFANA_LOKI_URL: ENC[AES256_GCM,data:V5p0oh6zRmOR/xEJoou3CVid9pA/0pE9/6P29r7gI5NXJRJt5x2oabcnb0QOtBkorzQ=,iv:Pz0WnRq09BMOYsU7D4oZC5H6SFiUr6m8dpFj+o9lkLo=,tag:dIYQh1+nKEO9n9K65Vecvw==,type:str]
+    GRAFANA_OTLP_URL: ENC[AES256_GCM,data:/Msha8NZu3fKQEKR5WYe3YAVJmpKoF/yvkepLp7nYdx1gxag7tgbaGH0yrVb4Yypk8aaxm+dIA==,iv:1SFJgSyGgPYwqpYV9BV8WIso9O4zA4LFbxlZar6ecGo=,tag:3kFZ25Dy+olk5b6Tv7G/dQ==,type:str]
+    GRAFANA_FLEET_URL: ENC[AES256_GCM,data:Q6bb4BeAsIfk/yq4E8qCTmPQitI/G4r/KYlLUZRP+lc4TTD/tpQZWbfnLVos,iv:vtOeY8LfLfvqbcf1iwtlIHBUlRtgPiQ4VwNN/n/10pc=,tag:YKy9KrvJ4ejKiTBZoL5P8w==,type:str]
+    GRAFANA_LOKI_HOST: ENC[AES256_GCM,data:1qEoNzHce4xOt6yEMdWFC5ZvDmlYXzKYmvWrmo1Jbr+Z,iv:OFtp/oWhQAtSPp+fqqw04dwCelTiRDF1AK5/GP1FPFo=,tag:kIqkH9EaiSQ8BhXAzISEbg==,type:str]
+    SSO_AUTHENTIK_HOST: ENC[AES256_GCM,data:guP75eoUTKSaV5tjGQ==,iv:dpdjoV1OhLBDD49wQHhhZ8Uu64UUhUi7sLLT80TMcWU=,tag:6sj0IvYymj8p16ZkXekVCQ==,type:str]
+    ZABBIX_HOST: ENC[AES256_GCM,data:5iPLFpez3jqqqmTLOp43cA==,iv:egyTfNtIVwGD+fWMBk+ZD2mjoJ1BwD8G/VECGmCGKa4=,tag:mXer+yBGlEKUZKcD6H77Sw==,type:str]
+    ARTIFACTORY_HOST: ENC[AES256_GCM,data:a5WBYsDhy9aZxYQa0CXLhT4Gl1bQ,iv:AixOE1WO8Ls4VWpyfkXH9fyGCcL6C8eBAGQsU2TrmEI=,tag:nnUvxzcWGzVhHy5AJhRJlQ==,type:str]
+    CLOUDFLARE_DOMAIN: ENC[AES256_GCM,data:08ab7/SQh5gN,iv:blCcevfT8xEnuIzgC1NkADFM1w0+U7rwZzYS+ZkoEZk=,tag:inemAb2YzlKv80KLi9pGLw==,type:str]
+sops:
+    age:
+        - recipient: age182k0gk669fkgkq697d86huftt94cfg7s9hq56jaj9qffwu9k648qyyx5dd
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA5WWluZ1gvWjdqNmVVU01K
+            aW1EOFVodUg5MVZCTy9QTEZVdVJCZFFZZEZrCmhuRHA1dGFMQ1VZWEVhYTZWNmtn
+            cDdoM1FzR0JlSHNsWUNVOVVDbU1kUVUKLS0tIEhwcU1FRHhIWmZOVDl5bURHRlo0
+            UFFQV1ZwZTIrc0tjN2lUK0FhN0JmSzgKRD15rZvmioSL4TPNHOgPPxkFJDHuoxf0
+            mEevguo/YgbgDiqUtFSsFgki1qBLq19OlvtNfx7+NxMLbwCuFBfmQQ==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-04-11T18:36:15Z"
+    mac: ENC[AES256_GCM,data:KMDY/UTfowBnYVX8DNj76S0hMwI2k0mjXYF35DIHhscvdhHyV8ONVfcSrdtsklaoB7SSO6jZB/T9RNRUnroYBF/A7dSX23GbxfdQ+G3hkPPsQunshbpqME+DYjjen7mP46dwvBC8JP/7vhr929bmBoVgIIqROa1O/lXpBNIYVNM=,iv:7TMNJd0ezPyIJ/9gO9LiRRGRBIZt12HEyLnWFt4g2es=,tag:3sBlL4fL9Uh22IHnVeALOA==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.12.2

--- a/clusters/kubenuc/vars/cluster-vars.sops.yaml
+++ b/clusters/kubenuc/vars/cluster-vars.sops.yaml
@@ -1,0 +1,35 @@
+---
+# This file must be encrypted with SOPS before committing.
+# Run: sops --encrypt --in-place clusters/kubenuc/vars/cluster-vars.sops.yaml
+#
+# Bootstrap steps (one-time per cluster):
+#   age-keygen -o age-kubenuc.agekey
+#   kubectl create secret generic sops-age \
+#     --namespace=flux-system \
+#     --from-file=age.agekey=age-kubenuc.agekey
+#   Update .sops.yaml with the age public key printed by age-keygen.
+#   Store the private key in 1Password — never commit it.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cluster-vars
+  namespace: flux-system
+stringData:
+  NEXTCLOUD_HOST: "cloud.ddlns.net"
+  HARBOR_HOST: "harbor.ddlns.net"
+  HARBOR_URL: "https://harbor.ddlns.net"
+  JELLYFIN_HOST: "tv.ddlns.net"
+  PORTAINER_HOST: "portainer.ddlns.net"
+  JENKINS_HOST: "jenkins.ddlns.net"
+  SSO_HOST: "test-sso.ddlns.net"
+  S3_API_HOST: "s3-api.ddlns.net"
+  S3_WEB_HOST: "nx.s3.ddlns.net"
+  GRAFANA_PROMETHEUS_URL: "https://prometheus-prod-58-prod-eu-central-0.grafana.net/api/prom/push"
+  GRAFANA_LOKI_URL: "https://logs-prod-039.grafana.net/loki/api/v1/push"
+  GRAFANA_OTLP_URL: "https://otlp-gateway-prod-eu-central-0.grafana.net/otlp"
+  GRAFANA_FLEET_URL: "https://fleet-management-prod-024.grafana.net"
+  GRAFANA_LOKI_HOST: "https://logs-prod-039.grafana.net"
+  SSO_AUTHENTIK_HOST: "sso.ddlns.net"
+  ZABBIX_HOST: "zabbix.ddlns.net"
+  ARTIFACTORY_HOST: "artifactory.ddlns.net"
+  CLOUDFLARE_DOMAIN: "ddlns.net"

--- a/clusters/oc-ampere/apps/teleport-agent/deploy.yaml
+++ b/clusters/oc-ampere/apps/teleport-agent/deploy.yaml
@@ -18,9 +18,15 @@ metadata:
   name: teleport-kube-agent
   namespace: flux-system
 spec:
+  dependsOn:
+    - name: cluster-vars
   interval: 5m
   sourceRef:
     kind: GitRepository
     name: flux-system
   path: ./clusters/oc-ampere/apps/teleport-agent/manifests
   prune: true
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-vars

--- a/clusters/oc-ampere/apps/teleport-agent/manifests/release.yml
+++ b/clusters/oc-ampere/apps/teleport-agent/manifests/release.yml
@@ -23,7 +23,7 @@ spec:
     remediation:
       retries: 6
   values:
-    proxyAddr: teleport.ddlns.net:443
+    proxyAddr: ${TELEPORT_HOST}:443
     kubeClusterName: "oc-ampere"
     joinTokenSecret:
       create: false

--- a/clusters/oc-ampere/cluster-vars.yaml
+++ b/clusters/oc-ampere/cluster-vars.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-vars
+  namespace: flux-system
+spec:
+  interval: 1h
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./clusters/oc-ampere/vars
+  prune: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age

--- a/clusters/oc-ampere/vars/cluster-vars.sops.yaml
+++ b/clusters/oc-ampere/vars/cluster-vars.sops.yaml
@@ -1,0 +1,19 @@
+---
+# This file must be encrypted with SOPS before committing.
+# Run: sops --encrypt --in-place clusters/oc-ampere/vars/cluster-vars.sops.yaml
+#
+# Bootstrap steps (one-time per cluster):
+#   age-keygen -o age-ocampere.agekey
+#   kubectl create secret generic sops-age \
+#     --namespace=flux-system \
+#     --from-file=age.agekey=age-ocampere.agekey \
+#     --context=<oc-ampere-context>
+#   Update .sops.yaml with the age public key printed by age-keygen.
+#   Store the private key in 1Password — never commit it.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cluster-vars
+  namespace: flux-system
+stringData:
+  TELEPORT_HOST: "teleport.ddlns.net"

--- a/clusters/oc-ampere/vars/cluster-vars.sops.yaml
+++ b/clusters/oc-ampere/vars/cluster-vars.sops.yaml
@@ -1,19 +1,33 @@
----
-# This file must be encrypted with SOPS before committing.
-# Run: sops --encrypt --in-place clusters/oc-ampere/vars/cluster-vars.sops.yaml
+#ENC[AES256_GCM,data:bjNyTHtnodA7iWc0NxFVgHGzDDOdoIRFbbaWM9redurNMe8Jz+JiyJLHXi27p1PjzPfvuWeSWLTL,iv:fh6neripbTvxAma5S0lVUxDeYvcDan3UctJFZaX7Wvg=,tag:0y5bkKIH3eZHnT12JdcRCw==,type:comment]
+#ENC[AES256_GCM,data:b0k3q+SZdWQzkgbj7/u3MCvI3xkonoFKTRJDQliLYZhunU1355XFRcTg4rydXqup/HCojbrFtYK9QKfb15WnUcre/XLoQatzxuqA/4+7,iv:uwiqDUNRoHCGqVpWiu29hzL3r7naxKwF6o+ZCasgBi4=,tag:+kqHv3IG0m9wByWeR/vQPA==,type:comment]
 #
-# Bootstrap steps (one-time per cluster):
-#   age-keygen -o age-ocampere.agekey
-#   kubectl create secret generic sops-age \
-#     --namespace=flux-system \
-#     --from-file=age.agekey=age-ocampere.agekey \
-#     --context=<oc-ampere-context>
-#   Update .sops.yaml with the age public key printed by age-keygen.
-#   Store the private key in 1Password — never commit it.
-apiVersion: v1
-kind: Secret
+#ENC[AES256_GCM,data:B4hbxlyLOWcZ+Qz+Iss1TwxtM8DJckjsWWSc1IvmgqGKEixw0tNrgg==,iv:KJJc29AlpLJ4D3PLSitjwxxZ3Fjzv3WoIsxZFfbPtMg=,tag:MWrEcWG3YaQEgKETWJ5Siw==,type:comment]
+#ENC[AES256_GCM,data:QYehXdh8F5XC4gKmpZAzXXYxlh1NTQwPLTDzJKu9FYP5r8mn,iv:Q7kvX72RWAWYao7cZksehdVczXsd9cDrh6KOHSAe3oo=,tag:X/oxtIDOuBXNV+pSTbLSJg==,type:comment]
+#ENC[AES256_GCM,data:uvfJDkZoczjvrk0eOniifdshAyMM15Ox2fA4aLmxzz57jGoNq+DhqOLY3g==,iv:QYEsEkIjmRjUoiTDJCDogszQaObzpkD/auzihq7Cb7E=,tag:esE4HcZmeZHlvFdC+1jt7g==,type:comment]
+#ENC[AES256_GCM,data:tI6HAGB5jt7vEK84oTxLct2UTJ3In7Ooe+DKaM2T,iv:KSTHeiTK6IwcSzYLwxmJAS47rzVieIhU+6+gRgRmFSc=,tag:fRTOH4puXqOgN80BjO9DRQ==,type:comment]
+#ENC[AES256_GCM,data:yEeq5qvl9Ai3h5v3t6OYDds9nLFYeXJhz+aWrIW4LCV8fHuTCZDkfRvfChQ7M28/0w==,iv:2GcHuM1UmiitJOYHZDYB4zRTX70r7rGMOtFrBcemK4Y=,tag:euziDEl+vLN0w/TkmpiGYg==,type:comment]
+#ENC[AES256_GCM,data:cTILQOhG561qWiCIqEJnXH8EBWPWQ2OS/poep/CuL7jPPg==,iv:fcSUOCW8ltbwq8dYJgXf5ZbpYoWIaBmzMMh1WxUNx3I=,tag:gnPC2q0Rw8fWhZtqcB137w==,type:comment]
+#ENC[AES256_GCM,data:+4jeAMQIPmAwyer6WNekwpeVZ60T7xgENuETmyJ+zpVWwlSGkQEoSUh3Nbx4xBuIR3BNzDfH1RjukURLI5C/Ktr7wg==,iv:v68Yur/wTSeqbX6KrXedO0tvrTcS9h14XRNJ+b0sANA=,tag:UQ7hQmmR73/IydwDtlypqw==,type:comment]
+#ENC[AES256_GCM,data:Fjv9r32zECyCzmt54SJwMOvwPu1Y5zEA9yFOyneOyyQAmbhD9TgdqowcCXVFCJQQXbVDKqtmnXXqow==,iv:oM5vAXZfD7aH7UKwnW5n/50bf4f29Gi3nwXN4sHWneo=,tag:b1qgEVZQFsclsRON/0Nr8A==,type:comment]
+apiVersion: ENC[AES256_GCM,data:mrk=,iv:E8AMC8A81z9f0hWJZWPvyN/BAWavwTJgwhMDrfWutu4=,tag:gDlxaxbo58HlyrMt8iTN1w==,type:str]
+kind: ENC[AES256_GCM,data:GwLpNjKS,iv:8stv3ZOZaZCtf8RselPWCp9ZszBz+9i/7UyszIWmg9k=,tag:b9TuinSQo2xFXSj2A6oNtA==,type:str]
 metadata:
-  name: cluster-vars
-  namespace: flux-system
+    name: ENC[AES256_GCM,data:Ng9MuW1Rtz0ggaTJ,iv:A1S8t6/+Ahq36LLYaZtstaW1rM1qSX8yFM9q8hOB5tI=,tag:yl/fu74tdCkroHgh3BF7Ew==,type:str]
+    namespace: ENC[AES256_GCM,data:Sl0i+INIOV3XKEc=,iv:dq3tlCZhUoCCVcubhjhvDSp2pPQO2TflSaFlnEJ70JQ=,tag:BK1zyvTxLusvkpfdMBuZ5g==,type:str]
 stringData:
-  TELEPORT_HOST: "teleport.ddlns.net"
+    TELEPORT_HOST: ENC[AES256_GCM,data:sr+EZns/fLkBoQPdgK2vnGWe,iv:AcdQT5k7c8pgzVnXxvO+h02luO4Q7dxyF3qcEKKkQ3M=,tag:sZEgvf8RMBilgKIBiDsNfA==,type:str]
+sops:
+    age:
+        - recipient: age1tljmetrhlj3ep4l2sxqfa5dx8anqlearhpkjnmuzxtkve3wdu57skxfhq0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSbytOM2YrdlIzUFNXL3Fv
+            Y0dVcEU0b0JTelE0T3NFSnZNSFRqbHJqenhNClUyRzhkVFg3R3pHYVVqc1FldDFH
+            cnhzSDhMVkw3V0gybjhrYmMxYWE1UTAKLS0tIGdGTkpVa1h2UXluOGg2emx0QWZK
+            YnFGU2dZcGpRc0NqNm5YWHMybVNac28KGj3JsjiuTwAgevRGiVjePCrsu0L9ol3I
+            jmbmGtObH9Q1XgAbx76I+UhQAcFoyI1ePOvj4GaHHO4fSzRx+cVumA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-04-11T18:37:51Z"
+    mac: ENC[AES256_GCM,data:szI/tq0/7P1nSRDX1LVtVPk+TkHv8u9W+/w1M7B68lb/qCMHHpq23WomDTGrxQTN5+8tWXPWgBAH6levr95gQKmSred4Ra7vRMSsGrVrpxNtGIXVWeIielJq24fBfmdiZKLNF6QX7+R/Xg94M8eTGtYHcK9Xj0AOhU0C7irhIek=,iv:4XBcpFd2P4a/C30TMRyJgTpi6it4E5nBGUnQccypplA=,tag:89uoinrj3+mCvNrccBuLTQ==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.12.2

--- a/clusters/oc-ampere/vars/cluster-vars.sops.yaml
+++ b/clusters/oc-ampere/vars/cluster-vars.sops.yaml
@@ -1,33 +1,33 @@
-#ENC[AES256_GCM,data:bjNyTHtnodA7iWc0NxFVgHGzDDOdoIRFbbaWM9redurNMe8Jz+JiyJLHXi27p1PjzPfvuWeSWLTL,iv:fh6neripbTvxAma5S0lVUxDeYvcDan3UctJFZaX7Wvg=,tag:0y5bkKIH3eZHnT12JdcRCw==,type:comment]
-#ENC[AES256_GCM,data:b0k3q+SZdWQzkgbj7/u3MCvI3xkonoFKTRJDQliLYZhunU1355XFRcTg4rydXqup/HCojbrFtYK9QKfb15WnUcre/XLoQatzxuqA/4+7,iv:uwiqDUNRoHCGqVpWiu29hzL3r7naxKwF6o+ZCasgBi4=,tag:+kqHv3IG0m9wByWeR/vQPA==,type:comment]
+#ENC[AES256_GCM,data:0vbkqy27NUL/+jBJKGAxQxNnFpU+WijYYAuMFimdevKAdi/kNceVkhJDkpXfh+MhqpL1fDnSLanX,iv:JXkhC8A2+1kl5ItRs8+h+XV3eO8hkrTwJzifFAb0kxQ=,tag:/f7GDBFD+QOaxzWZcHYi+Q==,type:comment]
+#ENC[AES256_GCM,data:kK1EWWF1VQicdkAV8nq/8XugB69xEaZ3Iy7ao9TjY3T+ktqKMfQURRA9bbdTbn9wcjopFJRodsZFAQ2BUORLTFrQxISgRYVT6q1fqC4x,iv:kF5/1k1QTEWVlB6yEFde4Mu8ZDhj/Y4ezmNKTYlimGc=,tag:SuYwfaCRPITzvKrMcHt2gA==,type:comment]
 #
-#ENC[AES256_GCM,data:B4hbxlyLOWcZ+Qz+Iss1TwxtM8DJckjsWWSc1IvmgqGKEixw0tNrgg==,iv:KJJc29AlpLJ4D3PLSitjwxxZ3Fjzv3WoIsxZFfbPtMg=,tag:MWrEcWG3YaQEgKETWJ5Siw==,type:comment]
-#ENC[AES256_GCM,data:QYehXdh8F5XC4gKmpZAzXXYxlh1NTQwPLTDzJKu9FYP5r8mn,iv:Q7kvX72RWAWYao7cZksehdVczXsd9cDrh6KOHSAe3oo=,tag:X/oxtIDOuBXNV+pSTbLSJg==,type:comment]
-#ENC[AES256_GCM,data:uvfJDkZoczjvrk0eOniifdshAyMM15Ox2fA4aLmxzz57jGoNq+DhqOLY3g==,iv:QYEsEkIjmRjUoiTDJCDogszQaObzpkD/auzihq7Cb7E=,tag:esE4HcZmeZHlvFdC+1jt7g==,type:comment]
-#ENC[AES256_GCM,data:tI6HAGB5jt7vEK84oTxLct2UTJ3In7Ooe+DKaM2T,iv:KSTHeiTK6IwcSzYLwxmJAS47rzVieIhU+6+gRgRmFSc=,tag:fRTOH4puXqOgN80BjO9DRQ==,type:comment]
-#ENC[AES256_GCM,data:yEeq5qvl9Ai3h5v3t6OYDds9nLFYeXJhz+aWrIW4LCV8fHuTCZDkfRvfChQ7M28/0w==,iv:2GcHuM1UmiitJOYHZDYB4zRTX70r7rGMOtFrBcemK4Y=,tag:euziDEl+vLN0w/TkmpiGYg==,type:comment]
-#ENC[AES256_GCM,data:cTILQOhG561qWiCIqEJnXH8EBWPWQ2OS/poep/CuL7jPPg==,iv:fcSUOCW8ltbwq8dYJgXf5ZbpYoWIaBmzMMh1WxUNx3I=,tag:gnPC2q0Rw8fWhZtqcB137w==,type:comment]
-#ENC[AES256_GCM,data:+4jeAMQIPmAwyer6WNekwpeVZ60T7xgENuETmyJ+zpVWwlSGkQEoSUh3Nbx4xBuIR3BNzDfH1RjukURLI5C/Ktr7wg==,iv:v68Yur/wTSeqbX6KrXedO0tvrTcS9h14XRNJ+b0sANA=,tag:UQ7hQmmR73/IydwDtlypqw==,type:comment]
-#ENC[AES256_GCM,data:Fjv9r32zECyCzmt54SJwMOvwPu1Y5zEA9yFOyneOyyQAmbhD9TgdqowcCXVFCJQQXbVDKqtmnXXqow==,iv:oM5vAXZfD7aH7UKwnW5n/50bf4f29Gi3nwXN4sHWneo=,tag:b1qgEVZQFsclsRON/0Nr8A==,type:comment]
-apiVersion: ENC[AES256_GCM,data:mrk=,iv:E8AMC8A81z9f0hWJZWPvyN/BAWavwTJgwhMDrfWutu4=,tag:gDlxaxbo58HlyrMt8iTN1w==,type:str]
-kind: ENC[AES256_GCM,data:GwLpNjKS,iv:8stv3ZOZaZCtf8RselPWCp9ZszBz+9i/7UyszIWmg9k=,tag:b9TuinSQo2xFXSj2A6oNtA==,type:str]
+#ENC[AES256_GCM,data:+f3wyFF/hp1clS8TLoYWdKbALCcqXfu+KuoL/rjU8/L1mMsYyq465Q==,iv:tFghuOcWq6+6/eLfy5iQUL92yNa7QCtLdvw8gMfSWC8=,tag:jDCVysTZqXwWGCMGm0zi8A==,type:comment]
+#ENC[AES256_GCM,data:8d7IikT6xU6cBsTDys69Fgz3QgN2mV+Ch7UK4ZvTc3p4t8xx,iv:/WMeVsF9z84bLsqxLwkRLWL3USFwAW11Z60Ul1WtA+U=,tag:aulEKxNKO+uvBlyJt0CFAw==,type:comment]
+#ENC[AES256_GCM,data:rd5G5T0ZgLjTiZIFvmJPGlgLIANA7qfLAEnqJRDd9bnHA54sLGhwbDvAXg==,iv:l52mJby698H9WZSNt5Ekmi08Hkj+jdOVgR2amlWasvo=,tag:6Q9WlyoGy40zbc4WT4l7jQ==,type:comment]
+#ENC[AES256_GCM,data:R8FE8Xqu+eciJO3jWZBMWLR25hKvlL9FE2bLpOLm,iv:9FD1tMhoAACAvqPAmXwgyYErx+BXienG1mj2BPtvBEo=,tag:ntoEKoaV2bJ87s3unK0bVQ==,type:comment]
+#ENC[AES256_GCM,data:+xf5dlsuNnC3b78P8Gv39sLjScwozKUUtJhrBzwlV5eVJEG4gUpNsVRjnnRqGg3o9A==,iv:8qN5owL0Z3cjfoGjBCnqalVgRmRO+Bc3Ez5lC2FtfiU=,tag:Q94FfzCGWdIVJm37xlJj7Q==,type:comment]
+#ENC[AES256_GCM,data:CyxFU3YnkYXp8mzzcjTlpPBr2D4ML52zEG1HwzIBxCAUTw==,iv:d6LAh6LzuKgoS3BVaO67MR5lbuWcPgnB4bjbYMTHMY4=,tag:0kSaY5chzxA5GO73roDoGQ==,type:comment]
+#ENC[AES256_GCM,data:LPzWzNJ/nkYXzZISnZ/qbzLUlWeiNJH5ZO1M/unC6yYCtkigluKc5tfekE8hyIMECxyC8ntJjSVwewPnjykskUX6OQ==,iv:Jd9Bws4nLKflGEQdQddtAKCzHXiAEtD0za7XCwRL5WA=,tag:jy9qQpul+ztR+4keHu4tng==,type:comment]
+#ENC[AES256_GCM,data:jeu4NoaaWAteLWUMo5ylwQCr7YIykUw9YBwUEROIHVELov5NAfI0O6EtBqxEn0DDyq01Hnz/eilwng==,iv:GVC0nufD3M9reKNV5SpJeuELDY8tcAwRtv7ZAwcd288=,tag:pk8RpH2w7W9LyHobGC2Qog==,type:comment]
+apiVersion: ENC[AES256_GCM,data:P5o=,iv:zrgOPx6yWGloExlMdZrf9EyoqLU69nH3KjExvvCot9Q=,tag:RUVDqA0Qt9IDvzhFtJaLqQ==,type:str]
+kind: ENC[AES256_GCM,data:goFZK4jC,iv:e+QDZNI7pjpKM5Pl6ef5tODgoRJ38YtKNQ0Nlr3orTM=,tag:2zcUFT52DxgpDYEBDziazw==,type:str]
 metadata:
-    name: ENC[AES256_GCM,data:Ng9MuW1Rtz0ggaTJ,iv:A1S8t6/+Ahq36LLYaZtstaW1rM1qSX8yFM9q8hOB5tI=,tag:yl/fu74tdCkroHgh3BF7Ew==,type:str]
-    namespace: ENC[AES256_GCM,data:Sl0i+INIOV3XKEc=,iv:dq3tlCZhUoCCVcubhjhvDSp2pPQO2TflSaFlnEJ70JQ=,tag:BK1zyvTxLusvkpfdMBuZ5g==,type:str]
+    name: ENC[AES256_GCM,data:GOF5q9VkPGRTm1Mk,iv:KcpQY+vEo7D9r5YV8Wg8vTUzpuptMNXrE8uanCs6vV0=,tag:4SDaVvVLJzEqWh1N7rmrmg==,type:str]
+    namespace: ENC[AES256_GCM,data:4EGesLZ88k/6TvQ=,iv:2d/hobKEHXF8DwxNC3HxtYnPcZNQ489JWqdDR2SMi8Q=,tag:LtiBpIGeIraf30KCA+Yvrg==,type:str]
 stringData:
-    TELEPORT_HOST: ENC[AES256_GCM,data:sr+EZns/fLkBoQPdgK2vnGWe,iv:AcdQT5k7c8pgzVnXxvO+h02luO4Q7dxyF3qcEKKkQ3M=,tag:sZEgvf8RMBilgKIBiDsNfA==,type:str]
+    TELEPORT_HOST: ENC[AES256_GCM,data:llbODRYgXwlCpsmgZ2nDOBiB,iv:7Ywam8VZjwEy1So8XS6XDK+0fHpF4rf7QmRF8HEJtYw=,tag:KYiN1aObE3W+SGosqbF0lw==,type:str]
 sops:
     age:
-        - recipient: age1tljmetrhlj3ep4l2sxqfa5dx8anqlearhpkjnmuzxtkve3wdu57skxfhq0
+        - recipient: age13fpkwl74k6lttn534vthcq08mr2r684067e2p9yw9h0w5j967g3qlsydgm
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSbytOM2YrdlIzUFNXL3Fv
-            Y0dVcEU0b0JTelE0T3NFSnZNSFRqbHJqenhNClUyRzhkVFg3R3pHYVVqc1FldDFH
-            cnhzSDhMVkw3V0gybjhrYmMxYWE1UTAKLS0tIGdGTkpVa1h2UXluOGg2emx0QWZK
-            YnFGU2dZcGpRc0NqNm5YWHMybVNac28KGj3JsjiuTwAgevRGiVjePCrsu0L9ol3I
-            jmbmGtObH9Q1XgAbx76I+UhQAcFoyI1ePOvj4GaHHO4fSzRx+cVumA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBMWXlMRmZZWjV5ZW1Ld2FE
+            TkRFSG5QT3NYc3JEajVCOEVsc1N5RXhjMEgwCmRRbU40bWFaZmtKTXZ0YjRpR0li
+            VS9ZNUhxNFgxVkE5V0VmUm9FYnVVWDAKLS0tIGlqUkovYzlOVlQ4cVVRSlZFMzUx
+            YkR2QTE1dDdRajRYMnVSeVd6VXlJYVEKf/SwfV1ceP6Pu2hyFLgK5ySw8IbI8yZZ
+            4RTMtU0LTOD7l/Z/WXkC8RK7spbXoAVidS1EUAeepUPHtZvCzSKk7w==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-11T18:37:51Z"
-    mac: ENC[AES256_GCM,data:szI/tq0/7P1nSRDX1LVtVPk+TkHv8u9W+/w1M7B68lb/qCMHHpq23WomDTGrxQTN5+8tWXPWgBAH6levr95gQKmSred4Ra7vRMSsGrVrpxNtGIXVWeIielJq24fBfmdiZKLNF6QX7+R/Xg94M8eTGtYHcK9Xj0AOhU0C7irhIek=,iv:4XBcpFd2P4a/C30TMRyJgTpi6it4E5nBGUnQccypplA=,tag:89uoinrj3+mCvNrccBuLTQ==,type:str]
+    lastmodified: "2026-04-11T18:52:00Z"
+    mac: ENC[AES256_GCM,data:IN3Mm+gdG15eOlb/1r5SeyhmFau+G//EgxRYm8Lk7OEj8zPrZcolMZBaXr3WNlA98HWsw4+mRXH90Nfye5IXBv3Q0sdaaCXbsqo5usuhN6fdhy7XJdeItL5c4YS/5L7Bq3+PO8TAKzeSH9BOYMI6hpXMje1Cbt/yn2A4/UwVoBI=,iv:X7F0bEhvsNp1HRQmmAvl/+bNWS3vfHD4D6s25lXjsSA=,tag:adlUdrbN9xuqvlOIOOEEtA==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2


### PR DESCRIPTION
## Summary

- Add SOPS/age encryption for all plaintext FQDNs, external URLs, and domain names across all clusters
- Zero plaintext URLs remain in git (outside the now-encrypted `.sops.yaml` vars files)
- All five clusters now have a `cluster-vars` Kustomization with SOPS decryption via `sops-age` secret

## Architecture

```
clusters/{cluster}/vars/cluster-vars.sops.yaml  ← age-encrypted (safe to commit)
        ↓ Flux decrypts via sops-age secret in flux-system
cluster-vars Secret (plaintext at runtime in K8s)
        ↓ postBuild.substituteFrom
HelmRelease: host: ${NEXTCLOUD_HOST}  →  host: cloud.ddlns.net
```

## Clusters covered

| Cluster | Variables hidden |
|---|---|
| `kubenuc` | All app hostnames (nextcloud, harbor, jellyfin, portainer, jenkins, sso, s3, zabbix, artifactory, cloudflare tunnel) + Grafana Cloud URLs (prometheus, loki, otlp, fleet) |
| `k8s-vms-daniele` | semaphore, awx, teleport, falco, cloudflare tunnel + Grafana Cloud URLs |
| `k3s-rabbit` | teleport proxyAddr + squid proxy URL |
| `oc-ampere` | teleport proxyAddr |
| `kubenuc-test` | All test hostnames (`.tst.ddlns.net` variants) |

## Bootstrap steps (already done per cluster)

- `age-keygen` ran to generate keypairs
- `sops-age` Kubernetes Secret bootstrapped into each cluster's `flux-system`
- All vars files encrypted with `sops --encrypt --in-place`
- Age private keys stored in 1Password


## Test plan

- [ ] Verify `flux get kustomizations` shows `cluster-vars` reconciling successfully on each cluster
- [ ] Confirm `kubectl get secret cluster-vars -n flux-system` exists on each cluster
- [ ] Spot-check a substituted HelmRelease value (should show actual domain, not `${VAR}`)
