### PR TITLE
feat(security): standardize securityContext for cert-manager, grafana-alloy

### DIFF
--- a/clusters/k8s-vms-daniele/apps/cert-manager/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/cert-manager/manifests/release.yml
@@ -27,3 +27,14 @@ spec:
     crds:
       enabled: true
       keep: true
+    # allowPrivilegeEscalation/capabilities.drop/readOnlyRootFilesystem are
+    # already chart defaults for all 3 components - only runAsUser needs
+    # setting to match house style
+    securityContext:
+      runAsUser: 65532
+    webhook:
+      securityContext:
+        runAsUser: 65532
+    cainjector:
+      securityContext:
+        runAsUser: 65532

--- a/clusters/k8s-vms-daniele/apps/grafana-alloy/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/grafana-alloy/manifests/release.yml
@@ -47,6 +47,34 @@ spec:
     cluster:
       name: k8s-vms-daniele
 
+    global:
+      podSecurityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+
+    # Settings applied to all Alloy instances (metrics, singleton, logs)
+    collectorCommon:
+      alloy:
+        alloy:
+          # capabilities intentionally left at chart defaults (drop ALL + a
+          # documented add-list) - alloy-logs needs DAC_OVERRIDE/CHOWN/FOWNER
+          # etc. to read host log files owned by other UIDs; zeroing the
+          # add-list here would break that collector
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65532
+          mounts:
+            extra:
+              - name: alloy-data
+                mountPath: /tmp/alloy
+        controller:
+          volumes:
+            extra:
+              - name: alloy-data
+                emptyDir: {}
+
     # Lightweight: metrics + logs only (no OTLP/traces)
     destinations:
       grafanaCloudMetrics:
@@ -120,6 +148,12 @@ spec:
     telemetryServices:
       kube-state-metrics:
         deploy: true
+        securityContext:
+          runAsUser: 65532
+          runAsGroup: 65532
+          fsGroup: 65532
+        containerSecurityContext:
+          runAsUser: 65532
 
     clusterMetrics:
       enabled: true

--- a/clusters/kubenuc/apps/cert-manager/manifests/release.yml
+++ b/clusters/kubenuc/apps/cert-manager/manifests/release.yml
@@ -27,3 +27,14 @@ spec:
     crds:
       enabled: true
       keep: true
+    # allowPrivilegeEscalation/capabilities.drop/readOnlyRootFilesystem are
+    # already chart defaults for all 3 components - only runAsUser needs
+    # setting to match house style
+    securityContext:
+      runAsUser: 65532
+    webhook:
+      securityContext:
+        runAsUser: 65532
+    cainjector:
+      securityContext:
+        runAsUser: 65532

--- a/clusters/kubenuc/apps/grafana-alloy/manifests/release.yml
+++ b/clusters/kubenuc/apps/grafana-alloy/manifests/release.yml
@@ -75,6 +75,11 @@ spec:
     cluster:
       name: kubenuc
 
+    global:
+      podSecurityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+
     destinations:
       grafanaCloudMetrics:
         type: prometheus
@@ -221,6 +226,20 @@ spec:
     # Settings applied to all Alloy instances (metrics, singleton, logs, receiver)
     collectorCommon:
       alloy:
+        alloy:
+          # capabilities intentionally left at chart defaults (drop ALL + a
+          # documented add-list) - alloy-logs needs DAC_OVERRIDE/CHOWN/FOWNER
+          # etc. to read host log files owned by other UIDs; zeroing the
+          # add-list here would break that collector
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65532
+          mounts:
+            extra:
+              - name: alloy-data
+                mountPath: /tmp/alloy
         controller:
           affinity:
             nodeAffinity:
@@ -232,6 +251,10 @@ spec:
                         values:
                           - kubenuc-m1
                           - kubenuc-w1
+          volumes:
+            extra:
+              - name: alloy-data
+                emptyDir: {}
 
     selfReporting:
       enabled: false
@@ -239,6 +262,12 @@ spec:
     telemetryServices:
       kube-state-metrics:
         deploy: true
+        securityContext:
+          runAsUser: 65532
+          runAsGroup: 65532
+          fsGroup: 65532
+        containerSecurityContext:
+          runAsUser: 65532
 
     clusterMetrics:
       enabled: true


### PR DESCRIPTION
## Summary
First batch of the Plan A / A9 securityContext standardization series (~25 active HelmReleases across both clusters currently have no explicit securityContext). Verified against real chart source and `helm template` renders (cloned upstream chart repos at the pinned versions, not guessed from memory) rather than assumed, since a wrong values key would silently no-op instead of erroring.

- **cert-manager** (kubenuc + k8s-vms-daniele): controller/webhook/cainjector already ship `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`, `readOnlyRootFilesystem: true` as chart defaults — only `runAsUser: 65532` was missing, added to all 3 components (`securityContext`, `webhook.securityContext`, `cainjector.securityContext`).
- **grafana-alloy / k8s-monitoring** (kubenuc + k8s-vms-daniele): added
  - `global.podSecurityContext` (`runAsNonRoot: true`, `runAsUser: 65532`) — applies pod-level to every Alloy instance
  - `collectorCommon.alloy.alloy.securityContext` (no-privesc, RO rootfs, non-root, uid 65532) — applies container-level to every Alloy instance
  - the required writable `emptyDir` at `/tmp/alloy` (Alloy's WAL/storage path has no volume mount by default in the upstream chart; `readOnlyRootFilesystem` would break every collector without it)
  - `telemetryServices.kube-state-metrics.securityContext` / `containerSecurityContext` (uid 65532; chart default is already hardened at uid 65534 otherwise)

  **Deliberately not touched:** capabilities are left at the chart's own default add-list rather than dropped to `[]`. The `alloy-logs` collector needs `DAC_OVERRIDE`/`CHOWN`/`FOWNER`/etc. to read host log files owned by other UIDs under `/var/log` and `/var/lib/docker/containers`, and there's no live cluster available in this sandbox to verify a safe per-instance capability carve-out. Zeroing it globally risks breaking log collection in production. Flagging for a follow-up once verifiable against the live cluster.

- **1Password Connect** and **external-dns**: audited, no changes needed — both charts already ship the full hardening profile (no-privesc, RO rootfs, non-root, `runAsUser` matching or exceeding house style) by default, confirmed via `helm template` render against the actual pinned versions/values.

## Test plan
- [x] YAML syntax validated (`python3 -c "import yaml; ..."`)
- [x] Values verified against real `helm template` output on cloned upstream chart sources at the exact pinned versions (not guessed)
- [x] CI (yamllint + KubeLinter + kustomize build + kubenuc/k8s-vms e2e)
- [ ] Manual verification post-merge: cert-manager issues certs normally; Alloy collectors (metrics/singleton/logs/receiver) start and continue shipping data to Grafana Cloud/Graylog with no WAL write errors; alloy-logs still reads host log files


---
_Generated by [Claude Code](https://claude.ai/code/session_013E8ocpdkiRcfaAGXUwqTiy)_