### PR TITLE
chore(s3): Rollback to 4.21.0

### DIFF
--- a/clusters/kubenuc/apps/s3/manifests/release.yml
+++ b/clusters/kubenuc/apps/s3/manifests/release.yml
@@ -13,6 +13,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: seaweedfs
+        version: "4.21.0"
         namespace: flux-system
       interval: 15m
   install:


### PR DESCRIPTION
Version 4.22.0 does not have all the new tags, rollback to previous version.