### PR TITLE
feat(kubenuc,sso): Upgrade Zitadel from v2 to v4

### DIFF
--- a/clusters/kubenuc/apps/sso/manifests/zitadel.yml
+++ b/clusters/kubenuc/apps/sso/manifests/zitadel.yml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: zitadel
-      version: "10.0.2"
+      version: "9.29.0"
       sourceRef:
         kind: HelmRepository
         name: zitadel-chart
@@ -23,6 +23,7 @@ spec:
       retries: 5
   upgrade:
     disableWait: true
+    force: true
     remediation:
       retries: 5
   values:
@@ -41,6 +42,8 @@ spec:
           hosts:
             - ${SSO_HOST}
     zitadel:
+      login:
+        enabled: false
       initContainers:
         - name: check-db-ready
           image: postgres:17@sha256:0027bef26712baaee437a4ea48fdf3d2d2e2bc5f0d81615374408ca320f3c7e3

--- a/renovate.json
+++ b/renovate.json
@@ -221,6 +221,12 @@
       "allowedVersions": "^17"
     },
     {
+      "description": "Pin zitadel chart to < 10 until v10 hop is planned (login auth change)",
+      "matchDatasources": ["helm"],
+      "matchPackageNames": ["zitadel"],
+      "allowedVersions": "< 10"
+    },
+    {
       "description": "Monitoring Stack",
       "matchDatasources": [
         "helm",


### PR DESCRIPTION
## Context

PR #1448 (Renovate) bumped Zitadel directly from chart `8.13.4` → `10.0.2`. That upgrade has been failing on every reconcile since:

```
cannot patch "zitadel" with kind Deployment: spec.selector: ... field is immutable
  (new selector adds app.kubernetes.io/component: start)
```

The old v2.67.2 Deployment is still running — production SSO is healthy and **no DB migration has run yet**. Clean state.

## Why a staged hop (v8→v9, not straight to v10)

- **v8→v9 boundary** is where the selector conflict occurs (v9 restructures to separate `deployment_zitadel` + `deployment_login` with new selector labels). Helm aborts before any DB change.
- **v9→v10** separately changes login auth from PAT → X.509 keypair. Mixing both migrations in one hop makes rollback harder.
- Landing on **9.29.0** (latest 9.x, app v4.13.0) rather than 9.0.0 picks up chart bugfixes; the app v2→v4 DB migration is identical either way.

## Changes

### `clusters/kubenuc/apps/sso/manifests/zitadel.yml`
- Chart version: `10.0.2` → `9.29.0`
- `spec.upgrade.force: true` — GitOps-native selector remediation: lets Helm delete+recreate the Deployment on upgrade so the new `app.kubernetes.io/component: start` selector can apply. Remove in a follow-up commit once the upgrade succeeds.
- `zitadel.login.enabled: false` — keeps the existing built-in login UI; avoids deploying the new Login UI v2 (which needs its own ingress config) on this intermediate hop. Adopting Login UI v2 is a deliberate later step with the v10 hop.

### `renovate.json`
- Added `allowedVersions: "< 10"` pin for the `zitadel` helm package so Renovate does not immediately re-raise the v10 major PR while that migration is being planned.

## Pre-flight (required before merge)
- [ ] `pg_dump` the zitadel database (v2→v4 migration is forward-only — no downgrade once run)
- [ ] Confirm `zitadel-master-secrets` exposes key named `masterkey`

## Verification after merge
1. `flux get hr zitadel -n sso` → `UpgradeSucceeded`
2. New `zitadel` Deployment selector includes `app.kubernetes.io/component: start`; pods Ready; init/setup jobs Completed
3. Zitadel pod logs show v2→v4 DB migrations completed without errors
4. End-to-end login at `${SSO_HOST}` works (built-in login, `login.enabled: false`)

## Rollback
Pin chart back to `8.13.4` **and** restore DB from pre-flight dump (pinning alone is insufficient once migrations ran).

## Follow-up (separate PR)
- Remove `spec.upgrade.force: true` once upgrade succeeds
- Plan v9→v10 hop: Login UI v2 ingress + X.509 login-client auth, lift the `< 10` Renovate pin