### PR TITLE
feat(grafana-alloy): cut metrics below 10K free-tier limit

### DIFF
--- a/clusters/k8s-vms-daniele/apps/grafana-alloy/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/grafana-alloy/manifests/release.yml
@@ -54,20 +54,56 @@ spec:
         url: ${GRAFANA_PROMETHEUS_URL}
         auth:
           type: basic
+        metricProcessingRules: |
+          write_relabel_config {
+            source_labels = ["__name__"]
+            regex         = "(alloy|prometheus_remote_storage|prometheus_target|prometheus_sd|scrape|otelcol|receiver|exporter|cluster|go|process)_.*|up|scrape_.*"
+            action        = "drop"
+          }
       - name: grafana-cloud-logs
         type: loki
         url: ${GRAFANA_LOKI_URL}
         auth:
           type: basic
 
+    selfReporting:
+      enabled: false
+
     clusterMetrics:
       enabled: true
       kepler:
         enabled: false
+      kubelet:
+        enabled: false
+      cadvisor:
+        enabled: false
+      apiServer:
+        enabled: false
+      kubeControllerManager:
+        enabled: false
+      kubeScheduler:
+        enabled: false
+      kubeProxy:
+        enabled: false
+      kubeDNS:
+        enabled: false
       node-exporter:
+        enabled: false
         deploy: false
-      metricsTuning:
-        useIntegrationAllowList: true
+      opencost:
+        enabled: false
+      windows-exporter:
+        enabled: false
+
+    annotationAutodiscovery:
+      enabled: true
+      annotations:
+        scrape: "prometheus.io/scrape"
+        metricsPortNumber: "prometheus.io/port"
+        metricsPath: "prometheus.io/path"
+        metricsScheme: "prometheus.io/scheme"
+      destinations:
+        - grafana-cloud-metrics
 
     clusterEvents:
       enabled: true

--- a/clusters/kubenuc/apps/grafana-alloy/manifests/release.yml
+++ b/clusters/kubenuc/apps/grafana-alloy/manifests/release.yml
@@ -119,8 +119,8 @@ spec:
         metricProcessingRules: |
           write_relabel_config {
             source_labels = ["__name__"]
-            regex = "alloy_component_dependencies_wait_seconds_bucket|alloy_component_evaluation_seconds_bucket|alloy_component_evaluation_seconds_(sum|count)|alloy_component_controller_running_components|prometheus_remote_storage_sent_batch_duration_seconds_bucket|cluster_.*"
-            action = "drop"
+            regex         = "(alloy|prometheus_remote_storage|prometheus_target|prometheus_sd|scrape|otelcol|receiver|exporter|cluster|go|process)_.*|up|scrape_.*"
+            action        = "drop"
           }
       - name: grafana-cloud-logs
         type: loki
@@ -165,12 +165,34 @@ spec:
                           - kubenuc-m1
                           - kubenuc-w1
 
+    selfReporting:
+      enabled: false
+
     clusterMetrics:
       enabled: true
       kepler:
         enabled: false
-      metricsTuning:
-        useIntegrationAllowList: true
+      kubelet:
+        enabled: false
+      cadvisor:
+        enabled: false
+      apiServer:
+        enabled: false
+      kubeControllerManager:
+        enabled: false
+      kubeScheduler:
+        enabled: false
+      kubeProxy:
+        enabled: false
+      kubeDNS:
+        enabled: false
+      node-exporter:
+        enabled: false
+        deploy: false
+      opencost:
+        enabled: false
+      windows-exporter:
+        enabled: false
       kube-state-metrics:
         metricsTuning:
           excludeMetrics:
@@ -182,17 +204,16 @@ spec:
             - kube_pod_status_reason
             - kube_secret_metadata_resource_version
             - kube_deployment_status_condition
-      node-exporter:
-        affinity:
-          nodeAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              nodeSelectorTerms:
-                - matchExpressions:
-                    - key: kubernetes.io/hostname
-                      operator: NotIn
-                      values:
-                        - kubenuc-m1
-                        - kubenuc-w1
+
+    annotationAutodiscovery:
+      enabled: true
+      annotations:
+        scrape: "prometheus.io/scrape"
+        metricsPortNumber: "prometheus.io/port"
+        metricsPath: "prometheus.io/path"
+        metricsScheme: "prometheus.io/scheme"
+      destinations:
+        - grafana-cloud-metrics
 
     clusterEvents:
       enabled: true


### PR DESCRIPTION
## Summary

- Disable all `clusterMetrics` built-in scrape targets except `kube-state-metrics` on both `kubenuc` and `k8s-vms-daniele` (kubelet, cAdvisor, apiServer, node-exporter, kubeProxy, kubeDNS, kubeControllerManager, kubeScheduler, opencost, windows-exporter all set to `enabled: false`; node-exporter also `deploy: false` to stop the DaemonSet)
- Enable `annotationAutodiscovery` wired to `prometheus.io/*` annotations on both clusters, so existing annotated pods (postgres-exporter, net-mon, film-tv-exporter) are scraped without any pod changes
- Replace narrow `metricProcessingRules` drop regex with a broad wildcard that eliminates all Alloy self-monitoring, remote-write bookkeeping, OTel, Go runtime, and `up` series
- Disable `selfReporting` on both clusters

## Verification

Post-deploy, confirm active series dropped in Grafana Cloud Explore:
```promql
count({__name__=~"alloy_.*"})                      # expect 0
count({__name__=~"node_.*", cluster="kubenuc"})    # expect 0
count({__name__=~"container_.*"})                  # expect 0
count({__name__=~"kube_.*"})                       # still non-zero (KSM kept)
count({__name__=~"pg_.*"})                         # now non-zero (postgres-exporter scraped)
```

Grafana Cloud → Billing/Usage: combined active series for both stacks should fall below 10K within one scrape cycle (~1 min) after Flux reconciles.

## Test plan

- [ ] Flux reconciles both HelmReleases without errors (`kubectl -n grafana-alloy get hr grafana-k8s-monitoring`)
- [ ] node-exporter DaemonSet absent on kubenuc after reconcile
- [ ] `alloy_*` series count drops to 0 in Grafana Cloud
- [ ] `kube_*` series still present (KSM healthy)
- [ ] Annotated app pods appear as scrape targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)