### PR TITLE
feat(security): add default-deny NetworkPolicy for zabbix, film-tv, net-mon, nut

### DIFF
--- a/clusters/kubenuc/apps/film-tv-exporter/manifests/networkpolicy-allow-ingress.yml
+++ b/clusters/kubenuc/apps/film-tv-exporter/manifests/networkpolicy-allow-ingress.yml
@@ -1,0 +1,28 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress
+  namespace: film-tv
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    # Metrics scraping from grafana-alloy: sonarr-exporter (9707), radarr-exporter
+    # (9708), lidarr-exporter (9709) - currently scaled to 0 but policy stays
+    # ready for when they're re-enabled
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: grafana-alloy
+      ports:
+        - protocol: TCP
+          port: 9707
+        - protocol: TCP
+          port: 9708
+        - protocol: TCP
+          port: 9709
+    # Intra-namespace traffic
+    - from:
+        - podSelector: {}

--- a/clusters/kubenuc/apps/film-tv-exporter/manifests/networkpolicy-default-deny-ingress.yml
+++ b/clusters/kubenuc/apps/film-tv-exporter/manifests/networkpolicy-default-deny-ingress.yml
@@ -1,0 +1,10 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: film-tv
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress

--- a/clusters/kubenuc/apps/net-mon/manifests/networkpolicy-allow-ingress.yml
+++ b/clusters/kubenuc/apps/net-mon/manifests/networkpolicy-allow-ingress.yml
@@ -1,0 +1,23 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress
+  namespace: net-mon
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    # Metrics scraping from grafana-alloy: network-exporter (9427) - currently
+    # scaled to 0 but policy stays ready for when it's re-enabled
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: grafana-alloy
+      ports:
+        - protocol: TCP
+          port: 9427
+    # Intra-namespace traffic
+    - from:
+        - podSelector: {}

--- a/clusters/kubenuc/apps/net-mon/manifests/networkpolicy-default-deny-ingress.yml
+++ b/clusters/kubenuc/apps/net-mon/manifests/networkpolicy-default-deny-ingress.yml
@@ -1,0 +1,10 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: net-mon
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress

--- a/clusters/kubenuc/apps/nut/manifests/networkpolicy-allow-ingress.yml
+++ b/clusters/kubenuc/apps/nut/manifests/networkpolicy-allow-ingress.yml
@@ -1,0 +1,22 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress
+  namespace: nut
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    # Metrics scraping from grafana-alloy: nut-exporter (9995, HTTP_PATH /metrics)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: grafana-alloy
+      ports:
+        - protocol: TCP
+          port: 9995
+    # Intra-namespace traffic
+    - from:
+        - podSelector: {}

--- a/clusters/kubenuc/apps/nut/manifests/networkpolicy-default-deny-ingress.yml
+++ b/clusters/kubenuc/apps/nut/manifests/networkpolicy-default-deny-ingress.yml
@@ -1,0 +1,10 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: nut
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress

--- a/clusters/kubenuc/apps/zabbix/manifests/networkpolicy-allow-ingress.yml
+++ b/clusters/kubenuc/apps/zabbix/manifests/networkpolicy-allow-ingress.yml
@@ -1,0 +1,26 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress
+  namespace: zabbix
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    # zabbix-proxy (10051, NodePort) receives passive-check pushes from
+    # devices/agents on the physical LAN, not from another cluster namespace
+    - from:
+        - ipBlock:
+            cidr: 10.10.40.0/24
+        - ipBlock:
+            cidr: 10.20.0.0/24
+        - ipBlock:
+            cidr: 10.10.8.0/24
+      ports:
+        - protocol: TCP
+          port: 10051
+    # Intra-namespace traffic
+    - from:
+        - podSelector: {}

--- a/clusters/kubenuc/apps/zabbix/manifests/networkpolicy-default-deny-ingress.yml
+++ b/clusters/kubenuc/apps/zabbix/manifests/networkpolicy-default-deny-ingress.yml
@@ -1,0 +1,10 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: zabbix
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress


### PR DESCRIPTION
## Summary
Closes out the last items from the Plan A / A8 default-deny NetworkPolicy series (originally deferred from batch 1 pending confirmed LAN CIDRs / port details):

- **zabbix**: `zabbix-proxy` is a `NodePort` Service (port 10051) receiving passive-check data pushed from devices/agents on the physical LAN, not from another cluster namespace — so the allow rule uses `ipBlock` CIDRs (`10.10.40.0/24`, `10.20.0.0/24`, `10.10.8.0/24`) instead of a `namespaceSelector`.
- **film-tv** (film-tv-exporter): grafana-alloy scrape allowed on 9707/9708/9709 (sonarr/radarr/lidarr exporters — currently `replicas: 0`, policy stays ready for re-enable).
- **net-mon**: grafana-alloy scrape allowed on 9427 (network-exporter — currently `replicas: 0`).
- **nut**: grafana-alloy scrape allowed on 9995 (nut-exporter — active).

All four namespaces are single-app with no ingress-facing Service beyond the above, so no `haproxy-ingress` rule is needed in any of them.

**Caveat to verify post-merge:** if the zabbix `NodePort` Service's `externalTrafficPolicy` is the k8s default (`Cluster`), traffic routed to a pod on a different node than the one that received it gets SNAT'd to the node's IP, which could mask the original LAN client source IP from the `ipBlock` match. If passive checks stop landing after this merges, the fix is `externalTrafficPolicy: Local` on the zabbix-proxy Service (pins traffic to the node the pod runs on, which is already forced via `nodeSelector: kubernetes.io/hostname: kubenuc-w1`, so this should be a no-op change).

## Test plan
- [x] YAML syntax validated (`python3 -c "import yaml; ..."`)
- [x] `kubeconform -strict -kubernetes-version 1.33.0` passes on all 8 new manifests
- [x] CI (yamllint + KubeLinter + kustomize build + kubenuc e2e)
- [ ] Manual verification post-merge: confirm zabbix passive checks still arrive from the LAN, and Alloy scraping of nut-exporter is unaffected


---
_Generated by [Claude Code](https://claude.ai/code/session_013E8ocpdkiRcfaAGXUwqTiy)_