### PR TITLE
chore(terraform): migrate proxmox_download_file alias — rabbit (PSP)

### DIFF
--- a/terraform/proxmox/rabbit/images.tf
+++ b/terraform/proxmox/rabbit/images.tf
@@ -5,7 +5,7 @@
 # ============================================================================
 
 # Ubuntu 24.04 LXC template
-resource "proxmox_virtual_environment_download_file" "rabbit_ubuntu_24_04_lxc" {
+resource "proxmox_download_file" "rabbit_ubuntu_24_04_lxc" {
   provider     = proxmox.rabbit
   content_type = "vztmpl"
   datastore_id = "local"
@@ -14,12 +14,22 @@ resource "proxmox_virtual_environment_download_file" "rabbit_ubuntu_24_04_lxc" {
 }
 
 # Ubuntu 22.04 LXC template
-resource "proxmox_virtual_environment_download_file" "rabbit_ubuntu_22_04_lxc" {
+resource "proxmox_download_file" "rabbit_ubuntu_22_04_lxc" {
   provider     = proxmox.rabbit
   content_type = "vztmpl"
   datastore_id = "local"
   node_name    = "rabbit-01-psp"
   url          = "http://download.proxmox.com/images/system/ubuntu-22.04-standard_22.04-1_amd64.tar.zst"
+}
+
+moved {
+  from = proxmox_virtual_environment_download_file.rabbit_ubuntu_24_04_lxc
+  to   = proxmox_download_file.rabbit_ubuntu_24_04_lxc
+}
+
+moved {
+  from = proxmox_virtual_environment_download_file.rabbit_ubuntu_22_04_lxc
+  to   = proxmox_download_file.rabbit_ubuntu_22_04_lxc
 }
 
 # Ubuntu 22.04 cloud image for VMs

--- a/terraform/proxmox/rabbit/lxc.tf
+++ b/terraform/proxmox/rabbit/lxc.tf
@@ -19,7 +19,7 @@ module "rabbit_satisfactory_shared_ddlns_net_lxc" {
   disk_size      = 30
   disk_datastore = "data-ssd2"
 
-  template_file_id = proxmox_virtual_environment_download_file.rabbit_ubuntu_24_04_lxc.id
+  template_file_id = proxmox_download_file.rabbit_ubuntu_24_04_lxc.id
   os_type          = "ubuntu"
 
   network_bridge         = "vmbr1"
@@ -61,7 +61,7 @@ module "rabbit_haproxy1_ddlns_net_lxc" {
   disk_size      = 20
   disk_datastore = "data-ssd"
 
-  template_file_id = proxmox_virtual_environment_download_file.rabbit_ubuntu_24_04_lxc.id
+  template_file_id = proxmox_download_file.rabbit_ubuntu_24_04_lxc.id
   os_type          = "ubuntu"
 
   network_bridge         = "vmbr1"
@@ -105,7 +105,7 @@ module "rabbit_test_mail_ddlns_net_lxc" {
   disk_size      = 30
   disk_datastore = "data-ssd"
 
-  template_file_id = proxmox_virtual_environment_download_file.rabbit_ubuntu_24_04_lxc.id
+  template_file_id = proxmox_download_file.rabbit_ubuntu_24_04_lxc.id
   os_type          = "debian"
 
   network_bridge         = "vmbr1"
@@ -149,7 +149,7 @@ module "rabbit_satisfactory_ddlns_net_lxc" {
   disk_size      = 30
   disk_datastore = "data-ssd2"
 
-  template_file_id = proxmox_virtual_environment_download_file.rabbit_ubuntu_24_04_lxc.id
+  template_file_id = proxmox_download_file.rabbit_ubuntu_24_04_lxc.id
   os_type          = "ubuntu"
 
   network_bridge         = "vmbr1"
@@ -192,7 +192,7 @@ module "rabbit_graylog_ddlns_net_lxc" {
   disk_size      = 50
   disk_datastore = "data-ssd"
 
-  template_file_id = proxmox_virtual_environment_download_file.rabbit_ubuntu_24_04_lxc.id
+  template_file_id = proxmox_download_file.rabbit_ubuntu_24_04_lxc.id
   os_type          = "ubuntu"
 
   network_bridge         = "vmbr1"
@@ -237,7 +237,7 @@ module "rabbit_pbs_01_psp_ddlns_net_lxc" {
   disk_size      = 30
   disk_datastore = "data-ssd"
 
-  template_file_id = proxmox_virtual_environment_download_file.rabbit_ubuntu_24_04_lxc.id
+  template_file_id = proxmox_download_file.rabbit_ubuntu_24_04_lxc.id
   os_type          = "debian"
 
   network_bridge         = "vmbr0"
@@ -284,7 +284,7 @@ module "rabbit_squid_ddlns_net_lxc" {
   disk_size      = 20
   disk_datastore = "data-ssd"
 
-  template_file_id = proxmox_virtual_environment_download_file.rabbit_ubuntu_24_04_lxc.id
+  template_file_id = proxmox_download_file.rabbit_ubuntu_24_04_lxc.id
   os_type          = "ubuntu"
 
   network_bridge         = "vmbr2"
@@ -327,7 +327,7 @@ module "rabbit_rtmp1_ddlns_net_lxc" {
   disk_size      = 30
   disk_datastore = "data-ssd2"
 
-  template_file_id = proxmox_virtual_environment_download_file.rabbit_ubuntu_24_04_lxc.id
+  template_file_id = proxmox_download_file.rabbit_ubuntu_24_04_lxc.id
   os_type          = "ubuntu"
 
   network_bridge         = "vmbr1"
@@ -372,7 +372,7 @@ module "rabbit_mon_bgy_lxc" {
   disk_size      = 4
   disk_datastore = "data-ssd"
 
-  template_file_id = proxmox_virtual_environment_download_file.rabbit_ubuntu_24_04_lxc.id
+  template_file_id = proxmox_download_file.rabbit_ubuntu_24_04_lxc.id
   os_type          = "ubuntu"
 
   network_bridge         = "vmbr1"


### PR DESCRIPTION
## Summary

- Rename `proxmox_virtual_environment_download_file` → `proxmox_download_file` in `terraform/proxmox/rabbit/` ahead of provider deprecation (bpg/proxmox ADR-007, introduced v0.100.0; repo already pins `~> 0.103`).
- Add `moved` blocks for in-place Terraform state migration — no resource destroy or re-download occurs.

## Affected resources

- `proxmox_download_file.rabbit_ubuntu_24_04_lxc` (renamed)
- `proxmox_download_file.rabbit_ubuntu_22_04_lxc` (renamed)
- 9 `template_file_id` references in `lxc.tf` updated accordingly.

## Test plan

- [x] `terraform fmt -check` passes (CI)
- [x] `terraform validate` passes (CI)
- [x] `terraform plan` shows `0 to add, 0 to change, 0 to destroy` with `has moved to` notes for each `moved` block

🤖 Generated with [Claude Code](https://claude.com/claude-code)