### PR TITLE
fix(renovate): pin k3s updates to per-cluster minor channel

### DIFF
--- a/clusters/CLAUDE.md
+++ b/clusters/CLAUDE.md
@@ -68,3 +68,17 @@ Renovate auto-PRs FluxCD component bumps — do not manually edit `clusters/{clu
 | `security-static-analysis.yml` | PR/push to `clusters/**` | KubeLinter static analysis across all cluster apps |
 
 PR validation runs k3s + Flux CD with a 2-hour timeout. Robot Framework E2E tests via `tests/robot/robot-test-job.yaml`.
+
+---
+
+## Renovate
+
+### Benign `Excess registryUrls` warning
+
+During Renovate runs you will see:
+
+```
+WARN: Excess registryUrls found for datasource lookup - using first configured only
+```
+
+This is **expected and harmless**. Several `HelmRepository` names (e.g. `1password-chart`, `grafana-charts`) are intentionally defined in multiple cluster directories — per-cluster isolation is by design. Renovate's Flux/helm manager aggregates all matching repo definitions repo-wide and attaches the URL once per occurrence; the helm datasource uses only the first URL. Because every duplicate name maps to the **same URL** across all clusters, the correct URL is always used. No action needed; do not rename `HelmRepository` resources to silence this warning.

--- a/renovate.json
+++ b/renovate.json
@@ -330,6 +330,13 @@
       "semanticCommitScope": "terraform-modules"
     },
     {
+      "description": "k3s: stay within the per-cluster pinned channel (patch/build only)",
+      "matchDatasources": ["github-releases"],
+      "matchPackageNames": ["k3s-io/k3s"],
+      "matchUpdateTypes": ["major", "minor"],
+      "enabled": false
+    },
+    {
       "description": "Strip v prefix from github-releases tags for unversioned pins",
       "matchDatasources": ["github-releases"],
       "matchPackageNames": ["fluxcd/flux2", "prometheus-pve/prometheus-pve-exporter", "grafana/alloy"],
@@ -398,7 +405,7 @@
       ],
       "depNameTemplate": "k3s-io/k3s",
       "datasourceTemplate": "github-releases",
-      "versioningTemplate": "loose"
+      "versioningTemplate": "regex:^v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(?:\\+k3s(?<build>\\d+))?$"
     },
     {
       "customType": "regex",


### PR DESCRIPTION
## Summary

- **Fix k3s channel drift**: the `system-upgrade-controller k3s target version` custom manager was using `loose` versioning with no update-type gate, causing Renovate to propose the absolute latest k3s release across minor versions (PR #1440 bumped all clusters to `v1.36.1+k3s1` regardless of each cluster's pinned channel).
  - Replaced `versioningTemplate: "loose"` with a regex that properly parses k3s semver tags (`v<major>.<minor>.<patch>+k3s<build>`).
  - Added a `packageRules` entry that disables `major` and `minor` update types for `k3s-io/k3s`, scoped only to that package. Each cluster now only receives patch/build PRs within its current minor (`v1.33.x` → kubenuc, `v1.32.x` → k8s-vms-daniele, `v1.34.x` → k3s-rabbit). Moving to a new minor requires a deliberate manual change to the `channel:` line.
- **Document benign `Excess registryUrls` warning**: added a Renovate subsection to `clusters/CLAUDE.md` explaining that the `WARN: Excess registryUrls found for datasource lookup` is cosmetic — identical `HelmRepository` names are intentionally duplicated per cluster (per-cluster isolation), all URLs are identical, and the correct URL is always used.

## Test plan

- [x] `npx --yes renovate-config-validator renovate.json` → `Config validated successfully`
- [ ] Confirm next Renovate run proposes only same-minor patch/build PRs for k3s (no `v1.36.x` PRs)
- [ ] Confirm other `github-releases` deps (flux2, kustomize, kube-linter, kubectl, helm) are unaffected by the new k3s-scoped rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)