### PR TITLE
fix(grafana-alloy): drop high-volume log sources to reduce Grafana Cloud ingestion

### DIFF
--- a/clusters/k8s-vms-daniele/apps/grafana-alloy/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/grafana-alloy/manifests/release.yml
@@ -157,6 +157,31 @@ spec:
 
     podLogs:
       enabled: true
+      extraLogProcessingStages: |
+        stage.drop {
+          expression          = ".*level=debug.*"
+          drop_counter_reason = "debug_noise"
+        }
+        stage.drop {
+          expression          = ".*level=info.*"
+          drop_counter_reason = "info_noise"
+        }
+        stage.drop {
+          expression          = ".*(healthcheck|readiness|liveness|health_check|/healthz|/readyz|/livez).*"
+          drop_counter_reason = "probe_noise"
+        }
+        stage.drop {
+          expression          = ".*Reconciliation finished.*"
+          drop_counter_reason = "flux_noise"
+        }
+        stage.drop {
+          expression          = ".*\" (2[0-9]{2}|3[0-9]{2}) .*"
+          drop_counter_reason = "success_access_logs"
+        }
+        stage.drop {
+          expression          = ".*\\[WARNING\\] No files matching import glob pattern.*"
+          drop_counter_reason = "coredns_noise"
+        }
 
     applicationObservability:
       enabled: false
@@ -175,40 +200,6 @@ spec:
       enabled: true
       remoteConfig:
         enabled: false
-      alloy:
-        extraConfig: |
-          loki.process "filter_logs" {
-            // Drop debug logs
-            stage.drop {
-              expression          = ".*level=debug.*"
-              drop_counter_reason = "debug_noise"
-            }
-            // Drop info-level logs (keep only warn/error/fatal)
-            stage.drop {
-              expression          = ".*level=info.*"
-              drop_counter_reason = "info_noise"
-            }
-            // Drop health checks
-            stage.drop {
-              expression          = ".*(healthcheck|readiness|liveness|health_check|/healthz|/readyz|/livez).*"
-              drop_counter_reason = "probe_noise"
-            }
-            // Drop Flux reconciliation success noise
-            stage.drop {
-              expression          = ".*Reconciliation finished.*"
-              drop_counter_reason = "flux_reconcile_noise"
-            }
-            // Drop HTTP 2xx/3xx access logs
-            stage.drop {
-              expression          = ".*\" (2[0-9]{2}|3[0-9]{2}) .*"
-              drop_counter_reason = "success_access_logs"
-            }
-            stage.drop {
-              expression          = ".*\\[WARNING\\] No files matching import glob pattern.*"
-              drop_counter_reason = "coredns_noise"
-            }
-            forward_to = [loki.write.default.receiver]
-          }
 
     alloy-receiver:
       enabled: false

--- a/clusters/kubenuc/apps/grafana-alloy/manifests/release.yml
+++ b/clusters/kubenuc/apps/grafana-alloy/manifests/release.yml
@@ -275,6 +275,21 @@ spec:
           expression          = ".*\\[WARNING\\] No files matching import glob pattern.*"
           drop_counter_reason = "coredns_noise"
         }
+        stage.match {
+          selector            = "{namespace=\"jfrog\",container=\"observability\"}"
+          action              = "drop"
+          drop_counter_reason = "jfrog_observability_noise"
+        }
+        stage.match {
+          selector            = "{namespace=\"openebs\",container=\"loki\"}"
+          action              = "drop"
+          drop_counter_reason = "openebs_loki_self_logs"
+        }
+        stage.match {
+          selector            = "{namespace=\"grafana-alloy\",container=\"alloy\"}"
+          action              = "drop"
+          drop_counter_reason = "alloy_self_logs"
+        }
 
     applicationObservability:
       enabled: true


### PR DESCRIPTION
## Summary

- **kubenuc**: Add `stage.match` drops for the three top log contributors identified via LogQL analysis:
  - `jfrog/observability` (~203 MB/7d, ~870 MB/month) — JFrog Artifactory telemetry sidecar; no operational value in Grafana Cloud
  - `openebs/loki` (~87 MB/7d) — self-hosted Loki instance forwarding its own logs back to Grafana Cloud (circular)
  - `grafana-alloy/alloy` DaemonSet (~86 MB/7d) — Alloy's own self-logs creating a feedback loop

- **k8s-vms-daniele**: Fix a bug where `loki.process "filter_logs"` was defined in `alloy-logs.alloy.extraConfig` but never referenced by anything in the pipeline — it was dead code producing zero filtering. The drop rules are moved to `podLogs.extraLogProcessingStages` where they actually execute before logs are shipped to Grafana Cloud.

## Root cause (k8s-vms-daniele)

The `extraConfig` field injects arbitrary Alloy River components, but a `loki.process` block only runs if something `forward_to`s it. Nothing did — all pod logs bypassed the filter entirely. `podLogs.extraLogProcessingStages` is the correct injection point for pipeline stages in the k8s-monitoring chart.

## Test plan

- [ ] Verify kubenuc Alloy pods reconcile successfully after chart re-render
- [ ] Verify k8s-vms-daniele Alloy pods reconcile successfully
- [ ] Monitor Grafana Cloud logs ingestion over the next 24h for reduction in `jfrog`, `openebs`, and `grafana-alloy` namespace volume
- [ ] Check Alloy UI (`/graph`) on k8s-vms-daniele to confirm `filter_logs` component no longer appears as a disconnected/unused node

🤖 Generated with [Claude Code](https://claude.com/claude-code)