### PR TITLE
fix(kubenuc,s3): Fix a typo in cert-manager annotation for S3

### DIFF
--- a/clusters/kubenuc/apps/s3/manifests/release.yml
+++ b/clusters/kubenuc/apps/s3/manifests/release.yml
@@ -47,7 +47,7 @@ spec:
         className: "haproxy"
         host: ${S3_API_HOST}
         annotations:
-          cert-manager.io/cluster-issuer: "letsencrypt-prod"
+          cert-manager.io/cluster-issuer: "letsencrypt"
           haproxy.org/request-body-size: "500m"
         tls:
         - secretName: s3-tls


### PR DESCRIPTION
Fix a typo in cert-manager annotation for S3