### PR TITLE
chore(terraform): migrate proxmox_download_file alias — gozzi-hpelvisor (BIO)

### DIFF
--- a/terraform/proxmox/gozzi-hpelvisor/hpelvisor-generated.tf
+++ b/terraform/proxmox/gozzi-hpelvisor/hpelvisor-generated.tf
@@ -19,7 +19,7 @@ module "hpelvisor_gitlab_ddlns_net_lxc" {
   disk_size      = 50
   disk_datastore = "data-hdd"
 
-  template_file_id = proxmox_virtual_environment_download_file.hpelvisor_ubuntu_24_04_lxc.id
+  template_file_id = proxmox_download_file.hpelvisor_ubuntu_24_04_lxc.id
   os_type          = "debian"
 
   network_bridge         = "vmbr5"
@@ -67,7 +67,7 @@ module "hpelvisor_dolibarr_test_bioadventures_eu_lxc" {
   disk_size      = 50
   disk_datastore = "data-hdd"
 
-  template_file_id = proxmox_virtual_environment_download_file.hpelvisor_ubuntu_24_04_lxc.id
+  template_file_id = proxmox_download_file.hpelvisor_ubuntu_24_04_lxc.id
   os_type          = "debian"
 
   network_bridge         = "vmbr5"

--- a/terraform/proxmox/gozzi-hpelvisor/images.tf
+++ b/terraform/proxmox/gozzi-hpelvisor/images.tf
@@ -5,7 +5,7 @@
 # ============================================================================
 
 # Ubuntu 24.04 LXC template
-resource "proxmox_virtual_environment_download_file" "gozzi_ubuntu_24_04_lxc" {
+resource "proxmox_download_file" "gozzi_ubuntu_24_04_lxc" {
   provider     = proxmox.gozzi_pve
   content_type = "vztmpl"
   datastore_id = "local"
@@ -15,13 +15,23 @@ resource "proxmox_virtual_environment_download_file" "gozzi_ubuntu_24_04_lxc" {
 }
 
 ## Ubuntu 22.04 LXC template
-resource "proxmox_virtual_environment_download_file" "gozzi_ubuntu_22_04_lxc" {
+resource "proxmox_download_file" "gozzi_ubuntu_22_04_lxc" {
   provider     = proxmox.gozzi_pve
   content_type = "vztmpl"
   datastore_id = "local"
   #node_name    = "gozzi-01-bio"
   node_name = "gozzi-pve"
   url       = "http://download.proxmox.com/images/system/ubuntu-22.04-standard_22.04-1_amd64.tar.zst"
+}
+
+moved {
+  from = proxmox_virtual_environment_download_file.gozzi_ubuntu_24_04_lxc
+  to   = proxmox_download_file.gozzi_ubuntu_24_04_lxc
+}
+
+moved {
+  from = proxmox_virtual_environment_download_file.gozzi_ubuntu_22_04_lxc
+  to   = proxmox_download_file.gozzi_ubuntu_22_04_lxc
 }
 
 ## Ubuntu 22.04 cloud image for VMs
@@ -43,7 +53,7 @@ resource "proxmox_virtual_environment_file" "gozzi_ubuntu_22_04_cloud" {
 # ============================================================================
 
 # Ubuntu 24.04 LXC template
-resource "proxmox_virtual_environment_download_file" "hpelvisor_ubuntu_24_04_lxc" {
+resource "proxmox_download_file" "hpelvisor_ubuntu_24_04_lxc" {
   provider     = proxmox.hpelvisor
   content_type = "vztmpl"
   datastore_id = "local"
@@ -52,12 +62,22 @@ resource "proxmox_virtual_environment_download_file" "hpelvisor_ubuntu_24_04_lxc
 }
 
 ## Ubuntu 22.04 LXC template
-resource "proxmox_virtual_environment_download_file" "hpelvisor_ubuntu_22_04_lxc" {
+resource "proxmox_download_file" "hpelvisor_ubuntu_22_04_lxc" {
   provider     = proxmox.hpelvisor
   content_type = "vztmpl"
   datastore_id = "local"
   node_name    = "hpelvisor"
   url          = "http://download.proxmox.com/images/system/ubuntu-22.04-standard_22.04-1_amd64.tar.zst"
+}
+
+moved {
+  from = proxmox_virtual_environment_download_file.hpelvisor_ubuntu_24_04_lxc
+  to   = proxmox_download_file.hpelvisor_ubuntu_24_04_lxc
+}
+
+moved {
+  from = proxmox_virtual_environment_download_file.hpelvisor_ubuntu_22_04_lxc
+  to   = proxmox_download_file.hpelvisor_ubuntu_22_04_lxc
 }
 
 ## Ubuntu 22.04 cloud image for VMs

--- a/terraform/proxmox/gozzi-hpelvisor/monitoring-lxc.tf
+++ b/terraform/proxmox/gozzi-hpelvisor/monitoring-lxc.tf
@@ -16,7 +16,7 @@ module "gozzi_mon_lug_lxc" {
   disk_size      = 4
   disk_datastore = "local-zfs"
 
-  template_file_id = proxmox_virtual_environment_download_file.gozzi_ubuntu_24_04_lxc.id
+  template_file_id = proxmox_download_file.gozzi_ubuntu_24_04_lxc.id
   os_type          = "ubuntu"
 
   network_bridge         = "vmbr5"


### PR DESCRIPTION
## Summary

- Rename `proxmox_virtual_environment_download_file` → `proxmox_download_file` in `terraform/proxmox/gozzi-hpelvisor/` ahead of provider deprecation (bpg/proxmox ADR-007, introduced v0.100.0; repo already pins `~> 0.103`).
- Add `moved` blocks for in-place Terraform state migration — no resource destroy or re-download occurs.

## Affected resources

- `proxmox_download_file.gozzi_ubuntu_24_04_lxc` (renamed)
- `proxmox_download_file.gozzi_ubuntu_22_04_lxc` (renamed)
- `proxmox_download_file.hpelvisor_ubuntu_24_04_lxc` (renamed)
- `proxmox_download_file.hpelvisor_ubuntu_22_04_lxc` (renamed)
- Consumer references updated in `hpelvisor-generated.tf` (2 refs) and `monitoring-lxc.tf` (1 ref).

## Test plan

- [x] `terraform fmt -check` passes (CI)
- [x] `terraform validate` passes (CI)
- [x] `terraform plan` shows `0 to add, 0 to change, 0 to destroy` with `has moved to` notes for each `moved` block

🤖 Generated with [Claude Code](https://claude.com/claude-code)