### PR TITLE
fix(kubenuc,sso): disable new Zitadel Login V2 (move login.enabled to top level)

### DIFF
--- a/clusters/kubenuc/apps/sso/manifests/zitadel.yml
+++ b/clusters/kubenuc/apps/sso/manifests/zitadel.yml
@@ -27,6 +27,8 @@ spec:
     remediation:
       retries: 5
   values:
+    login:
+      enabled: false
     ingress:
       enabled: true
       className: "haproxy"
@@ -42,8 +44,6 @@ spec:
           hosts:
             - ${SSO_HOST}
     zitadel:
-      login:
-        enabled: false
       initContainers:
         - name: check-db-ready
           image: postgres:17@sha256:0027bef26712baaee437a4ea48fdf3d2d2e2bc5f0d81615374408ca320f3c7e3


### PR DESCRIPTION
## Summary
- The v2→v4 Zitadel migration (#1464, chart 9.34.1) set `login.enabled: false` nested under `zitadel:` in `clusters/kubenuc/apps/sso/manifests/zitadel.yml`, but in this chart `login` is a **top-level** value — the nested key was silently ignored, so the new Login V2 deployment was rendered.
- That `zitadel-login` pod requires a `login-client` Secret which the setup job only auto-creates on a fresh `FirstInstance` bootstrap — never on a migrated/existing instance — so it's been stuck in `Init` (`secret "login-client" not found`).
- This moves `login.enabled: false` to the correct top-level location under `spec.values`, matching the [chart README guidance](https://github.com/zitadel/zitadel-charts/blob/zitadel-9.34.1/charts/zitadel/README.md#dont-switch-to-the-new-login-deployment) for staying on the legacy built-in login. The core `zitadel` deployment (already running healthy on v4.13.1) and its existing ingress are unaffected.
- Scope is `kubenuc` only — `oc-ampere` has no Zitadel `HelmRelease`.

## Test plan
- [x] Flux reconciles `HelmRelease/zitadel -n sso` cleanly (`upgrade.force: true` is set)
- [x] `zitadel-login` Deployment/pod and its ConfigMap/Service/ServiceAccount are pruned (`kubectl get pods,deploy -n sso -l app.kubernetes.io/component=login` → no resources found)
- [x] Core `zitadel` pod stays `1/1 Running`
- [x] Only the main ingress remains on `${SSO_HOST}`
- [x] Browse `https://${SSO_HOST}`, confirm the legacy login screen loads, and a login succeeds
- [x] Existing OIDC client apps brokered through Zitadel still authenticate

## Forward note
When the chart is bumped to v10 (Renovate currently pinned `< 10`), revisit Login V2 — v10 switches to an auto-generated RSA keypair (`<release>-login-service-key`), so enabling it then would no longer require a manual `login-client` PAT/secret.