### PR TITLE
fix(kubenuc,s3): Fix TLS Ingress issue

### DIFF
--- a/clusters/kubenuc/apps/s3/manifests/release.yml
+++ b/clusters/kubenuc/apps/s3/manifests/release.yml
@@ -49,4 +49,7 @@ spec:
         annotations:
           cert-manager.io/cluster-issuer: "letsencrypt-prod"
           haproxy.org/request-body-size: "500m"
-        tls: true
+        tls:
+        - secretName: s3-tls
+          hosts:
+            - ${S3_API_HOST}


### PR DESCRIPTION
Fix values.yaml file of seaweedfs due to:
```
DESCRIPTION: Upgrade "s3" failed: failed to create resource: failed to create typed patch object (nextcloud-fastnetserv/ingress-s3-seaweedfs-s3; networking.k8s.io/v1, Kind=Ingress): .spec.tls: expected list, got &{true}
```