### PR TITLE
fix(renovate): Replace RE2-incompatible lookahead with ignorePaths

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -28,7 +28,9 @@
   "platformAutomerge": false,
   "ignorePaths": [
     "**/node_modules/**",
-    "**/bower_components/**"
+    "**/bower_components/**",
+    "**/manifests/backup.yaml",
+    "**/manifests/backup.yml"
   ],
   "packageRules": [
     {
@@ -323,7 +325,7 @@
       "customType": "regex",
       "description": "Update container images in deployments",
       "managerFilePatterns": [
-        "/clusters/.+/apps/.+/manifests/(?!backup\\.ya?ml$).*\\.ya?ml$/"
+        "/clusters/.+/apps/.+/manifests/.*\\.ya?ml$/"
       ],
       "matchStrings": [
         "image:\\s+(?<depName>[^:]+):(?<currentValue>[^@\\s]+)(@(?<currentDigest>sha256:[a-f0-9]+))?"


### PR DESCRIPTION
Renovate uses the RE2 regex engine which does not support lookaheads. Remove the negative lookahead from customManagers[1].managerFilePatterns and preserve the backup.yaml exclusion via top-level ignorePaths instead.