### PR TITLE
fix(sops): add explicit kustomization.yaml to all cluster roots

### DIFF
--- a/clusters/k3s-rabbit/kustomization.yaml
+++ b/clusters/k3s-rabbit/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - apps.yaml
+  - charts.yaml
+  - cluster-vars.yaml

--- a/clusters/k8s-vms-daniele/kustomization.yaml
+++ b/clusters/k8s-vms-daniele/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - apps.yaml
+  - charts.yaml
+  - cluster-vars.yaml
+  - flux-instance.yaml

--- a/clusters/kubenuc-test/kustomization.yaml
+++ b/clusters/kubenuc-test/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - apps.yaml
+  - charts.yaml
+  - cluster-vars.yaml

--- a/clusters/kubenuc/kustomization.yaml
+++ b/clusters/kubenuc/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - apps.yaml
+  - charts.yaml
+  - cluster-vars.yaml
+  - flux-instance.yaml

--- a/clusters/oc-ampere/kustomization.yaml
+++ b/clusters/oc-ampere/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - apps.yaml
+  - charts.yaml
+  - cluster-vars.yaml
+  - flux-instance.yaml


### PR DESCRIPTION
Flux's kustomize-controller auto-discovers YAML recursively when no kustomization.yaml exists. The newly added vars/ subdirectory contains cluster-vars.sops.yaml whose encrypted content (ENC[AES256_GCM,...]) is not valid Kubernetes YAML, causing the root build to fail and preventing the cluster-vars Kustomization from being created.

Add explicit kustomization.yaml to each cluster root listing only the top-level resource files, stopping Kustomize from recursing into vars/.