### PR TITLE
fix(grafana-alloy): fix coredns regex and add INFO-only filter for Graylog

### DIFF
--- a/clusters/k8s-vms-daniele/apps/grafana-alloy/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/grafana-alloy/manifests/release.yml
@@ -158,7 +158,7 @@ spec:
               drop_counter_reason = "success_access_logs"
             }
             stage.drop {
-              expression          = "[WARNING] No files matching import glob pattern.*"
+              expression          = ".*\\[WARNING\\] No files matching import glob pattern.*"
               drop_counter_reason = "coredns_noise"
             }
             forward_to = [loki.write.default.receiver]

--- a/clusters/kubenuc/apps/grafana-alloy/manifests/release.yml
+++ b/clusters/kubenuc/apps/grafana-alloy/manifests/release.yml
@@ -115,6 +115,19 @@ spec:
           # bearerToken injected via valuesFrom from graylog-alloy-creds secret
         logs:
           enabled: true
+        processors:
+          filters:
+            enabled: true
+            errorMode: ignore
+            logs:
+              logRecord:
+                # Drop records whose OTel severity_text is debug/warn/error/fatal/critical.
+                # Records with severity_text="info" or unset pass through.
+                - 'severity_text != "" and IsMatch(severity_text, "(?i)^(debug|warn|warning|error|fatal|critical)$")'
+                # Fallback for logs without severity_text: structured level= field.
+                - 'IsMatch(body, "(?i)level=(warn|warning|error|fatal|critical|debug)")'
+                # Fallback: klog E/W/F prefix (e.g. "E0421 ", "W0421 ").
+                - 'IsMatch(body, "^[EWF][0-9]{4} ")'
 
     # Settings applied to all Alloy instances (metrics, singleton, logs, receiver)
     collectorCommon:
@@ -221,7 +234,7 @@ spec:
           drop_counter_reason = "grafana_cloud_ratelimit_noise"
         }
         stage.drop {
-          expression          = "[WARNING] No files matching import glob pattern.*"
+          expression          = ".*\\[WARNING\\] No files matching import glob pattern.*"
           drop_counter_reason = "coredns_noise"
         }
 


### PR DESCRIPTION
## Summary

- **Fixes coredns drop rule regex** on `kubenuc` and `k8s-vms-daniele`: the original `[WARNING]` expression was a RE2 character class (matching one of `W/A/R/N/I/G`) not a literal bracket. Fixed to `\[WARNING\]` with a leading `.*` so the rule fires anywhere in the log line.
- **Adds per-destination INFO-only filter for Graylog** on `kubenuc`: a `processors.filters` OTTL block on the `graylog-otlp` destination drops debug/warn/error/fatal/critical records before they reach Graylog. Grafana Cloud Loki receives all levels unchanged (the filter only applies to the Graylog destination).

## Verification

- `pre-commit run --all-files` — YAML/whitespace pass.
- Post-merge on kubenuc: `flux reconcile hr -n grafana-alloy grafana-k8s-monitoring` returns Ready; no OTTL parse errors in Alloy logs.
- In Graylog: `message:"No files matching import glob pattern"` → 0 results; breakdown by level shows INFO only.
- Alloy metric `loki_process_dropped_total{reason="coredns_noise"}` increments (proves the regex now matches).
- In Grafana Cloud Loki: warn/error/debug logs still appear (unaffected).

## Test plan

- [ ] Pre-commit passes
- [ ] Alloy pods restart cleanly post-merge
- [ ] No OTTL parse errors in Alloy logs
- [ ] Graylog receives INFO-level logs only
- [ ] Grafana Cloud Loki unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)