### PR TITLE
docs: update README, add NetBox, and create Claude Code skills

### DIFF
--- a/.claude/agents/terraform-agent.md
+++ b/.claude/agents/terraform-agent.md
@@ -41,12 +41,14 @@ All Terraform environments are mounted read-only at `/workspace/terraform/`:
   - `proxmox-vm/`       — Proxmox VM module
   - `proxmox-lxc/`      — Proxmox LXC module
   - `hetzner-server/`   — Hetzner Cloud server module
-  - `cloudflare-dns/`   — Cloudflare DNS records module
-- `/workspace/terraform/oci/`              — Oracle Cloud Infrastructure
+  - `oci-instance/`     — Oracle Cloud instance module
+- `/workspace/terraform/netbird/`          — Netbird VPN (networks, groups, policies)
+- `/workspace/terraform/oci/`              — Oracle Cloud Infrastructure (two accounts)
 - `/workspace/terraform/proxmox/`          — Proxmox hosts (one workspace each)
   - `ec200/`             — OVH EC200 (MXP)
   - `gozzi-hpelvisor/`   — Gozzi-01 BIO + hpelvisor
   - `rabbit/`            — Rabbit-01 PSP
+- `/workspace/terraform/tailscale/`        — Tailscale VPN (ACLs, DNS, auth keys)
 
 ## Notes
 

--- a/.claude/skills/ci-workflows.md
+++ b/.claude/skills/ci-workflows.md
@@ -1,0 +1,123 @@
+---
+name: ci-workflows
+description: GitHub Actions workflow patterns for infra-cd — Terraform CI (fmt/init/validate/plan/apply), cluster validation (k3s + FluxCD + Robot Framework), Flux cron updates, and runner selection.
+---
+
+# CI Workflows Skill
+
+Use this skill when creating or modifying GitHub Actions workflows. Complex CI decisions (e.g. matrix strategy, environment promotion gates) use Claude Code directly; boilerplate uses the Terraform/Kubernetes agents.
+
+## Terraform CI workflow pattern
+
+All Terraform workflows follow the same pattern. Copy from `.github/workflows/terraform.yml` and adjust the paths and runner.
+
+### Key parameters to change
+
+| Parameter | Location | Example |
+|---|---|---|
+| `on.push.paths` | trigger | `terraform/netbird/**` |
+| `on.pull_request.paths` | trigger | `terraform/netbird/**` |
+| `env.TF_WORKING_DIR` | env | `terraform/netbird` |
+| `runs-on` | jobs | see runner table below |
+| Workflow filename | file name | `terraform-netbird.yml` |
+
+### Runner selection
+
+| Runner | Used for |
+|---|---|
+| `self-hosted` | Generic / Hetzner VPS / PSP (BGY) |
+| `LGU` | Gozzi-01 + hpelvisor (Lugano, Switzerland) |
+| `mxp` | OVH EC200 (Milan, Italy) |
+
+Choose based on network proximity to the managed infrastructure, or `self-hosted` for cloud providers with no locality requirement.
+
+### Workflow stages
+
+```yaml
+steps:
+  - uses: actions/checkout@v4
+
+  - uses: hashicorp/setup-terraform@v4
+    with:
+      cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+
+  - name: Terraform Format Check
+    run: terraform fmt -check
+    working-directory: ${{ env.TF_WORKING_DIR }}
+
+  - name: Terraform Init
+    run: terraform init
+    working-directory: ${{ env.TF_WORKING_DIR }}
+    env:
+      OP_TOKEN: ${{ secrets.OP_TOKEN }}
+      OP_ENDPOINT: ${{ secrets.OP_ENDPOINT }}
+
+  - name: Terraform Validate
+    run: terraform validate
+    working-directory: ${{ env.TF_WORKING_DIR }}
+
+  - name: Terraform Plan
+    id: plan
+    run: terraform plan -no-color
+    working-directory: ${{ env.TF_WORKING_DIR }}
+    env:
+      TF_VAR_onepassword_token: ${{ secrets.OP_TOKEN }}
+      TF_VAR_onepassword_endpoint: ${{ secrets.OP_ENDPOINT }}
+
+  # Post plan as PR comment (copy the comment block from terraform.yml)
+
+  - name: Terraform Apply
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    run: terraform apply -auto-approve
+    working-directory: ${{ env.TF_WORKING_DIR }}
+    env:
+      TF_VAR_onepassword_token: ${{ secrets.OP_TOKEN }}
+      TF_VAR_onepassword_endpoint: ${{ secrets.OP_ENDPOINT }}
+```
+
+## Cluster validation workflow pattern
+
+Reference: `.github/workflows/validate-kubenuc.yml`
+
+Key components:
+- Spins up a k3s cluster (v1.33.3+k3s1)
+- Installs FluxCD (v2.7.5) via `flux install`
+- Applies cluster manifests
+- Runs Robot Framework E2E tests via `tests/robot/robot-test-job.yaml`
+- 2-hour timeout
+- Triggers on PRs touching `clusters/{cluster}/**`
+
+## FluxCD cron update workflow
+
+Reference: `.github/workflows/flux-cron.yml`
+
+- Runs Mondays at 3 AM
+- Also manually triggerable
+- Updates FluxCD components in `clusters/*/flux-system/`
+- Opens a PR with the update
+
+## Required GitHub Actions secrets
+
+| Secret | Purpose | Used by |
+|---|---|---|
+| `TF_API_TOKEN` | Terraform Cloud authentication | All Terraform workflows |
+| `OP_TOKEN` | 1Password Connect token | All Terraform workflows |
+| `OP_ENDPOINT` | 1Password Connect endpoint | All Terraform workflows |
+| `GITHUB_TOKEN` | Built-in, no configuration needed | All workflows |
+
+## Adding a new Terraform workflow
+
+1. Copy `.github/workflows/terraform.yml` to `.github/workflows/terraform-{name}.yml`
+2. Update `on.push.paths`, `on.pull_request.paths`, `env.TF_WORKING_DIR`, `runs-on`
+3. If multiple working directories in one workflow, use a matrix or separate jobs (see `terraform-mxp.yml` for the two-job pattern)
+4. Confirm the Terraform Cloud workspace exists and the runner is available
+
+## Verification checklist
+
+- [ ] Workflow triggers on the correct file paths
+- [ ] Runner is available and has network access to managed infrastructure
+- [ ] `terraform fmt -check` is the first step (CI enforces formatting)
+- [ ] Plan output is posted as a PR comment
+- [ ] Apply only runs on `main` branch push
+- [ ] Required secrets are present in the repository settings
+- [ ] Workflow file passes YAML validation (`pre-commit run --all-files`)

--- a/.claude/skills/cluster-operations.md
+++ b/.claude/skills/cluster-operations.md
@@ -1,0 +1,151 @@
+---
+name: cluster-operations
+description: Cluster lifecycle operations — setting up new clusters, kubenuc-test overlay pattern, kustomize patch conventions, and FluxCD bootstrap structure for infra-cd clusters.
+---
+
+# Cluster Operations Skill
+
+Use this skill when bootstrapping a new cluster, understanding the kubenuc-test overlay pattern, or troubleshooting cluster Kustomization structure.
+
+## When to use
+
+- Adding a brand new cluster under `clusters/`
+- Creating kubenuc-test-style overlay patches that reuse kubenuc manifests
+- Understanding what files are required for a functioning FluxCD cluster
+- Checking which apps exist on which clusters
+
+## Cluster directory structure
+
+Every cluster needs:
+
+```
+clusters/{cluster-name}/
+  kustomization.yaml          # Root Kustomization (optional, for direct apply)
+  flux-instance.yaml          # FluxInstance or flux-system bootstrap
+  apps.yaml                   # Flux Kustomization → ./apps/
+  charts.yaml                 # Flux Kustomization → ./charts/
+  cluster-vars.yaml           # Reference to SOPS-encrypted cluster-vars Secret
+  vars/
+    cluster-vars.sops.yaml    # SOPS-encrypted cluster variables
+  apps/
+    kustomization.yaml        # Lists all app directories
+    {app-name}/
+      deploy.yaml
+      manifests/
+      secrets/
+  charts/
+    kustomization.yaml        # Lists all HelmRepository/GitRepository files
+    {repo-name}.yml
+  flux-system/
+    kustomization.yaml
+    gotk-components.yaml      # FluxCD controllers (managed by flux bootstrap)
+    gotk-sync.yaml            # GitRepository + Kustomization for flux-system
+```
+
+## kubenuc-test overlay pattern
+
+`kubenuc-test` is a resource-reduced overlay of `kubenuc`. It reuses production manifests directly and patches them:
+
+```yaml
+# clusters/kubenuc-test/apps/{app}/deploy.yaml
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: {app-name}
+  namespace: flux-system
+spec:
+  interval: 5m
+  path: ./clusters/kubenuc/apps/{app}/manifests   # <-- points to kubenuc
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  targetNamespace: {app-namespace}
+  dependsOn:
+    - name: {dependency}
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-vars
+  patches:
+    # Scale down replicas
+    - patch: |-
+        - op: replace
+          path: /spec/values/replicaCount
+          value: 1
+      target:
+        kind: HelmRelease
+        name: {app-name}
+    # Shrink storage
+    - patch: |-
+        - op: replace
+          path: /spec/values/persistence/size
+          value: 1Gi
+      target:
+        kind: HelmRelease
+        name: {app-name}
+```
+
+**Chart sources**: `kubenuc-test/charts.yaml` points its Kustomization path to `./clusters/kubenuc/charts`, so it inherits all kubenuc chart sources automatically. No separate chart file changes are needed for apps that only exist on kubenuc-test.
+
+## Cluster variable substitution
+
+Each cluster needs its own SOPS-encrypted variables. Variables use the cluster prefix convention:
+- `kubenuc`: `${S3_API_HOST}`, `${CLUSTER_DOMAIN}`
+- `kubenuc-test`: `${TST_S3_API_HOST}`, `${TST_CLUSTER_DOMAIN}`
+
+## App dependency ordering
+
+Standard ordering that must be respected:
+
+```
+cert-manager (if TLS needed)
+    ↓
+openebs
+    ↓
+{database} (PostgreSQL via Zalando operator)
+    ↓
+{application}
+```
+
+For apps without storage or database needs, omit the preceding steps.
+
+## Kubernetes clusters in this repo
+
+| Cluster | Type | Purpose | Special notes |
+|---|---|---|---|
+| `kubenuc` | Bare metal | Primary production | 3 CP + 3 workers, HAProxy ingress |
+| `kubenuc-test` | Bare metal | Pre-production | Overlays kubenuc manifests, reduced resources |
+| `k3s-prod-test` | k3s | Production-like test | Independent manifests |
+| `k3s-rabbit` | k3s | Rabbit server cluster | Lightweight |
+| `k8s-vms-daniele` | VMs | Development | AWX, independent apps |
+| `oc-ampere` | OpenShift | ARM/Ampere OCI | Teleport agent only |
+
+## Agent delegation
+
+Use kubernetes-agent to validate Kustomization builds:
+
+```bash
+cd docker/agents && docker compose up -d kubernetes-agent
+
+# Validate cluster structure
+docker compose exec kubernetes-agent kustomize build \
+  /workspace/clusters/{cluster-name}/apps/{app}/manifests
+
+# Check all clusters build cleanly
+for cluster in kubenuc kubenuc-test k3s-prod-test k3s-rabbit k8s-vms-daniele; do
+  echo "=== $cluster ==="
+  docker compose exec kubernetes-agent kustomize build \
+    /workspace/clusters/$cluster/apps 2>&1 | tail -3
+done
+```
+
+## Verification checklist
+
+- [ ] All required files present in new cluster directory
+- [ ] `kustomize build` succeeds for modified cluster(s)
+- [ ] SOPS age key added to `.sops.yaml` for new clusters
+- [ ] FluxCD bootstrap completed on the actual cluster (`flux bootstrap`)
+- [ ] `cluster-vars` Secret decryptable by cluster's age key
+- [ ] `dependsOn` chains are complete
+- [ ] kubenuc-test patches apply without errors if the app is mirrored

--- a/.claude/skills/flux-operations.md
+++ b/.claude/skills/flux-operations.md
@@ -1,0 +1,147 @@
+---
+name: flux-operations
+description: FluxCD/GitOps operations for infra-cd — add/update apps, HelmRepositories, SOPS variable substitution, and dependency chains. Delegates YAML generation to kubernetes-agent with Ollama.
+---
+
+# FluxCD / GitOps Operations Skill
+
+Use this skill when adding or modifying Kubernetes applications, Helm chart sources, or Flux configuration in any cluster.
+
+## When to use
+
+- Adding a new application to a cluster
+- Adding a new Helm chart repository
+- Updating a HelmRelease values
+- Configuring SOPS-encrypted variable substitution
+- Setting up `dependsOn` chains between applications
+- Creating kubenuc-test overlay patches from kubenuc manifests
+
+## Repository patterns
+
+### Application directory structure
+
+```
+clusters/{cluster}/apps/{app-name}/
+  deploy.yaml          # Flux Kustomization (namespace: flux-system)
+  manifests/
+    release.yml        # HelmRelease with chart sourceRef and values
+    namespace.yaml     # Namespace (if needed)
+    backup.yml         # Optional: PostgreSQL backup CronJob
+  secrets/             # 1Password-backed secrets
+    secret-name.yml    # OnePasswordItem CRD
+```
+
+### deploy.yaml template (Flux Kustomization)
+
+```yaml
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: {app-name}
+  namespace: flux-system
+spec:
+  interval: 5m
+  path: ./clusters/{cluster}/apps/{app-name}/manifests
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  targetNamespace: {app-namespace}
+  dependsOn:
+    - name: openebs           # if app needs storage
+    - name: {db-name}         # if app needs a database
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-vars    # for ${VAR} substitution from SOPS
+```
+
+### HelmRelease template
+
+```yaml
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: {app-name}
+  namespace: {app-namespace}
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: {chart-name}
+      version: ">=1.0.0 <2.0.0"
+      sourceRef:
+        kind: HelmRepository
+        name: {repo-name}
+        namespace: flux-system
+  values:
+    {}
+```
+
+### Dependency chain convention
+
+```
+openebs → {database} → {application}
+```
+
+Always declare `dependsOn` in Kustomization, not in HelmRelease.
+
+### kubenuc-test overlay pattern
+
+`kubenuc-test` reuses `kubenuc` manifests via path reference and applies JSON patches:
+
+```yaml
+# clusters/kubenuc-test/apps/{app}/deploy.yaml
+spec:
+  path: ./clusters/kubenuc/apps/{app}/manifests  # reuse production manifests
+  patches:
+    - patch: |-
+        - op: replace
+          path: /spec/values/replicas
+          value: 1
+      target:
+        kind: HelmRelease
+        name: {app-name}
+```
+
+### Storage class
+
+Use `openebs-hostpath` for all persistent volumes (the default storage class on kubenuc).
+
+### Sync intervals
+
+- Apps: `5m` (default, do not go below)
+- Charts: `15m`
+- Infrastructure (openebs, cert-manager): `15m`
+
+## SOPS variable substitution
+
+Variables encrypted in `clusters/{cluster}/vars/cluster-vars.sops.yaml` are available as `${VAR_NAME}` in manifests when `postBuild.substituteFrom` references the `cluster-vars` Secret.
+
+Common variables: `${S3_API_HOST}`, `${S3_WEB_HOST}`, `${CLUSTER_DOMAIN}`.
+
+## Agent delegation
+
+For YAML generation and kustomize validation, use the kubernetes-agent with Ollama:
+
+```bash
+cd docker/agents && docker compose up -d kubernetes-agent
+
+# Validate after changes
+docker compose exec kubernetes-agent kustomize build \
+  /workspace/clusters/kubenuc/apps/{app-name}/manifests
+
+# Generate HelmRelease values YAML via Ollama
+docker compose exec kubernetes-agent sh -c \
+  "echo 'Generate a HelmRelease for {chart} with openebs-hostpath storage' | \
+   curl -s $OLLAMA_HOST/api/generate -d @-"
+```
+
+## Verification checklist
+
+- [ ] `kustomize build` renders without errors for modified clusters
+- [ ] `pre-commit run --all-files` passes (YAML lint, whitespace)
+- [ ] `dependsOn` chain is complete and correct
+- [ ] Secrets reference 1Password items (not raw values)
+- [ ] `kubenuc-test` patches apply correctly if the app exists on both clusters
+- [ ] PR created and CI validation passes

--- a/.claude/skills/secrets-management.md
+++ b/.claude/skills/secrets-management.md
@@ -1,0 +1,147 @@
+---
+name: secrets-management
+description: Secrets management patterns for infra-cd — 1Password Operator (OnePasswordItem/ExternalSecret), SOPS age encryption for FluxCD variable substitution, and Terraform 1Password provider.
+---
+
+# Secrets Management Skill
+
+Use this skill when adding, rotating, or troubleshooting secrets in Kubernetes, Terraform, or FluxCD variable substitution.
+
+## When to use
+
+- Adding a new application that needs Kubernetes secrets
+- Setting up SOPS-encrypted cluster variables for FluxCD substitution
+- Configuring the 1Password Terraform provider for a new environment
+- Troubleshooting missing or stale secrets in a cluster
+
+## Pattern 1: 1Password Operator (Kubernetes secrets)
+
+Use `OnePasswordItem` for injecting 1Password items directly as Kubernetes `Secret` resources.
+
+### OnePasswordItem CRD
+
+```yaml
+# clusters/{cluster}/apps/{app}/secrets/my-secret.yml
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: my-secret
+  namespace: {app-namespace}
+spec:
+  itemPath: "vaults/{vault-name}/items/{item-title}"
+```
+
+The operator creates a matching `Secret` with the same name. Fields in the 1Password item become keys in the Secret.
+
+**Convention:** Store all K8s secrets under vault `k8s_secrets`. Item title matches the Kubernetes secret name.
+
+### ExternalSecret (alternative)
+
+Used when you need to transform or select specific fields:
+
+```yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: my-secret
+  namespace: {app-namespace}
+spec:
+  secretStoreRef:
+    name: onepassword-connect
+    kind: ClusterSecretStore
+  target:
+    name: my-secret
+  data:
+    - secretKey: username
+      remoteRef:
+        key: vaults/{vault}/items/{item}
+        property: username
+    - secretKey: password
+      remoteRef:
+        key: vaults/{vault}/items/{item}
+        property: password
+```
+
+## Pattern 2: SOPS-encrypted cluster variables
+
+FluxCD uses `cluster-vars` Secret for `${VAR}` substitution in manifests. The Secret is created from a SOPS-encrypted file.
+
+### File location
+
+```
+clusters/{cluster}/vars/cluster-vars.sops.yaml
+```
+
+### Adding a new variable
+
+1. Decrypt the file: `sops clusters/{cluster}/vars/cluster-vars.sops.yaml`
+2. Add the new key under `data:` (all values must be base64 or plain string)
+3. Save (SOPS re-encrypts on save)
+4. Reference in manifests as `${MY_VAR_NAME}`
+
+### Age key management
+
+Each cluster has its own age key in `.sops.yaml`:
+
+```yaml
+# .sops.yaml
+creation_rules:
+  - path_regex: clusters/{cluster}/vars/.*\.sops\.yaml
+    age: age1...{cluster-public-key}...
+```
+
+**Never commit age private keys (`.agekey` files) — they are gitignored.**
+
+The age private key must be available as a Kubernetes Secret named `sops-age` in `flux-system` namespace for FluxCD to decrypt during reconciliation.
+
+## Pattern 3: Terraform 1Password provider
+
+Always source Terraform provider credentials from 1Password, never hardcode:
+
+```hcl
+# variables.tf
+variable "onepassword_token" {
+  type      = string
+  sensitive = true
+}
+variable "onepassword_endpoint" {
+  type      = string
+  sensitive = true
+}
+
+# provider.tf
+provider "onepassword" {
+  token = var.onepassword_token
+  url   = var.onepassword_endpoint
+}
+
+# data.tf
+data "onepassword_item" "my_credentials" {
+  vault = "infra"
+  title = "My Service"
+}
+
+# main.tf (usage)
+resource "some_resource" "example" {
+  api_key = data.onepassword_item.my_credentials.credential
+}
+```
+
+In CI, `OP_TOKEN` and `OP_ENDPOINT` are passed as environment variables from GitHub Actions secrets.
+
+## Never commit
+
+- Raw Kubernetes `Secret` manifests with `data:` base64 values
+- `.env` files
+- TLS certificates or SSH private keys
+- API tokens or passwords in plaintext
+- Age private keys (`.agekey`)
+
+## Verification checklist
+
+- [ ] 1Password item created in correct vault (`k8s_secrets` for K8s, `infra` for Terraform)
+- [ ] `OnePasswordItem` itemPath matches the exact vault + item title
+- [ ] SOPS-encrypted file re-encrypted after adding new variables
+- [ ] FluxCD `postBuild.substituteFrom` references `cluster-vars` Secret
+- [ ] `sops -d clusters/{cluster}/vars/cluster-vars.sops.yaml` decrypts without error
+- [ ] No plaintext secrets in git history (`git log -p` check)

--- a/.claude/skills/terraform-operations.md
+++ b/.claude/skills/terraform-operations.md
@@ -1,0 +1,166 @@
+---
+name: terraform-operations
+description: Terraform operations for infra-cd — create new environments, write modules, set up CI workflows, update renovate config. Delegates HCL generation and validation to terraform-agent with Ollama.
+---
+
+# Terraform Operations Skill
+
+Use this skill when creating new Terraform environments, writing modules, or setting up CI pipelines for Terraform.
+
+## When to use
+
+- Creating a new Terraform environment directory
+- Writing or updating a reusable module under `terraform/modules/`
+- Setting up a GitHub Actions CI workflow for a new environment
+- Importing existing infrastructure into Terraform state
+- Updating `renovate.json` for new provider/environment coverage
+- Running `terraform fmt`, `validate`, `plan` via the agent
+
+## Directory convention
+
+Each environment follows this layout:
+
+```
+terraform/{environment}/
+  terraform.tf      # Cloud backend + required_providers (always split from provider.tf)
+  provider.tf       # Provider configs (sourced from 1Password data sources)
+  variables.tf      # onepassword_token, onepassword_endpoint, plus env-specific vars
+  data.tf           # 1Password data sources for credentials
+  main.tf           # Resources and module calls
+  outputs.tf        # Exported values
+```
+
+### terraform.tf template
+
+```hcl
+terraform {
+  cloud {
+    organization = "Fastnetserv"
+    workspaces {
+      name = "{workspace-name}"
+    }
+  }
+  required_providers {
+    {provider} = {
+      source  = "{source}"
+      version = "~> {major}.{minor}"
+    }
+    onepassword = {
+      source  = "1Password/onepassword"
+      version = "~> 3.0"
+    }
+  }
+  required_version = ">= 1.5.0"
+}
+```
+
+### 1Password secret pattern
+
+```hcl
+# data.tf
+data "onepassword_item" "credentials" {
+  vault = "infra"
+  title = "My Service API Credentials"
+}
+
+# provider.tf
+provider "myservice" {
+  api_token = data.onepassword_item.credentials.credential
+}
+
+provider "onepassword" {
+  token    = var.onepassword_token
+  url      = var.onepassword_endpoint
+}
+
+# variables.tf
+variable "onepassword_token" {
+  type      = string
+  sensitive = true
+}
+variable "onepassword_endpoint" {
+  type      = string
+  sensitive = true
+}
+```
+
+### Module convention
+
+Reusable modules live under `terraform/modules/{module-name}/`:
+- `main.tf` — resource with `lifecycle { prevent_destroy = true }`
+- `variables.tf` — typed, documented variables
+- `outputs.tf` — id, IPs, key identifiers
+- `versions.tf` — `required_providers` with minimum version constraint
+
+### Import blocks (Terraform 1.5+)
+
+Prefer declarative import blocks over `terraform import` CLI:
+
+```hcl
+import {
+  id = "provider-specific-resource-id"
+  to = resource_type.resource_name
+}
+```
+
+## CI workflow pattern
+
+Copy from `.github/workflows/terraform.yml`. Adjust:
+- `on.push.paths` and `on.pull_request.paths` to match the new directory
+- `env.TF_WORKING_DIR` to the new directory
+- `runs-on` to the appropriate runner:
+  - `self-hosted` — generic / Hetzner / PSP (BGY)
+  - `LGU` — Gozzi-01 / hpelvisor (LUG, Switzerland)
+  - `mxp` — OVH EC200 (MXP, Italy)
+
+Workflow stages: `fmt -check` → `init` → `validate` → `plan` (PR comment) → `apply` (main only).
+
+## renovate.json update
+
+When adding a new Terraform directory, add a matching `packageRules` entry in `renovate.json` if the directory needs separate grouping or a different commit scope from the defaults:
+
+```json
+{
+  "description": "Terraform providers - {environment}",
+  "matchManagers": ["terraform"],
+  "matchFileNames": ["terraform/{environment}/**"],
+  "groupName": "terraform-{environment}-providers",
+  "semanticCommitType": "chore",
+  "semanticCommitScope": "terraform-{environment}"
+}
+```
+
+## Always run terraform fmt
+
+CI enforces `terraform fmt -check`. Always format before committing:
+
+```bash
+docker compose exec terraform-agent sh -c "cd /workspace/terraform/{env} && terraform fmt"
+```
+
+## Agent delegation
+
+```bash
+cd docker/agents && docker compose up -d terraform-agent
+
+# Validate a new environment
+docker compose exec terraform-agent sh -c \
+  "cd /workspace/terraform/{env} && terraform init && terraform validate"
+
+# Security scan
+docker compose exec terraform-agent checkov -d /workspace/terraform/{env} --quiet
+
+# Generate HCL via Ollama (for boilerplate)
+# Provide environment variables: TF_API_TOKEN, OP_TOKEN, OP_ENDPOINT
+```
+
+## Verification checklist
+
+- [ ] `terraform fmt -check` passes
+- [ ] `terraform init && terraform validate` succeeds
+- [ ] Terraform Cloud workspace created in Fastnetserv org
+- [ ] No raw secrets in `.tf` files — all sourced from 1Password
+- [ ] `renovate.json` updated if directory needs separate tracking
+- [ ] CI workflow file created and triggers on the correct path
+- [ ] `CLAUDE.md` directory structure section updated
+- [ ] PR created and CI plan output looks correct

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@
 # Ignore Mac .DS_Store files
 .DS_Store
 
+# Docker .env files (contain secrets — use .env.example as template)
+portainer/**/.env
+
 # Ignored vscode files
 .vscode/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ The repository follows strict GitOps principles: **changes to this repository dr
 
 ```
 infra-cd/
-├── .github/workflows/      # GitHub Actions CI/CD pipelines (8 workflows)
+├── .github/workflows/      # GitHub Actions CI/CD pipelines
 ├── .claude/                # Claude Code configuration and permissions
 ├── ansible/                # Ansible playbooks for OS automation
 │   ├── falco/              # Falco host-level security (Debian 12/13)
@@ -43,10 +43,12 @@ infra-cd/
 │   └── test-kind-flux-local.sh  # Local Kind+FluxCD test script
 ├── terraform/              # Infrastructure-as-Code
 │   ├── DNS/                # DNS records management
-│   ├── hetzner/            # Hetzner Cloud servers
-│   ├── oci/                # Oracle Cloud Infrastructure
 │   ├── ec200/              # Legacy standalone ec200 (pre-module)
-│   ├── modules/            # Reusable Terraform modules (proxmox-vm, proxmox-lxc, hetzner-server, cloudflare-dns)
+│   ├── hetzner/            # Hetzner Cloud servers
+│   ├── netbird/            # Netbird VPN (networks, groups, policies)
+│   ├── oci/                # Oracle Cloud Infrastructure (two accounts)
+│   ├── tailscale/          # Tailscale VPN (ACLs, DNS, auth keys)
+│   ├── modules/            # Reusable Terraform modules (proxmox-vm, proxmox-lxc, hetzner-server, oci-instance)
 │   └── proxmox/            # Proxmox-managed infra, one workspace per host
 │       ├── ec200/          # OVH EC200 (Proxmox host, MXP workspace)
 │       ├── gozzi-hpelvisor/# Gozzi-01 BIO + hpelvisor Proxmox hosts
@@ -142,7 +144,6 @@ clusters/{cluster-name}/
 
 | Workflow | Trigger | Purpose |
 |---|---|---|
-| `claude.yml` | Issue/PR comments | Claude Code AI integration |
 | `terraform.yml` | PR/push to `terraform/hetzner/` | Hetzner infrastructure |
 | `terraform-bio.yml` | PR/push to `terraform/proxmox/gozzi-hpelvisor/` | Gozzi-01 BIO + hpelvisor Proxmox hosts |
 | `terraform-mxp.yml` | PR/push to `terraform/proxmox/ec200/` | OVH EC200 (MXP) Proxmox host |
@@ -319,6 +320,46 @@ Hardware managed by this repository (from README.md):
 - **OCI Ampere**: Oracle Cloud ARM-based instances
 - **OVH EC200**: EC200 dedicated server
 - Additional on-premises nodes across Prague, Bergamo, Zurich, Mexico locations
+
+---
+
+## Skills & Agents Architecture
+
+Claude Code uses a layered approach for domain-specific operations in this repository:
+
+### Skills (`.claude/skills/`)
+
+Skills provide repository-specific patterns and conventions as quick-reference guides. Invoke them when working in their domain:
+
+| Skill | Domain |
+|---|---|
+| `flux-operations` | Add/update FluxCD apps, HelmRepositories, SOPS vars, dependsOn chains |
+| `terraform-operations` | New TF environments, modules, CI workflows, renovate config |
+| `secrets-management` | 1Password Operator, ExternalSecret, SOPS age encryption |
+| `cluster-operations` | New clusters, kubenuc-test overlay pattern, kustomize patches |
+| `ci-workflows` | GitHub Actions templates, runner selection, required secrets |
+
+### Agents (`.claude/agents/`)
+
+Agents are Docker containers for executing operations. They support local Ollama models to minimize API usage:
+
+| Agent | Purpose | Ollama use |
+|---|---|---|
+| `kubernetes-agent` | kubectl, helm, kustomize, flux CLI | YAML/manifest generation |
+| `terraform-agent` | terraform, tflint, checkov, 1Password CLI | HCL generation |
+| `ansible-agent` | ansible, ansible-lint, community collections | Playbook generation |
+
+**Hybrid model strategy:** Use Ollama (local) for routine boilerplate generation (YAML manifests, HCL resources). Use Claude Code API for complex reasoning (dependency analysis, security review, multi-file refactors).
+
+### Starting agents
+
+```bash
+cd docker/agents
+docker compose up -d          # Start all agents
+docker compose up -d terraform-agent kubernetes-agent  # Start specific agents
+```
+
+Set `OLLAMA_HOST` in `docker/agents/.env` to point to your Ollama instance.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,53 +1,63 @@
 # infra-cd
 
-This project is an personal exercise of style on how-to handle infra-as-code.
+This project is a personal exercise in infrastructure-as-code. My infrastructure spans several legacy services that I'm progressively migrating to IaC on spare time — far from perfect, always evolving.
 
-My infrastructure is composed by several legacy services that from time-to-time I'm converting into IaC. I work on it on spare time and this repository it's far from being perfect :)
+## CI/CD & Tooling
 
+- [Ansible](https://www.ansible.com/) — OS-level configuration and patching
+- [FluxCD](https://fluxcd.io/) — GitOps continuous delivery for Kubernetes
+- [Packer](https://www.packer.io/) — Machine image builds
+- [Terraform](https://www.terraform.io/) — Infrastructure provisioning
+- [Renovate](https://github.com/renovatebot/renovate) — Automated dependency updates
+- [Robot Framework](https://robotframework.org/) — E2E cluster validation tests
+- [pre-commit](https://pre-commit.com/) — YAML linting and whitespace enforcement
+- [Claude Code](https://claude.ai/code) — AI-assisted development
 
-CI/CD technology used:
+## Secret & Identity Management
 
-- Ansible
-- [FluxCD](https://fluxcd.io/)
-- [Packer](https://www.packer.io/)
-- [Terraform](https://www.terraform.io/)
+- [1Password Secrets Automation](https://developer.1password.com/docs/connect/get-started/) — Secret injection for Terraform and Kubernetes via Operator
+- [SOPS + age](https://github.com/mozilla/sops) — Encrypted cluster variable substitution for FluxCD
 
-Token/Secret managers:
-- [1Password Secrets Automation workflow](https://developer.1password.com/docs/connect/get-started/)
+## Hardware
 
-## Hardware ⚙️
+| Hostname | Type | Model | CPU | Memory | Storage | IPv6 | Location | Bandwidth | Active? |
+|---|---|---|---|---|---|---|---|---|---|
+| astronomical-01-prg | Server | HP Proliant DL360 Gen9 | 2x Xeon E5-2680 v4 | 256 GB | 2x500GB SSD + 3x1920GB SSD Kingston DC600M | N/A | PRG 🇨🇿 | 1 Gbit down/up | ❌ |
+| rabbit-01-psp | Server | HP Proliant DL360 Gen9 | 2x Xeon E5-2680 v4 | 128 GB | 2x500GB SSD + 6x960GB SSD Kingston DC500M | No | BGY 🇮🇹 | 1 Gbit down/up | ✅ |
+| gozzi-01-lug | Server | HP Proliant DL360 Gen9 | 2x Xeon E5-2680 v4 | 128 GB | 2x500GB SSD + 3x960GB SSD | Yes | LUG 🇨🇭 | 10 Gbit down/up | ✅ |
+| gozzi-02-lug | Server | HP Proliant DL380e Gen8 | 2x Xeon E5-2420 v2 | 64 GB | 2x72GB SAS 15K rpm + 16x600GB SAS 10K rpm | Yes | LUG 🇨🇭 | 10 Gbit down/up | ✅ |
+| ms01-mxp | MicroServer | Miniserver MS-01 | 1x i9-13900H | 64 GB | 1x2TB M.2 SSD + 1x1920GB U.2 SSD | Yes | MXP 🇮🇹 | 2x2.5 Gbit down/1 Gbit up | ✅ |
+| mail2 | VPS | N/A | 2 Cores | 4 GB | 1x40 GB | Yes | NBG 🇩🇪 | 5 Gbit down/up | ✅ |
+| reverse01 | VPS | N/A | 1 Core | 1 GB | — | No | ZRH 🇨🇭 | 500 Mbit down/up | ✅ |
+| reverse02 | VPS | N/A | 1 Core | 1 GB | — | No | ZRH 🇨🇭 | 500 Mbit down/up | ✅ |
+| k8s-arm | VPS | N/A | 4 Cores | 12 GB | — | No | ZRH 🇨🇭 | 1 Gbit down/up | ✅ |
+| vpn-01 | VPS | N/A | 1 Core | 1 GB | — | No | NL 🇳🇱 | 500 Mbit down/up | ✅ |
+| vpn-02 | VPS | N/A | 1 Core | 1 GB | — | No | NL 🇳🇱 | 500 Mbit down/up | ✅ |
 
-| Hostname            | Type        | Model                   | CPU                   | Memory | Storage                                          | IPv6 | Location | Bandwidth                | Active? |
-| --------------------| ----------- | ----------------------- | --------------------- | ------ | ------------------------------------------------ | ---- | -------- | ------------------------ | ------- |
-| astronomical-01-prg | Server      | HP Proliant DL360 Gen9  | 2x Xeon E5-2680 v4    | 256 Gb | 2x500GB SSD<br><br>3x1920GB SSD Kingston DC600M  | N/A  | PRG 🇨🇿   | 1 Gbit down/1 Gbit up    |    ❌   |
-| rabbit-01-psp       | Server      | HP Proliant DL360 Gen9  | 2x Xeon E5-2680 v4    | 128 Gb | 2x500GB SSD<br><br>6x960GB SSD Kingston DC500M   | No   | BGY 🇮🇹   | 1 Gbit down/1 Gbit up    |    ✅   |
-| gozzi-01-lug        | Server      | HP Proliant DL360 Gen9  | 2x Xeon E5-2680 v4    | 128 Gb | 2x500GB SSD<br><br>3x960GB SSD                   | Yes  | LUG 🇨🇭   | 10 Gbit down/up          |    ✅   |
-| gozzi-02-lug        | Server      | HP Proliant DL380e Gen8 | 2x Xeon E5-2420 v2    | 64 Gb  | 2x72GB SAS 15K rpm<br><br>16x600GB SAS 10K rpm   | Yes  | LUG 🇨🇭   | 10 Gbit down/up          |    ✅   |
-| ms01-mxp            | MicroServer | Miniserver MS-01        | 1x i9-13900H Gen 13th | 64 Gb  | 1x2TB M2 SSD<br><br>1x1920GB U2 SSD              | Yes  | MXP 🇮🇹   | 2x2.5Gbit down/1 Gbit up |    ✅   |
-| mail2               | VPS         | N/A                     | 2 Cores               | 4Gb    | 1x40Gb                                           | Yes  | NBG 🇩🇪   | 5 Gbit down/up           |    ✅   |
-| reverse01           | VPS         | N/A                     | 1 Core                | 1Gb    |                                                  | No   | ZRH 🇨🇭   | 500 Mbit down/up         |    ✅   |
-| reverse02           | VPS         | N/A                     | 1 Core                | 1Gb    |                                                  | No   | ZRH 🇨🇭   | 500 Mbit down/up         |    ✅   |
-| k8s-arm             | VPS         | N/A                     | 4 Cores               | 12Gb   |                                                  | No   | ZRH 🇨🇭   | 1 Gbit down/up           |    ✅   |
-| vpn-01              | VPS         | N/A                     | 1 Core                | 1Gb    |                                                  | No   | NL 🇳🇱    | 500 Mbit down/up         |    ✅   |
-| vpn-02              | VPS         | N/A                     | 1 Core                | 1Gb    |                                                  | No   | NL 🇳🇱    | 500 Mbit down/up         |    ✅   |
+## Kubernetes Clusters ☸️
 
-## Kubernetes clusters ☸️
+| Name | Type | CP Nodes | Worker Nodes | Region |
+|---|---|---|---|---|
+| kubenuc | Bare metal (HP ProLiant) | 3x 2 Cores / 6 GB | 3x 8 Cores / 16 GB | MXP, BGY, LUG |
+| kubenuc-test | Bare metal (HP ProLiant) | Shared with kubenuc | Shared with kubenuc | MXP, BGY, LUG |
+| k3s-prod-test | k3s | 1x 4 Cores / 4 GB | 1x 8 Cores / 16 GB | LUG |
+| k3s-rabbit | k3s | 1x node | — | BGY |
+| k8s-vms-daniele | VMs | 1x node | — | LUG |
+| oc-ampere | OpenShift (OCI) | ARM compute | — | ZRH (OCI) |
 
-| Name        | CP Nodes      | Worker Nodes  | Region        |
-| ----------- | ------------- | ------------- | ------------- |
-| kubenuc     | 3x 2Cores/6GB | 3x 8Core/16GB | MXP, BGY, LUG |
-| k3s-preprod | 1x 4Cores/4GB | 1x 8Core/16Gb | LUG           |
-| kubearm     |               |               | ZRH           |
+## Terraform Environments
 
+| Directory | Purpose | CI Runner |
+|---|---|---|
+| `terraform/DNS/` | Cloudflare DNS records | — |
+| `terraform/hetzner/` | Hetzner Cloud VPS | self-hosted |
+| `terraform/oci/` | Oracle Cloud Infrastructure | — |
+| `terraform/proxmox/ec200/` | OVH EC200 Proxmox host (MXP) | mxp |
+| `terraform/proxmox/gozzi-hpelvisor/` | Gozzi-01 + hpelvisor Proxmox hosts (LUG) | LGU |
+| `terraform/proxmox/rabbit/` | Rabbit-01 Proxmox host (BGY) | self-hosted |
 
 ## TODO
 
-- Terraform Hetzner
-- Version promotion [git issue](https://github.com/dark-vex/infra-cd/issues/427) and/or [Renovate](https://github.com/renovatebot/renovate)
 - Implement ExternalDNS
-- SOPS
 - Teleport IaC config
-
-Print Instance IP and update ansible inventory file and cloudflare DNS records
-
-https://github.com/fluxcd/flux2/discussions/1076
+- NetBox asset inventory deployment

--- a/portainer/netbox/.env.example
+++ b/portainer/netbox/.env.example
@@ -1,0 +1,21 @@
+# NetBox environment variables — copy to .env and fill in values from 1Password
+# 1Password item: "NetBox Docker"
+
+# PostgreSQL
+POSTGRES_PASSWORD=change-me
+
+# NetBox
+# Generate with: python3 -c "import secrets; print(secrets.token_hex(50))"
+NETBOX_SECRET_KEY=change-me-generate-a-50-char-random-string
+
+# Published port (default: 8080)
+NETBOX_PORT=8080
+
+# Superuser — created on first run only
+NETBOX_SUPERUSER_NAME=admin
+NETBOX_SUPERUSER_EMAIL=admin@example.com
+NETBOX_SUPERUSER_PASSWORD=change-me
+NETBOX_SUPERUSER_API_TOKEN=change-me-generate-a-40-char-hex-token
+
+# Comma-separated list of allowed hostnames (use * for any, or set your FQDN)
+NETBOX_ALLOWED_HOSTS=netbox.example.com

--- a/portainer/netbox/docker-compose.yml
+++ b/portainer/netbox/docker-compose.yml
@@ -1,0 +1,122 @@
+---
+# NetBox — Network Source of Truth / IT Asset Inventory
+# https://github.com/netbox-community/netbox-docker
+#
+# Secrets: copy .env.example to .env and fill in values from 1Password
+# (actual .env file is gitignored)
+#
+# First run — initialise the DB and create superuser:
+#   docker compose run --rm netbox /opt/netbox/netbox/manage.py migrate
+#   docker compose run --rm netbox /opt/netbox/netbox/manage.py createsuperuser
+
+services:
+  netbox:
+    image: ghcr.io/netbox-community/netbox:v4.3-latest
+    container_name: netbox
+    depends_on:
+      - postgres
+      - redis
+      - redis-cache
+    environment:
+      ALLOWED_HOSTS: "${NETBOX_ALLOWED_HOSTS:-*}"
+      DB_HOST: postgres
+      DB_NAME: netbox
+      DB_USER: netbox
+      DB_PASSWORD: "${POSTGRES_PASSWORD}"
+      REDIS_HOST: redis
+      REDIS_PORT: "6379"
+      REDIS_DATABASE: "0"
+      REDIS_CACHE_HOST: redis-cache
+      REDIS_CACHE_PORT: "6379"
+      REDIS_CACHE_DATABASE: "1"
+      SECRET_KEY: "${NETBOX_SECRET_KEY}"
+      SUPERUSER_NAME: "${NETBOX_SUPERUSER_NAME:-admin}"
+      SUPERUSER_EMAIL: "${NETBOX_SUPERUSER_EMAIL:-admin@localhost}"
+      SUPERUSER_PASSWORD: "${NETBOX_SUPERUSER_PASSWORD}"
+      SUPERUSER_API_TOKEN: "${NETBOX_SUPERUSER_API_TOKEN}"
+      TIME_ZONE: "Europe/Rome"
+      LANGUAGE_CODE: "en-us"
+    volumes:
+      - netbox-media:/opt/netbox/netbox/media
+      - netbox-reports:/opt/netbox/netbox/reports
+      - netbox-scripts:/opt/netbox/netbox/scripts
+    ports:
+      - "${NETBOX_PORT:-8080}:8080"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/api/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
+  netbox-worker:
+    image: ghcr.io/netbox-community/netbox:v4.3-latest
+    container_name: netbox-worker
+    command: /opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py rqworker
+    depends_on:
+      - netbox
+    environment:
+      DB_HOST: postgres
+      DB_NAME: netbox
+      DB_USER: netbox
+      DB_PASSWORD: "${POSTGRES_PASSWORD}"
+      REDIS_HOST: redis
+      REDIS_PORT: "6379"
+      REDIS_DATABASE: "0"
+      REDIS_CACHE_HOST: redis-cache
+      REDIS_CACHE_PORT: "6379"
+      REDIS_CACHE_DATABASE: "1"
+      SECRET_KEY: "${NETBOX_SECRET_KEY}"
+    volumes:
+      - netbox-media:/opt/netbox/netbox/media
+      - netbox-reports:/opt/netbox/netbox/reports
+      - netbox-scripts:/opt/netbox/netbox/scripts
+    restart: unless-stopped
+
+  postgres:
+    image: postgres:16-alpine
+    container_name: netbox-postgres
+    environment:
+      POSTGRES_DB: netbox
+      POSTGRES_USER: netbox
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
+    volumes:
+      - netbox-postgres:/var/lib/postgresql/data
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "netbox"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    container_name: netbox-redis
+    command: redis-server --save 60 1 --loglevel warning
+    volumes:
+      - netbox-redis:/data
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  redis-cache:
+    image: redis:7-alpine
+    container_name: netbox-redis-cache
+    command: redis-server --loglevel warning
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+volumes:
+  netbox-postgres:
+  netbox-redis:
+  netbox-media:
+  netbox-reports:
+  netbox-scripts:


### PR DESCRIPTION
## Summary

- **README.md**: Refreshed technology stack, updated K8s cluster table (all 6 clusters: kubenuc, kubenuc-test, k3s-prod-test, k3s-rabbit, k8s-vms-daniele, oc-ampere), removed completed TODO items, added Terraform environments table
- **NetBox asset inventory**: Docker Compose stack (`portainer/netbox/`) with NetBox v4.3 + PostgreSQL 16 + Redis 7, plus `.env.example` template; `.env` files added to `.gitignore`
- **Claude Code skills** (`.claude/skills/`): 5 new domain-specific skills — `flux-operations`, `terraform-operations`, `secrets-management`, `cluster-operations`, `ci-workflows` — each with repository patterns, agent delegation guidance, and verification checklists
- **CLAUDE.md**: Added Skills & Agents Architecture section, updated directory structure (netbird, tailscale, oci-instance), removed deleted `claude.yml` reference
- **terraform-agent**: Updated workspace layout to include netbird, tailscale, oci environments

## Test plan

- [x] README renders correctly on GitHub
- [ ] `portainer/netbox/docker-compose.yml` validates: `docker compose -f portainer/netbox/docker-compose.yml config`
- [ ] Skills are accessible from Claude Code sessions
- [ ] Pre-commit hooks pass (trailing whitespace, EOF newline, YAML syntax)

🤖 Generated with [Claude Code](https://claude.com/claude-code)