### PR TITLE
feat(security): standardize securityContext for jellyfin, portainer, semaphore

### DIFF
--- a/clusters/k8s-vms-daniele/apps/semaphore/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/semaphore/manifests/release.yml
@@ -67,6 +67,19 @@ spec:
       valuesKey: access-key
       targetPath: semaphore.accessKey
   values:
+    # Note: this chart's key names are inverted from the usual convention -
+    # `securityContext` renders at pod level, `podSecurityContext` renders
+    # at container level (verified via helm template). readOnlyRootFilesystem
+    # and a forced UID are intentionally left out: ansible/terraform tool
+    # caches invoked by Semaphore jobs may write to $HOME (no HOME env is set
+    # by the chart), and the existing workdir PVC data is owned by whatever
+    # UID the pod ran as before - no live cluster to verify either is safe
+    podSecurityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+
     database:
       type: postgres
 

--- a/clusters/kubenuc/apps/jellyfin/manifests/release.yml
+++ b/clusters/kubenuc/apps/jellyfin/manifests/release.yml
@@ -27,6 +27,16 @@ spec:
     image:
       tag: latest
       pullPolicy: Always
+    # runAsUser/runAsNonRoot intentionally left unset: the existing
+    # openebs-hostpath config PVC has data written by the image's default
+    # (root) user with no live cluster available to verify a UID switch
+    # won't hit permission-denied on it
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+      readOnlyRootFilesystem: true
     env:
       JELLYFIN_PublishedServerUrl: jellyfin
       TZ: Europe/Rome

--- a/clusters/kubenuc/apps/portainer/manifests/release.yml
+++ b/clusters/kubenuc/apps/portainer/manifests/release.yml
@@ -75,6 +75,21 @@ spec:
                 template:
                   spec:
                     containers:
+                      # Chart has no securityContext support at all (verified
+                      # empty across the chart's full history) - hardened via
+                      # strategic-merge patch instead. readOnlyRootFilesystem
+                      # and a forced UID are intentionally left out: EE
+                      # features (git-based stack deploy, backup/restore) may
+                      # write to /tmp, and the existing BoltDB PVC data is
+                      # owned by whatever UID the pod ran as before with no
+                      # securityContext - no live cluster to verify either is
+                      # safe
+                      - name: portainer
+                        securityContext:
+                          allowPrivilegeEscalation: false
+                          capabilities:
+                            drop:
+                              - ALL
                       - name: tailscale
                         image: ghcr.io/tailscale/tailscale:v1.98.4@sha256:25cde9ad76020b0e29229136d0c38b5962e9a0e1774ffac9b0df68e4a37d6cf0
                         imagePullPolicy: IfNotPresent

--- a/clusters/kubenuc/apps/portainer/manifests/release.yml
+++ b/clusters/kubenuc/apps/portainer/manifests/release.yml
@@ -95,8 +95,19 @@ spec:
                           - name: TS_STATE_DIR
                             value: /data/tailscale
                         securityContext:
+                          allowPrivilegeEscalation: false
                           capabilities:
-                            add: ["NET_ADMIN"]
+                            drop:
+                              - ALL
+                            add:
+                              - NET_ADMIN
+                          # readOnlyRootFilesystem/runAsUser intentionally
+                          # left unset: kernel-mode tailscaled
+                          # (TS_USERSPACE=false) needs root to configure
+                          # /dev/net/tun and may write its control socket
+                          # outside the /data/tailscale mount (e.g. /tmp or
+                          # /var/run); can't verify either is safe without a
+                          # live cluster
                         resources:
                           requests:
                             cpu: 50m


### PR DESCRIPTION
## Summary
Second batch of the Plan A / A9 securityContext standardization series. Verified against real chart source and `helm template` renders (cloned upstream chart repos at the pinned versions).

- **jellyfin**: full profile including `readOnlyRootFilesystem: true` (confirmed safe — the existing `persistence.config` PVC covers Jellyfin's config/cache/log/transcodes, all written under `/config`). `runAsUser`/`runAsNonRoot` deliberately left unset: the existing openebs-hostpath PVC data was written by the image's default (root) user, and there's no live cluster here to verify a UID switch won't hit permission-denied on it.
- **portainer**: this chart has **never** supported `securityContext` via values at any version (verified empty across the chart's full git history) — hardened via a second strategic-merge `postRenderer` patch instead (same mechanism already used for the hand-written tailscale sidecar). Only `allowPrivilegeEscalation: false` + `capabilities.drop: [ALL]` applied; `readOnlyRootFilesystem` skipped (Enterprise Edition features like git-based stack deploy and backup/restore may use `/tmp`) and no UID forced (existing BoltDB data ownership). Also hardened the tailscale sidecar itself the same way, plus explicit `capabilities.drop: [ALL]` before re-adding `NET_ADMIN` — `readOnlyRootFilesystem`/`runAsUser` left alone there too since kernel-mode tailscaled needs root for `/dev/net/tun` and may write its control socket outside the mounted state dir.
- **semaphore**: this chart's key names are **inverted** from the usual convention (`securityContext` renders pod-level, `podSecurityContext` renders container-level — verified via template render). Only `allowPrivilegeEscalation: false` + `capabilities.drop: [ALL]` applied; `readOnlyRootFilesystem` skipped (ansible/terraform tool caches invoked by jobs may write to `$HOME`, which the chart doesn't set) and no UID forced (existing workdir PVC ownership).

Every skipped field is a documented, verify-after-rollout caveat (inline comments in each file) rather than a silent gap.

## Test plan
- [x] YAML syntax validated, including the embedded postRenderer patch string parsed separately
- [x] Values verified against real `helm template` output on cloned upstream chart sources at the exact pinned versions
- [ ] CI (yamllint + KubeLinter + kustomize build + kubenuc/k8s-vms e2e)
- [ ] Manual verification post-merge: jellyfin starts and can read/write its existing `/config` data; portainer starts, BoltDB is readable, and a git-based stack deploy / backup-restore still works; tailscale sidecar reconnects; semaphore can still run an ansible/terraform job without HOME-write failures


---
_Generated by [Claude Code](https://claude.ai/code/session_013E8ocpdkiRcfaAGXUwqTiy)_