### PR TITLE
fix(kubenuc,jfrog): Increased upgrade timeout

### DIFF
--- a/clusters/kubenuc/apps/jfrog-acr/manifests/release.yml
+++ b/clusters/kubenuc/apps/jfrog-acr/manifests/release.yml
@@ -24,7 +24,7 @@ spec:
   upgrade:
     remediation:
       retries: 6
-    timeout: 15m
+    timeout: 30m
   values:
     artifactory:
       artifactory:


### PR DESCRIPTION
In order to avoid the automatic roll-back from fluxcd which cause a upgrade/roll-back loop, I have increased the upgrade timeout to 30 minutes.