### PR TITLE
fix(ci): guard self-hosted runner jobs against untrusted fork PRs

### DIFF
--- a/.github/workflows/terraform-bio.yml
+++ b/.github/workflows/terraform-bio.yml
@@ -18,6 +18,7 @@ jobs:
   terraform-proxmox:
     name: "Terraform Diff (Proxmox)"
     runs-on: LGU
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     defaults:
       run:
         working-directory: terraform/proxmox/gozzi-hpelvisor/

--- a/.github/workflows/terraform-dns.yml
+++ b/.github/workflows/terraform-dns.yml
@@ -20,6 +20,7 @@ jobs:
   terraform-dns:
     name: "Terraform Diff (Cloudflare DNS)"
     runs-on: self-hosted
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     defaults:
       run:
         working-directory: terraform/DNS/

--- a/.github/workflows/terraform-grafana.yml
+++ b/.github/workflows/terraform-grafana.yml
@@ -18,6 +18,7 @@ jobs:
   terraform:
     name: "Terraform Diff"
     runs-on: self-hosted
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     defaults:
       run:
         working-directory: terraform/grafana/

--- a/.github/workflows/terraform-mxp.yml
+++ b/.github/workflows/terraform-mxp.yml
@@ -20,6 +20,7 @@ jobs:
   terraform:
     name: "Terraform Diff"
     runs-on: mxp
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     defaults:
       run:
         working-directory: terraform/ec200/
@@ -131,6 +132,7 @@ jobs:
   terraform-proxmox:
     name: "Terraform Diff (Proxmox)"
     runs-on: mxp
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     defaults:
       run:
         working-directory: terraform/proxmox/ec200/

--- a/.github/workflows/terraform-netbox.yml
+++ b/.github/workflows/terraform-netbox.yml
@@ -18,6 +18,7 @@ jobs:
   terraform:
     name: "Terraform Diff"
     runs-on: self-hosted
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     defaults:
       run:
         working-directory: terraform/netbox/

--- a/.github/workflows/terraform-oci.yml
+++ b/.github/workflows/terraform-oci.yml
@@ -20,6 +20,7 @@ jobs:
   terraform-k8s-armchair:
     name: "Terraform Diff - OCI k8s-armchair"
     runs-on: self-hosted
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     defaults:
       run:
         working-directory: terraform/oci/k8s-armchair/
@@ -116,6 +117,7 @@ jobs:
   terraform-teleport:
     name: "Terraform Diff - OCI teleport"
     runs-on: self-hosted
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     defaults:
       run:
         working-directory: terraform/oci/teleport/
@@ -212,6 +214,7 @@ jobs:
   terraform-test-vpn:
     name: "Terraform Diff - OCI test-vpn"
     runs-on: self-hosted
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     defaults:
       run:
         working-directory: terraform/oci/test_vpn/

--- a/.github/workflows/terraform-psp.yml
+++ b/.github/workflows/terraform-psp.yml
@@ -18,6 +18,7 @@ jobs:
   terraform-proxmox:
     name: "Terraform Diff (Proxmox)"
     runs-on: self-hosted
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     defaults:
       run:
         working-directory: terraform/proxmox/rabbit/

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -18,6 +18,7 @@ jobs:
   terraform:
     name: "Terraform Diff"
     runs-on: self-hosted
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     defaults:
       run:
         working-directory: terraform/hetzner/

--- a/.github/workflows/validate-k8s-vms.yml
+++ b/.github/workflows/validate-k8s-vms.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   detect-changes:
     runs-on: self-hosted
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     outputs:
       deploy_apps: ${{ steps.detect.outputs.deploy_apps }}
     steps:
@@ -42,6 +43,8 @@ jobs:
   cluster-test:
     needs: detect-changes
     runs-on: self-hosted
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    environment: kubenuc-test
     timeout-minutes: 120
     env:
       DEPLOY_APPS: ${{ needs.detect-changes.outputs.deploy_apps }}

--- a/.github/workflows/validate-kubenuc.yml
+++ b/.github/workflows/validate-kubenuc.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   detect-changes:
     runs-on: self-hosted
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     outputs:
       deploy_apps: ${{ steps.detect.outputs.deploy_apps }}
     steps:
@@ -41,6 +42,8 @@ jobs:
   cluster-test:
     needs: detect-changes
     runs-on: self-hosted
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    environment: kubenuc-test
     timeout-minutes: 120
     env:
       DEPLOY_APPS: ${{ needs.detect-changes.outputs.deploy_apps }}


### PR DESCRIPTION
## Summary

This is PR **A1** of a larger security-hardening plan (fork guard → secrets scanning → action pinning → PSS/NetworkPolicy rollout), the first and highest-priority item because it closes an active exposure.

- `infra-cd` is a **public** repo. All cluster e2e and terraform CI runs on self-hosted runners (`self-hosted`, `mxp`, `LGU`) with no check on whether the triggering PR comes from a fork. A fork PR could execute arbitrary code on these runners — reaching the LAN and any persistent workspace state — even without access to repo secrets.
- Adds an event-aware guard to every job using `self-hosted`/`mxp`/`LGU` across all 10 affected workflows (`validate-kubenuc.yml`, `validate-k8s-vms.yml`, `terraform.yml`, `terraform-bio.yml`, `terraform-dns.yml`, `terraform-grafana.yml`, `terraform-mxp.yml`, `terraform-netbox.yml`, `terraform-oci.yml`, `terraform-psp.yml`):
  ```yaml
  if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
  ```
  The `event_name` check is required because several terraform workflows also trigger on `push` to `main`, where `github.event.pull_request` is empty — a bare repo-name comparison would incorrectly skip legitimate push-triggered applies.
- `security-static-analysis.yml` is intentionally left unguarded: it runs on `ubuntu-latest` and references no `secrets.*`, so it's safe for fork PRs.
- Attaches a `kubenuc-test` GitHub environment to the two e2e `cluster-test` jobs (`validate-kubenuc.yml`, `validate-k8s-vms.yml`) that inject `OP_TOKEN` / `SOPS_AGE_KEY_KUBENUC_TEST` into the live test cluster, so those secrets can be scoped/gated independently going forward.

## Manual follow-up (not part of this diff)

- GitHub repo settings → Actions → require approval for all outside collaborators (belt-and-suspenders alongside these job-level guards).
- The `kubenuc-test` environment will be auto-created on first workflow run referencing it; consider adding required reviewers/protection rules to it via repo settings once created.

## Test plan

- [x] All 10 modified workflow files parse as valid YAML (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Verified exactly 15 job-level guards added, matching every self-hosted/mxp/LGU job across the 10 files (counts: terraform-oci×3, terraform-mxp×2, validate-kubenuc×2, validate-k8s-vms×2, others×1 each)
- [ ] Open a scratch PR from a fork to confirm self-hosted jobs are skipped
- [ ] Confirm a push-to-main terraform run still executes (guard doesn't block legitimate applies)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_013E8ocpdkiRcfaAGXUwqTiy)_