### PR TITLE
chore(security): add CODEOWNERS, terraform-prod environment gate, secret cleanup

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Default owner for everything in the repo.
+# Required so branch protection's "require review from code owners" is enforceable.
+* @dark-vex
+
+# CI/CD workflow changes always need explicit owner review — this is where
+# self-hosted runner exposure and secrets handling live.
+/.github/workflows/ @dark-vex

--- a/.github/workflows/terraform-bio.yml
+++ b/.github/workflows/terraform-bio.yml
@@ -19,6 +19,7 @@ jobs:
     name: "Terraform Diff (Proxmox)"
     runs-on: LGU
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    environment: terraform-prod
     defaults:
       run:
         working-directory: terraform/proxmox/gozzi-hpelvisor/
@@ -125,3 +126,7 @@ jobs:
         env:
           OP_TOKEN: '${{ secrets.OP_TOKEN }}'
           OP_ENDPOINT: '${{ secrets.OP_ENDPOINT }}'
+
+      - name: Cleanup SSH public key
+        if: always()
+        run: rm -f ~/.ssh/id_rsa.pub

--- a/.github/workflows/terraform-dns.yml
+++ b/.github/workflows/terraform-dns.yml
@@ -21,6 +21,7 @@ jobs:
     name: "Terraform Diff (Cloudflare DNS)"
     runs-on: self-hosted
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    environment: terraform-prod
     defaults:
       run:
         working-directory: terraform/DNS/

--- a/.github/workflows/terraform-grafana.yml
+++ b/.github/workflows/terraform-grafana.yml
@@ -19,6 +19,7 @@ jobs:
     name: "Terraform Diff"
     runs-on: self-hosted
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    environment: terraform-prod
     defaults:
       run:
         working-directory: terraform/grafana/

--- a/.github/workflows/terraform-mxp.yml
+++ b/.github/workflows/terraform-mxp.yml
@@ -21,6 +21,7 @@ jobs:
     name: "Terraform Diff"
     runs-on: mxp
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    environment: terraform-prod
     defaults:
       run:
         working-directory: terraform/ec200/
@@ -129,10 +130,15 @@ jobs:
 
           OP_ENDPOINT: '${{ secrets.OP_ENDPOINT }}'
 
+      - name: Cleanup SSH public key
+        if: always()
+        run: rm -f ~/.ssh/id_rsa.pub
+
   terraform-proxmox:
     name: "Terraform Diff (Proxmox)"
     runs-on: mxp
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    environment: terraform-prod
     defaults:
       run:
         working-directory: terraform/proxmox/ec200/
@@ -239,3 +245,7 @@ jobs:
         env:
           OP_TOKEN: '${{ secrets.OP_TOKEN }}'
           OP_ENDPOINT: '${{ secrets.OP_ENDPOINT }}'
+
+      - name: Cleanup SSH public key
+        if: always()
+        run: rm -f ~/.ssh/id_rsa.pub

--- a/.github/workflows/terraform-netbox.yml
+++ b/.github/workflows/terraform-netbox.yml
@@ -19,6 +19,7 @@ jobs:
     name: "Terraform Diff"
     runs-on: self-hosted
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    environment: terraform-prod
     defaults:
       run:
         working-directory: terraform/netbox/

--- a/.github/workflows/terraform-oci.yml
+++ b/.github/workflows/terraform-oci.yml
@@ -21,6 +21,7 @@ jobs:
     name: "Terraform Diff - OCI k8s-armchair"
     runs-on: self-hosted
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    environment: terraform-prod
     defaults:
       run:
         working-directory: terraform/oci/k8s-armchair/
@@ -118,6 +119,7 @@ jobs:
     name: "Terraform Diff - OCI teleport"
     runs-on: self-hosted
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    environment: terraform-prod
     defaults:
       run:
         working-directory: terraform/oci/teleport/
@@ -215,6 +217,7 @@ jobs:
     name: "Terraform Diff - OCI test-vpn"
     runs-on: self-hosted
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    environment: terraform-prod
     defaults:
       run:
         working-directory: terraform/oci/test_vpn/

--- a/.github/workflows/terraform-psp.yml
+++ b/.github/workflows/terraform-psp.yml
@@ -19,6 +19,7 @@ jobs:
     name: "Terraform Diff (Proxmox)"
     runs-on: self-hosted
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    environment: terraform-prod
     defaults:
       run:
         working-directory: terraform/proxmox/rabbit/
@@ -125,3 +126,7 @@ jobs:
         env:
           OP_TOKEN: '${{ secrets.OP_TOKEN }}'
           OP_ENDPOINT: '${{ secrets.OP_ENDPOINT }}'
+
+      - name: Cleanup SSH public key
+        if: always()
+        run: rm -f ~/.ssh/id_rsa.pub

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -19,6 +19,7 @@ jobs:
     name: "Terraform Diff"
     runs-on: self-hosted
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    environment: terraform-prod
     defaults:
       run:
         working-directory: terraform/hetzner/
@@ -119,3 +120,7 @@ jobs:
       - name: Terraform Apply
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         run: terraform apply -auto-approve -var 'onepassword_token=${{ secrets.OP_TOKEN }}' -var 'onepassword_endpoint=${{ secrets.OP_ENDPOINT }}'
+
+      - name: Cleanup SSH public key
+        if: always()
+        run: rm -f ~/.ssh/id_rsa.pub


### PR DESCRIPTION
## Summary

This is **A5** of the security-hardening plan, following **A1** (fork-PR guard, #1546), **A3** (gitleaks, #1547), and **A4** (SHA-pinning, #1548).

- `.github/CODEOWNERS`: `* @dark-vex`, with an explicit rule for `.github/workflows/**` — required-review branch protection needs a CODEOWNERS file to be enforceable, and workflow changes are where self-hosted runner exposure and secrets handling live.
- Added `environment: terraform-prod` to all 11 jobs across the 8 `terraform*.yml` workflows that run push-to-main auto-apply (hetzner, DNS, grafana, netbox, mxp ×2, oci ×3, psp, bio). This is a **job-level tag only** — GitHub auto-creates the environment with no protection rules on first reference, so it's a no-op today, but gives an audit trail and a future hook for required reviewers. (Discussed and confirmed: a job-level tag also covers the PR-plan runs in the same job, not just the apply step, since plan and apply currently share one job per workflow — accepted trade-off vs. a full plan/apply job split, which would be a much larger restructuring of 8 production pipelines.)
- Added an `always()` "Cleanup SSH public key" step removing `~/.ssh/id_rsa.pub` in the 4 workflows that write `secrets.PUB_KEY` to a file on the (persistent, self-hosted) runner: `terraform.yml`, `terraform-mxp.yml` (both jobs), `terraform-psp.yml`, `terraform-bio.yml`.

## Note on `terraform-mxp.yml`

That file already used CRLF line endings before this PR (confirmed via `git show` on pre-session commits — not introduced by this session). Edits were made carefully (byte-level, CRLF-preserving) so the diff stays a clean 10 lines instead of rewriting the whole file.

## Test plan

- [x] All 9 changed/added files parse as valid YAML
- [x] Exactly 11 `environment: terraform-prod` job tags added, matching every push-to-main apply job
- [x] Exactly 5 cleanup steps added, matching every `secrets.PUB_KEY` write site
- [x] `terraform-mxp.yml` diff confirmed minimal (10 lines) with CRLF endings preserved
- [ ] CI: all Terraform Diff / gitleaks / KubeLinter / CodeQL checks pass
- [ ] Confirm branch protection can now require CODEOWNERS review (repo setting, not part of this diff)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_013E8ocpdkiRcfaAGXUwqTiy)_