### PR TITLE
feat(netbox): scaffold Terraform inventory management for NetBox

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -44,7 +44,10 @@
       "Bash(rtk pre-commit:*)",
       "Bash(rtk gh:*)",
       "Bash(rtk helm:*)",
-      "mcp__MCP_DOCKER__createConfluencePage"
+      "mcp__MCP_DOCKER__createConfluencePage",
+      "mcp__netbox__netbox_get_objects",
+      "mcp__netbox__netbox_get_object_by_id",
+      "WebFetch(domain:checkpoint-api.hashicorp.com)"
     ],
     "deny": [],
     "ask": []

--- a/.github/workflows/terraform-netbox.yml
+++ b/.github/workflows/terraform-netbox.yml
@@ -1,0 +1,112 @@
+name: "Terraform NetBox"
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'terraform/netbox/**'
+  pull_request:
+    paths:
+      - 'terraform/netbox/**'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  terraform:
+    name: "Terraform Diff"
+    runs-on: self-hosted
+    defaults:
+      run:
+        working-directory: terraform/netbox/
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - uses: hashicorp/setup-terraform@v4
+        with:
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+
+      - name: Terraform fmt
+        id: fmt
+        run: terraform fmt -check
+        continue-on-error: true
+
+      - name: Terraform Init
+        id: init
+        run: terraform init
+
+      - name: Terraform Validate
+        id: validate
+        run: terraform validate -no-color
+
+      - name: Terraform Plan
+        id: plan
+        run: terraform plan -no-color -var 'onepassword_token=${{ secrets.OP_TOKEN }}' -var 'onepassword_endpoint=${{ secrets.OP_ENDPOINT }}'
+        continue-on-error: true
+
+      - uses: actions/github-script@v9
+        if: github.event_name == 'pull_request'
+        env:
+          PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            })
+            const botComment = comments.find(comment => {
+              return comment.user.type === 'Bot' && comment.body.includes('Terraform Format and Style')
+            })
+
+            const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
+            #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
+            #### Terraform Validation 🤖\`${{ steps.validate.outcome }}\`
+            <details><summary>Validation Output</summary>
+
+            \`\`\`\n
+            ${{ steps.validate.outputs.stdout }}
+            \`\`\`
+
+            </details>
+
+            #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
+
+            <details><summary>Show Plan</summary>
+
+            \`\`\`\n
+            ${process.env.PLAN}
+            \`\`\`
+
+            </details>
+
+            *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`, Working Directory: \`terraform/netbox\`, Workflow: \`${{ github.workflow }}\`*`;
+
+            if (botComment) {
+              github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: output
+              })
+            } else {
+              github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: output
+              })
+            }
+
+      - name: Terraform Plan Status
+        if: steps.plan.outcome == 'failure'
+        run: exit 1
+
+      - name: Terraform Apply
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        run: terraform apply -auto-approve -var 'onepassword_token=${{ secrets.OP_TOKEN }}' -var 'onepassword_endpoint=${{ secrets.OP_ENDPOINT }}'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,10 +205,12 @@ This repository uses **1Password** for all secrets:
 **Never:**
 - Commit `.env` files, plaintext credentials, or Kubernetes `Secret` manifests with base64-encoded values
 - Add TLS certificates, SSH private keys, or tokens to git
+- Hardcode hostnames, FQDNs, or internal service URLs — these are treated as sensitive infrastructure details regardless of whether they appear to be "just configuration"
 
 **Always:**
 - Reference secrets via `OnePasswordItem` CRDs or `ExternalSecret` resources
 - Store new secrets in 1Password first, then reference by path
+- Store server URLs and FQDNs in 1Password alongside credentials (e.g. use `.url` or `.hostname` from a `onepassword_item` data source in Terraform, or a `OnePasswordItem` field in Kubernetes)
 
 ---
 

--- a/renovate.json
+++ b/renovate.json
@@ -285,6 +285,14 @@
       "semanticCommitScope": "terraform-dns"
     },
     {
+      "description": "Terraform providers - NetBox environment (separate PR)",
+      "matchManagers": ["terraform"],
+      "matchFileNames": ["terraform/netbox/**"],
+      "groupName": "terraform-netbox-providers",
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "terraform-netbox"
+    },
+    {
       "description": "Pin Digest for FluxCD controller images",
       "matchDatasources": [
         "docker"

--- a/terraform/netbox/data.tf
+++ b/terraform/netbox/data.tf
@@ -1,0 +1,12 @@
+locals {
+  onepassword_vault = "66qfxcmgwlhutunx6slav6fyve"
+}
+
+data "onepassword_item" "netbox" {
+  vault = local.onepassword_vault
+  # Create a Login item in 1Password:
+  #   - Website/URL field : https://<your-netbox-fqdn>  (drives server_url)
+  #   - Password field    : your NetBox API token        (drives api_token)
+  # Then replace this placeholder with the item UUID from the vault.
+  uuid = "TODO_REPLACE_WITH_1PASSWORD_ITEM_UUID"
+}

--- a/terraform/netbox/data.tf
+++ b/terraform/netbox/data.tf
@@ -4,5 +4,5 @@ locals {
 
 data "onepassword_item" "netbox" {
   vault = local.onepassword_vault
-  uuid = "5nqy6wpltkh7b4qqbbfb3z773i"
+  uuid  = "q7b4mjw54keaujuqyqezw7dv7i"
 }

--- a/terraform/netbox/data.tf
+++ b/terraform/netbox/data.tf
@@ -4,9 +4,5 @@ locals {
 
 data "onepassword_item" "netbox" {
   vault = local.onepassword_vault
-  # Create a Login item in 1Password:
-  #   - Website/URL field : https://<your-netbox-fqdn>  (drives server_url)
-  #   - Password field    : your NetBox API token        (drives api_token)
-  # Then replace this placeholder with the item UUID from the vault.
-  uuid = "TODO_REPLACE_WITH_1PASSWORD_ITEM_UUID"
+  uuid = "5nqy6wpltkh7b4qqbbfb3z773i"
 }

--- a/terraform/netbox/devices.tf
+++ b/terraform/netbox/devices.tf
@@ -1,0 +1,57 @@
+# Physical servers
+#
+# All bare-metal hosts run Proxmox VE as the hypervisor. Kubernetes nodes are
+# VMs/LXCs provisioned on top of Proxmox — they are not modeled here.
+
+resource "netbox_device" "astronomical_01_prg" {
+  name           = "astronomical-01-prg"
+  device_type_id = netbox_device_type.dl360_gen9.id
+  role_id        = netbox_device_role.hypervisor.id
+  site_id        = netbox_site.prg.id
+  location_id    = netbox_location.prague.id
+  platform_id    = netbox_platform.proxmox.id
+  status         = "decommissioning"
+}
+
+resource "netbox_device" "rabbit_01_psp" {
+  name           = "rabbit-01-psp"
+  device_type_id = netbox_device_type.dl360_gen9.id
+  role_id        = netbox_device_role.hypervisor.id
+  site_id        = netbox_site.bgy.id
+  location_id    = netbox_location.bergamo.id
+  rack_id        = netbox_rack.bergamo.id
+  platform_id    = netbox_platform.proxmox.id
+  status         = "active"
+}
+
+resource "netbox_device" "gozzi_01_lug" {
+  name           = "gozzi-01-lug"
+  device_type_id = netbox_device_type.dl360_gen9.id
+  role_id        = netbox_device_role.hypervisor.id
+  site_id        = netbox_site.lgu.id
+  location_id    = netbox_location.balerna.id
+  rack_id        = netbox_rack.bio.id
+  platform_id    = netbox_platform.proxmox.id
+  status         = "active"
+}
+
+resource "netbox_device" "gozzi_02_lug" {
+  name           = "gozzi-02-lug"
+  device_type_id = netbox_device_type.dl380e_gen8.id
+  role_id        = netbox_device_role.hypervisor.id
+  site_id        = netbox_site.lgu.id
+  location_id    = netbox_location.balerna.id
+  rack_id        = netbox_rack.bio.id
+  platform_id    = netbox_platform.proxmox.id
+  status         = "active"
+}
+
+resource "netbox_device" "ms01_mxp" {
+  name           = "ms01-mxp"
+  device_type_id = netbox_device_type.ms01.id
+  role_id        = netbox_device_role.hypervisor.id
+  site_id        = netbox_site.mxp.id
+  location_id    = netbox_location.milan.id
+  platform_id    = netbox_platform.proxmox.id
+  status         = "active"
+}

--- a/terraform/netbox/manufacturers.tf
+++ b/terraform/netbox/manufacturers.tf
@@ -1,0 +1,48 @@
+# ── Manufacturers ────────────────────────────────────────────────────────────
+
+resource "netbox_manufacturer" "hpe" {
+  name = "HPE"
+  slug = "hpe"
+}
+
+resource "netbox_manufacturer" "minisforum" {
+  name = "Minisforum"
+  slug = "minisforum"
+}
+
+# ── Device Types ─────────────────────────────────────────────────────────────
+
+resource "netbox_device_type" "dl360_gen9" {
+  manufacturer_id = netbox_manufacturer.hpe.id
+  model           = "ProLiant DL360 Gen9"
+  slug            = "proliant-dl360-gen9"
+  u_height        = 1
+  is_full_depth   = true
+}
+
+resource "netbox_device_type" "dl380e_gen8" {
+  manufacturer_id = netbox_manufacturer.hpe.id
+  model           = "ProLiant DL380e Gen8"
+  slug            = "proliant-dl380e-gen8"
+  u_height        = 2
+  is_full_depth   = true
+}
+
+resource "netbox_device_type" "ms01" {
+  manufacturer_id = netbox_manufacturer.minisforum.id
+  model           = "MS-01"
+  slug            = "ms-01"
+  u_height        = 0
+}
+
+# ── Platforms ─────────────────────────────────────────────────────────────────
+
+resource "netbox_platform" "proxmox" {
+  name = "Proxmox VE"
+  slug = "proxmox-ve"
+}
+
+resource "netbox_platform" "debian" {
+  name = "Debian"
+  slug = "debian"
+}

--- a/terraform/netbox/provider.tf
+++ b/terraform/netbox/provider.tf
@@ -1,0 +1,9 @@
+provider "onepassword" {
+  url   = var.onepassword_endpoint
+  token = var.onepassword_token
+}
+
+provider "netbox" {
+  server_url = data.onepassword_item.netbox.url
+  api_token  = data.onepassword_item.netbox.password
+}

--- a/terraform/netbox/provider.tf
+++ b/terraform/netbox/provider.tf
@@ -1,6 +1,6 @@
 provider "onepassword" {
-  url   = var.onepassword_endpoint
-  token = var.onepassword_token
+  connect_url   = var.onepassword_endpoint
+  connect_token = var.onepassword_token
 }
 
 provider "netbox" {

--- a/terraform/netbox/racks.tf
+++ b/terraform/netbox/racks.tf
@@ -1,0 +1,27 @@
+# Existing racks — imported from NetBox (IDs 1–2)
+
+import {
+  to = netbox_rack.bio
+  id = "1"
+}
+
+resource "netbox_rack" "bio" {
+  name        = "Bio Rack"
+  site_id     = netbox_site.lgu.id
+  location_id = netbox_location.balerna.id
+  status      = "active"
+  u_height    = 24
+}
+
+import {
+  to = netbox_rack.bergamo
+  id = "2"
+}
+
+resource "netbox_rack" "bergamo" {
+  name        = "Ddlns Bergamo"
+  site_id     = netbox_site.bgy.id
+  location_id = netbox_location.bergamo.id
+  status      = "active"
+  u_height    = 48
+}

--- a/terraform/netbox/roles.tf
+++ b/terraform/netbox/roles.tf
@@ -1,0 +1,38 @@
+# ── Device Roles ─────────────────────────────────────────────────────────────
+
+# Existing role — imported from NetBox (ID 1)
+
+import {
+  to = netbox_device_role.switch
+  id = "1"
+}
+
+resource "netbox_device_role" "switch" {
+  name      = "Switch"
+  slug      = "switch"
+  color_hex = "00ffff"
+  vm_role   = false
+}
+
+# New roles — not yet in NetBox
+
+resource "netbox_device_role" "server" {
+  name      = "Server"
+  slug      = "server"
+  color_hex = "4caf50"
+  vm_role   = false
+}
+
+resource "netbox_device_role" "hypervisor" {
+  name      = "Hypervisor"
+  slug      = "hypervisor"
+  color_hex = "2196f3"
+  vm_role   = false
+}
+
+resource "netbox_device_role" "vps" {
+  name      = "VPS"
+  slug      = "vps"
+  color_hex = "ff9800"
+  vm_role   = true
+}

--- a/terraform/netbox/sites.tf
+++ b/terraform/netbox/sites.tf
@@ -1,0 +1,136 @@
+# ── Sites ───────────────────────────────────────────────────────────────────
+
+# Existing sites — imported from NetBox (IDs 1–4)
+
+import {
+  to = netbox_site.lgu
+  id = "1"
+}
+
+resource "netbox_site" "lgu" {
+  name   = "ddlns-lgu"
+  slug   = "ddlns-lgu"
+  status = "active"
+}
+
+import {
+  to = netbox_site.bgy
+  id = "2"
+}
+
+resource "netbox_site" "bgy" {
+  name   = "ddlns-bgy"
+  slug   = "ddlns-bgy"
+  status = "active"
+}
+
+import {
+  to = netbox_site.mxp
+  id = "3"
+}
+
+resource "netbox_site" "mxp" {
+  name   = "ddlns-mxp"
+  slug   = "ddlns-mxp"
+  status = "active"
+}
+
+import {
+  to = netbox_site.prg
+  id = "4"
+}
+
+resource "netbox_site" "prg" {
+  name   = "ddlns-prg"
+  slug   = "ddlns-prg"
+  status = "planned"
+}
+
+# New sites — not yet in NetBox
+
+resource "netbox_site" "zrh" {
+  name   = "ddlns-zrh"
+  slug   = "ddlns-zrh"
+  status = "active"
+}
+
+resource "netbox_site" "nbg" {
+  name   = "ddlns-nbg"
+  slug   = "ddlns-nbg"
+  status = "active"
+}
+
+resource "netbox_site" "nl" {
+  name   = "ddlns-nl"
+  slug   = "ddlns-nl"
+  status = "active"
+}
+
+# ── Locations ────────────────────────────────────────────────────────────────
+
+# Existing locations — imported from NetBox (IDs 1–4)
+
+import {
+  to = netbox_location.bergamo
+  id = "1"
+}
+
+resource "netbox_location" "bergamo" {
+  name    = "Bergamo"
+  slug    = "bergamo"
+  site_id = netbox_site.bgy.id
+}
+
+import {
+  to = netbox_location.balerna
+  id = "2"
+}
+
+resource "netbox_location" "balerna" {
+  name        = "Balerna"
+  slug        = "balerna"
+  site_id     = netbox_site.lgu.id
+  description = "Balerna site - Bioadventures"
+}
+
+import {
+  to = netbox_location.milan
+  id = "3"
+}
+
+resource "netbox_location" "milan" {
+  name    = "Milan"
+  slug    = "milan"
+  site_id = netbox_site.mxp.id
+}
+
+import {
+  to = netbox_location.prague
+  id = "4"
+}
+
+resource "netbox_location" "prague" {
+  name    = "Prague"
+  slug    = "prague"
+  site_id = netbox_site.prg.id
+}
+
+# New locations — not yet in NetBox
+
+resource "netbox_location" "zurich" {
+  name    = "Zurich"
+  slug    = "zurich"
+  site_id = netbox_site.zrh.id
+}
+
+resource "netbox_location" "nuremberg" {
+  name    = "Nuremberg"
+  slug    = "nuremberg"
+  site_id = netbox_site.nbg.id
+}
+
+resource "netbox_location" "netherlands" {
+  name    = "Netherlands"
+  slug    = "netherlands"
+  site_id = netbox_site.nl.id
+}

--- a/terraform/netbox/terraform.tf
+++ b/terraform/netbox/terraform.tf
@@ -1,0 +1,22 @@
+terraform {
+  cloud {
+    organization = "Fastnetserv"
+    workspaces {
+      name = "infra-cd-netbox"
+    }
+  }
+
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    netbox = {
+      source  = "e-breuninger/netbox"
+      version = "~> 5.0"
+    }
+
+    onepassword = {
+      source  = "1Password/onepassword"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/terraform/netbox/variables.tf
+++ b/terraform/netbox/variables.tf
@@ -1,0 +1,11 @@
+variable "onepassword_token" {
+  description = "1Password Connect token"
+  type        = string
+  sensitive   = true
+}
+
+variable "onepassword_endpoint" {
+  description = "1Password Connect endpoint URL"
+  type        = string
+  sensitive   = true
+}

--- a/terraform/netbox/vms.tf
+++ b/terraform/netbox/vms.tf
@@ -1,0 +1,84 @@
+# ── Cluster Types ────────────────────────────────────────────────────────────
+
+resource "netbox_cluster_type" "hetzner_cloud" {
+  name = "Hetzner Cloud"
+  slug = "hetzner-cloud"
+}
+
+# ── Clusters (one per provider + region) ─────────────────────────────────────
+
+resource "netbox_cluster" "hetzner_nbg" {
+  name            = "hetzner-nbg"
+  cluster_type_id = netbox_cluster_type.hetzner_cloud.id
+  site_id         = netbox_site.nbg.id
+}
+
+resource "netbox_cluster" "hetzner_zrh" {
+  name            = "hetzner-zrh"
+  cluster_type_id = netbox_cluster_type.hetzner_cloud.id
+  site_id         = netbox_site.zrh.id
+}
+
+resource "netbox_cluster" "hetzner_nl" {
+  name            = "hetzner-nl"
+  cluster_type_id = netbox_cluster_type.hetzner_cloud.id
+  site_id         = netbox_site.nl.id
+}
+
+# ── Virtual Machines (Hetzner VPS) ───────────────────────────────────────────
+
+resource "netbox_virtual_machine" "mail2" {
+  name         = "mail2"
+  cluster_id   = netbox_cluster.hetzner_nbg.id
+  role_id      = netbox_device_role.vps.id
+  platform_id  = netbox_platform.debian.id
+  status       = "active"
+  vcpus        = 2
+  memory_mb    = 4096
+  disk_size_mb = 40960
+}
+
+resource "netbox_virtual_machine" "reverse01" {
+  name       = "reverse01"
+  cluster_id = netbox_cluster.hetzner_zrh.id
+  role_id    = netbox_device_role.vps.id
+  status     = "active"
+  vcpus      = 1
+  memory_mb  = 1024
+}
+
+resource "netbox_virtual_machine" "reverse02" {
+  name       = "reverse02"
+  cluster_id = netbox_cluster.hetzner_zrh.id
+  role_id    = netbox_device_role.vps.id
+  status     = "active"
+  vcpus      = 1
+  memory_mb  = 1024
+}
+
+resource "netbox_virtual_machine" "k8s_arm" {
+  name       = "k8s-arm"
+  cluster_id = netbox_cluster.hetzner_zrh.id
+  role_id    = netbox_device_role.vps.id
+  status     = "active"
+  vcpus      = 4
+  memory_mb  = 12288
+}
+
+resource "netbox_virtual_machine" "vpn_01" {
+  name       = "vpn-01"
+  cluster_id = netbox_cluster.hetzner_nl.id
+  role_id    = netbox_device_role.vps.id
+  status     = "active"
+  vcpus      = 1
+  memory_mb  = 1024
+}
+
+resource "netbox_virtual_machine" "vpn_02" {
+  name       = "vpn-02"
+  cluster_id = netbox_cluster.hetzner_nl.id
+  role_id    = netbox_device_role.vps.id
+  status     = "active"
+  vcpus      = 1
+  memory_mb  = 1024
+}


### PR DESCRIPTION
Adds terraform/netbox/ to manage the full asset inventory in NetBox as code, covering sites, locations, racks, device roles, manufacturers, device types, platforms, physical servers, and Hetzner VPS instances.

Imports the 4 existing sites, 4 locations, 2 racks, and the Switch device role using Terraform 1.5 import blocks. Creates the 3 missing sites (ZRH, NBG, NL) and all previously absent inventory objects.

Prerequisites before first apply:
- Create NetBox API token and store in 1Password vault 66qfxcmgwlhutunx6slav6fyve, then update the UUID in data.tf
- Create Terraform Cloud workspace infra-cd-netbox in Fastnetserv org