### PR TITLE
feat(security): add gitleaks secret scanning (pre-commit + CI)

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,28 @@
+name: gitleaks
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  scan:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0
+
+      # Audit-first rollout: report findings without blocking merges for ~1 week,
+      # then remove continue-on-error to make this a required check.
+      - uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }} # only required for GitHub Organizations, not personal accounts

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,31 @@
+title = "infra-cd gitleaks config"
+
+[extend]
+useDefault = true
+
+[[rules]]
+id = "age-secret-key"
+description = "SOPS/age private key material"
+regex = '''AGE-SECRET-KEY-[A-Z0-9]+'''
+tags = ["secret", "age"]
+
+[allowlist]
+description = "SOPS-encrypted payloads and accepted test-only credentials"
+regexTarget = "line"
+regexes = [
+  # SOPS ciphertext — not a plaintext secret, decryptable only with a private age key
+  '''ENC\[AES256_GCM,.*\]''',
+  # 1Password vault UUID — a public identifier, not a credential (OP_TOKEN is the secret)
+  '''onepassword_vault\s*=\s*"[a-z0-9]+"''',
+]
+paths = [
+  # SOPS-encrypted files across all clusters and terraform stacks
+  '''clusters/.*/vars/.*\.sops\.ya?ml$''',
+  '''clusters/.*/apps/.*/secrets/.*\.sops\.ya?ml$''',
+  '''terraform/.*/secrets\.sops\.ya?ml$''',
+  # age recipient (public key) files — public by design, not secret material
+  '''\.sops\.yaml$''',
+  # Accepted test-only credential: kubenuc-test is an ephemeral CI-only cluster,
+  # torn down after every e2e run — see PLAN A / A2 decision.
+  '''clusters/kubenuc-test/apps/postgresql/secrets/dbadmin\.yaml$''',
+]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,7 @@ repos:
     -   id: check-yaml
         args: [--allow-multiple-documents]
     -   id: check-added-large-files
+-   repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+    -   id: gitleaks


### PR DESCRIPTION
## Summary

This is **A3** of the security-hardening plan, following **A1** (fork-PR guard, merged in #1546). Adds secret-scanning defense-in-depth for this public repo: a local pre-commit hook plus a CI workflow on every PR and push to `main`.

- `.pre-commit-config.yaml`: adds the `gitleaks/gitleaks` `v8.30.1` hook. Verified locally — installs and passes against the current tree.
- `.gitleaks.toml`: allowlists
  - SOPS ciphertext (`ENC[AES256_GCM...]`) under `clusters/**/secrets/`, `**/*.sops.yaml`, and `terraform/**/secrets.sops.yaml`
  - 1Password vault UUIDs (`onepassword_vault = "..."` in terraform — these are identifiers, not credentials; `OP_TOKEN` is the actual secret)
  - the accepted `clusters/kubenuc-test/apps/postgresql/secrets/dbadmin.yaml` test password (kubenuc-test is an ephemeral CI-only cluster, torn down after every e2e run — confirmed out of scope for rotation during A1's review)
  - a custom `AGE-SECRET-KEY-` rule as a backstop for age private keys
- `.github/workflows/gitleaks.yml`: `ubuntu-latest` (safe for fork PRs — no secrets needed to scan), `gitleaks-action` pinned to `v3.0.0` by commit SHA (current major; v2 is being sunset by GitHub's Node 20 deprecation), `actions/checkout` pinned to `v7` by SHA with `fetch-depth: 0`. `continue-on-error: true` for an audit-first rollout — remove once findings are triaged for about a week.

## Full-history triage

Ran `gitleaks detect --log-opts="--all"` against the complete, unshallowed history (2302 commits — the working clone was shallow at 52 commits, so I unshallowed it first to get a real answer). **3 findings, all already remediated, none live:**
- Two are a hardcoded `test-secret-key-123456789012345678901234567890` placeholder in `validate-kubenuc.yml` / `validate-kubenuc-ingress.yml` — both files no longer exist in current `HEAD`.
- One is a Sysdig `apiToken` (UUID format) in `apps/kubenuc/sysdig-harbor-scanner/release.yml` (commit `8e91e64`, 2022) — already revoked and rotated to 1Password in a later commit (`15fee14`, "Revoked test API token, generated a new one and moved on 1p"), and the whole app directory has since been removed from the repo.

No history rewrite performed — per repo policy (public repo, Flux tracks `main`, GitHub caches orphaned commits anyway), rotation/removal is the correct remediation for already-exposed secrets, not history-scrubbing. Both findings here were already handled before this PR.

## Test plan

- [x] `.gitleaks.toml`, `.pre-commit-config.yaml`, `.github/workflows/gitleaks.yml` all parse correctly
- [x] `pre-commit run gitleaks --all-files` passes locally against current tree
- [x] `gitleaks detect --no-git` (working tree) — no leaks found
- [x] `gitleaks detect --log-opts="--all"` (full history, 2302 commits) — 3 findings, all triaged above as already remediated
- [x] Confirm the CI workflow runs on this PR (fork-PR-safe check)
- [ ] After ~1 week with no false positives, remove `continue-on-error: true` to make the check required

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_013E8ocpdkiRcfaAGXUwqTiy)_