### PR TITLE
chore(terraform): migrate proxmox_download_file alias — ec200 (MXP)

### DIFF
--- a/terraform/proxmox/ec200/ec200.tf
+++ b/terraform/proxmox/ec200/ec200.tf
@@ -24,7 +24,7 @@
 #   disk_size       = 20
 #   disk_datastore  = "local-lvm"
 #
-#   template_file_id = proxmox_virtual_environment_download_file.ec200_ubuntu_24_04_lxc.id
+#   template_file_id = proxmox_download_file.ec200_ubuntu_24_04_lxc.id
 #   os_type          = "ubuntu"
 #
 #   network_bridge = "vmbr0"
@@ -60,7 +60,7 @@ module "ec200_mon_mxp_lxc" {
   disk_size      = 4
   disk_datastore = "local-lvm"
 
-  template_file_id = proxmox_virtual_environment_download_file.ec200_ubuntu_24_04_lxc.id
+  template_file_id = proxmox_download_file.ec200_ubuntu_24_04_lxc.id
   os_type          = "ubuntu"
 
   network_bridge         = "vmbr0"

--- a/terraform/proxmox/ec200/images.tf
+++ b/terraform/proxmox/ec200/images.tf
@@ -1,10 +1,15 @@
 # Cloud images and LXC templates for pve-ec200
 
 # Ubuntu 24.04 LXC template
-resource "proxmox_virtual_environment_download_file" "ec200_ubuntu_24_04_lxc" {
+resource "proxmox_download_file" "ec200_ubuntu_24_04_lxc" {
   provider     = proxmox.ec200
   content_type = "vztmpl"
   datastore_id = "local"
   node_name    = "pve-ec200"
   url          = "http://download.proxmox.com/images/system/ubuntu-24.04-standard_24.04-2_amd64.tar.zst"
+}
+
+moved {
+  from = proxmox_virtual_environment_download_file.ec200_ubuntu_24_04_lxc
+  to   = proxmox_download_file.ec200_ubuntu_24_04_lxc
 }


### PR DESCRIPTION
## Summary

- Rename `proxmox_virtual_environment_download_file` → `proxmox_download_file` in `terraform/proxmox/ec200/` ahead of provider deprecation (bpg/proxmox ADR-007, introduced v0.100.0; repo already pins `~> 0.103`).
- Add `moved` block for in-place Terraform state migration — no resource destroy or re-download occurs.

## Affected resources

- `proxmox_download_file.ec200_ubuntu_24_04_lxc` (renamed from `proxmox_virtual_environment_download_file`)

## Test plan

- [ ] `terraform fmt -check` passes (CI)
- [ ] `terraform validate` passes (CI)
- [ ] `terraform plan` shows `0 to add, 0 to change, 0 to destroy` with a `has moved to` note for each `moved` block

🤖 Generated with [Claude Code](https://claude.com/claude-code)