### PR TITLE
Potential fix for code scanning alert no. 4082: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate-kubenuc.yml
+++ b/.github/workflows/validate-kubenuc.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - 'clusters/kubenuc/**'
 
+permissions:
+  contents: read
+
 jobs:
   detect-changes:
     runs-on: self-hosted


### PR DESCRIPTION
Potential fix for [https://github.com/dark-vex/infra-cd/security/code-scanning/4082](https://github.com/dark-vex/infra-cd/security/code-scanning/4082)

Add an explicit top-level `permissions` block in `.github/workflows/validate-kubenuc.yml` so all jobs inherit least-privilege token scopes by default.  
The safest minimal change (without altering functional behavior for typical CI read operations) is:

- `permissions:`
  - `contents: read`

Place it at workflow root (after `on:` block and before `jobs:`). This addresses CodeQL’s finding for all jobs in this workflow unless a specific job later needs broader scopes (which can then be added per-job explicitly).

No imports, methods, or dependencies are needed since this is YAML workflow configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
