### PR TITLE
chore(kubenuc,haproxy): Enable cors for all ingresses

### DIFF
--- a/clusters/kubenuc/apps/haproxy-ingress/manifests/release.yml
+++ b/clusters/kubenuc/apps/haproxy-ingress/manifests/release.yml
@@ -69,7 +69,8 @@ spec:
               topologyKey: "kubernetes.io/hostname"
       config:
         ssl-redirect: "false"
-        # Client max body size (0 = unlimited)
         client-body-buffer-size: "0"
-        # Forward headers
         forwarded-for: "true"
+        request-body-size: "0"
+        cors-enable: "true"
+        cors-allow-headers: "X-Forwarded-For"

--- a/clusters/kubenuc/apps/harbor/manifests/release.yml
+++ b/clusters/kubenuc/apps/harbor/manifests/release.yml
@@ -109,7 +109,6 @@ spec:
         className: "haproxy"
         annotations:
           cert-manager.io/cluster-issuer: letsencrypt
-          haproxy.org/request-body-size: "0"
         hosts:
           core: ${HARBOR_HOST}
       tls:

--- a/clusters/kubenuc/apps/jenkins/manifests/release.yml
+++ b/clusters/kubenuc/apps/jenkins/manifests/release.yml
@@ -38,7 +38,6 @@ spec:
 
         annotations:
           cert-manager.io/cluster-issuer: letsencrypt
-          haproxy.org/request-body-size: "100m"
         ingressClassName: haproxy
 
         hostName: ${JENKINS_HOST}

--- a/clusters/kubenuc/apps/jfrog-acr/manifests/release.yml
+++ b/clusters/kubenuc/apps/jfrog-acr/manifests/release.yml
@@ -53,7 +53,6 @@ spec:
         className: "haproxy"
         annotations:
           cert-manager.io/cluster-issuer: letsencrypt
-          haproxy.org/request-body-size: "0"
         tls:
         - secretName: artifactory-tls
           hosts:

--- a/clusters/kubenuc/apps/nextcloud/manifests/release.yml
+++ b/clusters/kubenuc/apps/nextcloud/manifests/release.yml
@@ -38,9 +38,6 @@ spec:
       className: haproxy
       annotations:
         cert-manager.io/cluster-issuer: "letsencrypt"
-        haproxy.org/request-body-size: "0"
-        haproxy.org/cors-enable: "true"
-        haproxy.org/cors-allow-headers: "X-Forwarded-For"
       tls:
         - secretName: nx-fastnet-tls
           hosts:


### PR DESCRIPTION
Add cors enabled by default for all ingresses and removing the annotations from nextcloud, harbor and artifactory