### PR TITLE
feat(security): add checkov IaC scanning for terraform/ (audit-first)

### DIFF
--- a/.github/workflows/security-static-analysis.yml
+++ b/.github/workflows/security-static-analysis.yml
@@ -8,12 +8,14 @@ on:
       - '.github/workflows/security-static-analysis.yml'
       - '.kube-linter.yaml'
       - 'clusters/**'
+      - 'terraform/**'
   push:
     branches: [main]
     paths:
       - '.github/workflows/security-static-analysis.yml'
       - '.kube-linter.yaml'
       - 'clusters/**'
+      - 'terraform/**'
   workflow_dispatch:
 
 permissions:
@@ -48,3 +50,52 @@ jobs:
             clusters/k3s-rabbit/apps \
             clusters/oc-ampere/apps \
             --config .kube-linter.yaml
+
+  checkov:
+    name: Terraform IaC scan (checkov)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Setup Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: '3.12'
+
+      - name: Install checkov
+        run: pip install checkov==3.3.6
+
+      - name: Run checkov
+        run: |
+          mkdir -p checkov-report
+          checkov \
+            --directory terraform/ \
+            --framework terraform \
+            --soft-fail \
+            --compact \
+            --skip-download \
+            --skip-path 'terraform/grafana/alerting\.tf$' \
+            --output cli \
+            --output sarif \
+            --output-file-path checkov-report
+        # --skip-download: no external module/provider fetching or Prisma Cloud
+        # phone-home needed for a static scan.
+        # --skip-path on alerting.tf: python-hcl2 (checkov's parser) treats a
+        # bare `for` attribute as the reserved for-expression keyword even
+        # outside a comprehension, and fails to parse the Grafana provider's
+        # `rule { for = "6h" ... }` block. Confirmed independently via
+        # `python3 -c "import hcl2; hcl2.load(...)"` — real `terraform
+        # validate`/`fmt`/`plan` handle this file fine; it's a parser
+        # limitation, not a finding. Audit-first: soft-fail while findings
+        # are triaged; flip to hard-fail per directory once addressed.
+
+      - name: Upload SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@8533807ff379ac610d2b2c389c47e7c629d31d13 # v4.36.3
+        with:
+          sarif_file: checkov-report/results_sarif.sarif
+          category: checkov


### PR DESCRIPTION
## Summary

This is **A6** of the security-hardening plan, following **A1** (fork-PR guard, #1546), **A3** (gitleaks, #1547), **A4** (SHA-pinning, #1548), and **A5** (CODEOWNERS/apply gate/secret cleanup, #1551).

Adds a `checkov` job to `security-static-analysis.yml`, mirroring the existing KubeLinter job's `ubuntu-latest`/audit-first pattern:

- **pip-installs checkov 3.3.6** rather than using the `bridgecrewio/checkov-action` wrapper — its `action.yml` pins a Docker image at checkov `2.0.545` (from 2022) with no newer release since. pip gives a current, maintained checkov with full CLI control (SARIF output, `--skip-path`).
- `--soft-fail` (audit-first, matches repo policy); `--skip-download` avoids provider/module fetching and the Prisma Cloud "guidelines" phone-home — neither is needed for a static scan.
- `--skip-path` excludes `terraform/grafana/alerting.tf`: **python-hcl2** (checkov's HCL parser) fails on that file's `rule { for = "6h" ... }` block, treating the bare `for` attribute as the reserved for-expression keyword even outside a comprehension. Confirmed independently (`python3 -c "import hcl2; hcl2.load(...)"`) that this is a parser limitation, not a real syntax issue — `terraform validate`/`fmt`/`plan` all handle the file fine, and it's already live in the repo.
- Uploads results via `github/codeql-action/upload-sarif`.
- `on.paths` for both `pull_request` and `push` gained `terraform/**` — the workflow previously only watched `clusters/**` and the workflow file itself, so it would never have triggered on terraform changes.

## Verification

Ran the exact CI command locally end-to-end:
- **109 passed / 3 failed / 0 parsing errors**, exit code `0` (confirms soft-fail behaves as expected)
- The 3 failures are `CKV_OCI_4` (OCI compute boot volume in-transit encryption) — a real, pre-existing finding on the 3 OCI instances (`k8s-armchair`, `teleport`, `test_vpn`), left for a follow-up fix under the audit-first policy, not addressed in this PR
- Valid SARIF output with a matching result count (3)
- `security-static-analysis.yml` parses as valid YAML

## Test plan

- [x] Local dry-run of the exact `checkov` command matches CI invocation
- [x] SARIF file structurally valid, uploadable
- [x] Confirmed `alerting.tf` parse failure is a checkov/python-hcl2 limitation, not a real Terraform issue
- [ ] CI: checkov job runs and uploads SARIF for real; other checks (KubeLinter, gitleaks, Terraform Diff ×N) unaffected
- [ ] Follow-up (separate PR): address `CKV_OCI_4` on the 3 OCI instances, then flip this check to hard-fail once findings are clean

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_013E8ocpdkiRcfaAGXUwqTiy)_