### PR TITLE
fix(grafana-alloy): migrate k8s-monitoring HelmRelease values from v3 to v4

### DIFF
--- a/clusters/k8s-vms-daniele/apps/grafana-alloy/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/grafana-alloy/manifests/release.yml
@@ -29,27 +29,27 @@ spec:
     - kind: Secret
       name: grafana-cloud-credentials
       valuesKey: password
-      targetPath: destinations[0].auth.password
+      targetPath: destinations.grafanaCloudMetrics.auth.password
     - kind: Secret
       name: grafana-cloud-credentials
       valuesKey: password
-      targetPath: destinations[1].auth.password
+      targetPath: destinations.grafanaCloudLogs.auth.password
     # --- Destination usernames ---
     - kind: Secret
       name: grafana-cloud-credentials
       valuesKey: metrics-username
-      targetPath: destinations[0].auth.username
+      targetPath: destinations.grafanaCloudMetrics.auth.username
     - kind: Secret
       name: grafana-cloud-credentials
       valuesKey: logs-username
-      targetPath: destinations[1].auth.username
+      targetPath: destinations.grafanaCloudLogs.auth.username
   values:
     cluster:
       name: k8s-vms-daniele
 
     # Lightweight: metrics + logs only (no OTLP/traces)
     destinations:
-      - name: grafana-cloud-metrics
+      grafanaCloudMetrics:
         type: prometheus
         url: ${GRAFANA_PROMETHEUS_URL}
         auth:
@@ -85,7 +85,7 @@ spec:
             regex         = "(controller_runtime_reconcile_time_seconds|workqueue_queue_duration_seconds|workqueue_work_duration_seconds)_bucket"
             action        = "drop"
           }
-      - name: grafana-cloud-logs
+      grafanaCloudLogs:
         type: loki
         url: ${GRAFANA_LOKI_URL}
         auth:
@@ -117,10 +117,15 @@ spec:
     selfReporting:
       enabled: false
 
+    telemetryServices:
+      kube-state-metrics:
+        deploy: true
+
     clusterMetrics:
       enabled: true
-      kepler:
-        enabled: false
+      collector: alloy-metrics
+      destinations:
+        - grafanaCloudMetrics
       kubelet:
         enabled: false
       cadvisor:
@@ -135,14 +140,6 @@ spec:
         enabled: false
       kubeDNS:
         enabled: false
-      node-exporter:
-        enabled: false
-        deploy: false
-      opencost:
-        enabled: false
-      windows-exporter:
-        enabled: false
-        deploy: false
       kube-state-metrics:
         metricsTuning:
           excludeMetrics:
@@ -184,19 +181,26 @@ spec:
 
     annotationAutodiscovery:
       enabled: true
+      collector: alloy-metrics
       annotations:
         scrape: "prometheus.io/scrape"
         metricsPortNumber: "prometheus.io/port"
         metricsPath: "prometheus.io/path"
         metricsScheme: "prometheus.io/scheme"
       destinations:
-        - grafana-cloud-metrics
+        - grafanaCloudMetrics
 
     clusterEvents:
       enabled: true
+      collector: alloy-singleton
+      destinations:
+        - grafanaCloudLogs
 
-    podLogs:
+    podLogsViaLoki:
       enabled: true
+      collector: alloy-logs
+      destinations:
+        - grafanaCloudLogs
       extraLogProcessingStages: |
         stage.drop {
           expression          = ".*level=debug.*"
@@ -226,20 +230,63 @@ spec:
     applicationObservability:
       enabled: false
 
-    alloy-metrics:
-      enabled: true
-      remoteConfig:
-        enabled: false
+    collectors:
+      alloy-metrics:
+        presets:
+          - clustered
+          - statefulset
+        alloy:
+          extraEnv:
+            - name: CLUSTER_NAME
+              value: k8s-vms-daniele
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+        remoteConfig:
+          enabled: false
 
-    alloy-singleton:
-      enabled: true
-      remoteConfig:
-        enabled: false
+      alloy-singleton:
+        presets:
+          - singleton
+        alloy:
+          extraEnv:
+            - name: CLUSTER_NAME
+              value: k8s-vms-daniele
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+        remoteConfig:
+          enabled: false
 
-    alloy-logs:
-      enabled: true
-      remoteConfig:
-        enabled: false
-
-    alloy-receiver:
-      enabled: false
+      alloy-logs:
+        presets:
+          - daemonset
+          - filesystem-log-reader
+        alloy:
+          extraEnv:
+            - name: CLUSTER_NAME
+              value: k8s-vms-daniele
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+        remoteConfig:
+          enabled: false

--- a/clusters/kubenuc/apps/grafana-alloy/manifests/release.yml
+++ b/clusters/kubenuc/apps/grafana-alloy/manifests/release.yml
@@ -40,43 +40,43 @@ spec:
     - kind: Secret
       name: grafana-cloud-credentials
       valuesKey: password
-      targetPath: destinations[0].auth.password
+      targetPath: destinations.grafanaCloudMetrics.auth.password
     - kind: Secret
       name: grafana-cloud-credentials
       valuesKey: password
-      targetPath: destinations[1].auth.password
+      targetPath: destinations.grafanaCloudLogs.auth.password
     - kind: Secret
       name: grafana-cloud-credentials
       valuesKey: password
-      targetPath: destinations[2].auth.password
+      targetPath: destinations.gcOtlp.auth.password
     # --- Destination usernames ---
     - kind: Secret
       name: grafana-cloud-credentials
       valuesKey: metrics-username
-      targetPath: destinations[0].auth.username
+      targetPath: destinations.grafanaCloudMetrics.auth.username
     - kind: Secret
       name: grafana-cloud-credentials
       valuesKey: logs-username
-      targetPath: destinations[1].auth.username
+      targetPath: destinations.grafanaCloudLogs.auth.username
     - kind: Secret
       name: grafana-cloud-credentials
       valuesKey: otlp-username
-      targetPath: destinations[2].auth.username
+      targetPath: destinations.gcOtlp.auth.username
     # --- Graylog OTLP gRPC destination ---
     - kind: Secret
       name: graylog-alloy-creds
       valuesKey: url
-      targetPath: destinations[3].url
+      targetPath: destinations.graylogOtlp.url
     - kind: Secret
       name: graylog-alloy-creds
       valuesKey: bearer_token
-      targetPath: destinations[3].auth.bearerToken
+      targetPath: destinations.graylogOtlp.auth.bearerToken
   values:
     cluster:
       name: kubenuc
 
     destinations:
-      - name: grafana-cloud-metrics
+      grafanaCloudMetrics:
         type: prometheus
         url: ${GRAFANA_PROMETHEUS_URL}
         auth:
@@ -113,7 +113,7 @@ spec:
             regex         = "(controller_runtime_reconcile_time_seconds|workqueue_queue_duration_seconds|workqueue_work_duration_seconds)_bucket"
             action        = "drop"
           }
-      - name: grafana-cloud-logs
+      grafanaCloudLogs:
         type: loki
         url: ${GRAFANA_LOKI_URL}
         auth:
@@ -179,7 +179,7 @@ spec:
             action   = "drop"
             drop_counter_reason = "gc_loki_default_deny"
           }
-      - name: gc-otlp-endpoint
+      gcOtlp:
         type: otlp
         url: ${GRAFANA_OTLP_URL}
         protocol: http
@@ -191,7 +191,7 @@ spec:
           enabled: true
         traces:
           enabled: true
-      - name: graylog-otlp
+      graylogOtlp:
         type: otlp
         protocol: grpc
         # url injected via valuesFrom from graylog-alloy-creds secret
@@ -201,6 +201,10 @@ spec:
           # bearerToken injected via valuesFrom from graylog-alloy-creds secret
         logs:
           enabled: true
+        metrics:
+          enabled: false
+        traces:
+          enabled: false
         processors:
           filters:
             enabled: true
@@ -235,10 +239,15 @@ spec:
     selfReporting:
       enabled: false
 
+    telemetryServices:
+      kube-state-metrics:
+        deploy: true
+
     clusterMetrics:
       enabled: true
-      kepler:
-        enabled: false
+      collector: alloy-metrics
+      destinations:
+        - grafanaCloudMetrics
       kubelet:
         enabled: false
       cadvisor:
@@ -253,14 +262,6 @@ spec:
         enabled: false
       kubeDNS:
         enabled: false
-      node-exporter:
-        enabled: false
-        deploy: false
-      opencost:
-        enabled: false
-      windows-exporter:
-        enabled: false
-        deploy: false
       kube-state-metrics:
         metricsTuning:
           excludeMetrics:
@@ -302,22 +303,27 @@ spec:
 
     annotationAutodiscovery:
       enabled: true
+      collector: alloy-metrics
       annotations:
         scrape: "prometheus.io/scrape"
         metricsPortNumber: "prometheus.io/port"
         metricsPath: "prometheus.io/path"
         metricsScheme: "prometheus.io/scheme"
       destinations:
-        - grafana-cloud-metrics
+        - grafanaCloudMetrics
 
     clusterEvents:
       enabled: true
-
-    podLogs:
-      enabled: true
+      collector: alloy-singleton
       destinations:
-        - grafana-cloud-logs
-        - graylog-otlp
+        - grafanaCloudLogs
+
+    podLogsViaLoki:
+      enabled: true
+      collector: alloy-logs
+      destinations:
+        - grafanaCloudLogs
+        - graylogOtlp
       extraLogProcessingStages: |
         stage.regex {
           expression = "(?i)(?:\"(?:level|lvl|severity)\"\\s*:\\s*\"|(?:^|\\s)(?:level|lvl|severity)=)(?P<level>debug|info|warn(?:ing)?|error|fatal|critical)"
@@ -376,6 +382,9 @@ spec:
 
     applicationObservability:
       enabled: true
+      collector: alloy-receiver
+      destinations:
+        - gcOtlp
       receivers:
         otlp:
           grpc:
@@ -388,143 +397,98 @@ spec:
           enabled: true
           port: 9411
 
-    alloy-metrics:
-      enabled: true
-      configReloader:
-        enabled: false
-      controller:
-        affinity:
-          nodeAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              nodeSelectorTerms:
-                - matchExpressions:
-                    - key: kubernetes.io/hostname
-                      operator: NotIn
-                      values:
-                        - kubenuc-m1
-                        - kubenuc-w1
-      alloy:
-        extraEnv:
-          - name: CLUSTER_NAME
-            value: kubenuc
-          - name: NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-      remoteConfig:
-        enabled: false
+    collectors:
+      alloy-metrics:
+        presets:
+          - clustered
+          - statefulset
+        alloy:
+          extraEnv:
+            - name: CLUSTER_NAME
+              value: kubenuc
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+        remoteConfig:
+          enabled: false
 
-    alloy-singleton:
-      enabled: true
-      configReloader:
-        enabled: false
-      controller:
-        affinity:
-          nodeAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              nodeSelectorTerms:
-                - matchExpressions:
-                    - key: kubernetes.io/hostname
-                      operator: NotIn
-                      values:
-                        - kubenuc-m1
-                        - kubenuc-w1
-      alloy:
-        extraEnv:
-          - name: CLUSTER_NAME
-            value: kubenuc
-          - name: NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-      remoteConfig:
-        enabled: false
+      alloy-singleton:
+        presets:
+          - singleton
+        alloy:
+          extraEnv:
+            - name: CLUSTER_NAME
+              value: kubenuc
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+        remoteConfig:
+          enabled: false
 
-    alloy-logs:
-      enabled: true
-      configReloader:
-        enabled: false
-      controller:
-        affinity:
-          nodeAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              nodeSelectorTerms:
-                - matchExpressions:
-                    - key: kubernetes.io/hostname
-                      operator: NotIn
-                      values:
-                        - kubenuc-m1
-                        - kubenuc-w1
-      alloy:
-        extraEnv:
-          - name: CLUSTER_NAME
-            value: kubenuc
-          - name: NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: NODE_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-      remoteConfig:
-        enabled: false
+      alloy-logs:
+        presets:
+          - daemonset
+          - filesystem-log-reader
+        alloy:
+          extraEnv:
+            - name: CLUSTER_NAME
+              value: kubenuc
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+        remoteConfig:
+          enabled: false
 
-    alloy-receiver:
-      enabled: true
-      configReloader:
-        enabled: false
-      controller:
-        affinity:
-          nodeAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              nodeSelectorTerms:
-                - matchExpressions:
-                    - key: kubernetes.io/hostname
-                      operator: NotIn
-                      values:
-                        - kubenuc-m1
-                        - kubenuc-w1
-      alloy:
-        extraPorts:
-          - name: otlp-grpc
-            port: 4317
-            targetPort: 4317
-            protocol: TCP
-          - name: otlp-http
-            port: 4318
-            targetPort: 4318
-            protocol: TCP
-          - name: zipkin
-            port: 9411
-            targetPort: 9411
-            protocol: TCP
-        extraEnv:
-          - name: CLUSTER_NAME
-            value: kubenuc
-          - name: NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: NODE_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-      remoteConfig:
-        enabled: false
+      alloy-receiver:
+        presets:
+          - daemonset
+        alloy:
+          extraPorts:
+            - name: otlp-grpc
+              port: 4317
+              targetPort: 4317
+              protocol: TCP
+            - name: otlp-http
+              port: 4318
+              targetPort: 4318
+              protocol: TCP
+            - name: zipkin
+              port: 9411
+              targetPort: 9411
+              protocol: TCP
+          extraEnv:
+            - name: CLUSTER_NAME
+              value: kubenuc
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+        remoteConfig:
+          enabled: false


### PR DESCRIPTION
## Summary

- Renovate PR #1448 bumped `k8s-monitoring` to `4.x` but only changed the version string; the `values:` blocks were still v3-format, causing reconciliation to fail: `at '/destinations': got array, want object`
- v4 is a major rewrite — most top-level keys were renamed/restructured; stale v3 keys pass schema but are silently ignored, which would have dropped pod-log collection, metric/log drop rules (free-tier guard), node anti-affinity, and OTLP receiver ports
- This PR performs the full v3→v4 migration for both affected HelmReleases

## Changes

**Both clusters (`kubenuc` + `k8s-vms-daniele`):**
- `destinations:` list → map with camelCase keys (`grafanaCloudMetrics`, `grafanaCloudLogs`, `gcOtlp`, `graylogOtlp`)
- `valuesFrom.targetPath`: array indices → dot-notation map paths (e.g. `destinations[0].auth.password` → `destinations.grafanaCloudMetrics.auth.password`)
- `podLogs` → `podLogsViaLoki` (renamed feature)
- Top-level `alloy-*:` keys → `collectors:` map with `presets:` (`clustered`+`statefulset`, `singleton`, `daemonset`+`filesystem-log-reader`, `daemonset`)
- All features assigned explicit `collector:` and `destinations:` (v4 requires this; empty list fans out to all capable destinations)
- `telemetryServices.kube-state-metrics.deploy: true` added — v4 no longer auto-deploys KSM via the clusterMetrics feature; without this key all `kube_*` metrics would vanish
- `configReloader.enabled: false` removed (not a valid v4 collector key)

**kubenuc extras:**
- `graylogOtlp`: `metrics.enabled: false` + `traces.enabled: false` added (v4 OTLP destinations default all signal types to `true`; v3 only had `logs.enabled: true`)
- `alloy-receiver` collector defined with `daemonset` preset + `extraPorts` (required: `applicationObservability` render-validates the assigned collector exposes them)
- Per-collector affinity removed — already consolidated in existing `collectorCommon.alloy.controller.affinity`

## Behavior notes vs v3

- `clusterEvents` now routes only to `grafanaCloudLogs` (v3 implicit fan-out would have also included OTLP destinations; narrowed intentionally — cluster events belong in Loki)
- `applicationObservability` now routes only to `gcOtlp` (v3 implicit fan-out; Graylog is for application logs via pod-log pipeline, not for traces/metrics)

## Validation

Rendered both configs with `helm template` against `k8s-monitoring@4.1.4` (exit 0, ~2600 lines). Confirmed present in rendered Alloy configuration:
- [x] `write_relabel_config` metric drop rules (free-tier guard)
- [x] `stage.drop` Loki log drop stages (free-tier guard)
- [x] OTLP receiver ports 4317 / 4318 / 9411
- [x] Node anti-affinity excluding `kubenuc-m1` / `kubenuc-w1` on all collectors
- [x] KSM deployed + `excludeMetrics` applied
- [x] Graylog `severity_text` filter rules

## Rollback

Revert the version pin to `"3.x.x"` in both `release.yml` files to restore the last-working major; Renovate will re-raise the v4 PR.