### PR TITLE
feat(security): complete A9 securityContext standardization (harbor, jenkins, nextcloud, authentik, zitadel)

### DIFF
--- a/clusters/kubenuc/apps/jenkins/manifests/release.yml
+++ b/clusters/kubenuc/apps/jenkins/manifests/release.yml
@@ -47,6 +47,13 @@ spec:
             - ${JENKINS_HOST}
 
     agent:
+      # Chart's own opt-in restricted-PSS securityContext - build agents run
+      # arbitrary pipeline-defined code and get no securityContext at all by
+      # default (unlike the controller, which is already hardened
+      # out-of-the-box). Some job types that write outside the workspace
+      # volume (e.g. tool caches under $HOME) may need adjustment after
+      # rollout - not verifiable without a live cluster.
+      restrictedPssSecurityContext: true
       resources:
         requests:
           cpu: "512m"

--- a/clusters/kubenuc/apps/nextcloud/manifests/release.yml
+++ b/clusters/kubenuc/apps/nextcloud/manifests/release.yml
@@ -53,6 +53,19 @@ spec:
       podSecurityContext:
         fsGroup: 33
         fsGroupChangePolicy: "OnRootMismatch"
+      # readOnlyRootFilesystem intentionally not set: entrypoint.sh writes
+      # /usr/local/etc/php/conf.d/redis-session.ini on every start (REDIS_HOST
+      # is set), and apache2-foreground writes /var/run/apache2 +
+      # /var/lock/apache2 - none of these are covered by existing mounts.
+      # runAsUser intentionally not set: the existing 160Gi PVC was written
+      # by the image's default www-data (uid 33, matched by fsGroup above);
+      # no live cluster to verify a UID switch is safe
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        runAsNonRoot: true
 
     resources:
       requests:
@@ -115,9 +128,19 @@ spec:
           memory: 512Mi
     cronjob:
       enabled: true
-      securityContext:
-        fsGroup: 33
-        fsGroupChangePolicy: "OnRootMismatch"
+      # cronjob.securityContext was a dead no-op key - the chart only reads
+      # cronjob.sidecar.securityContext (container-level) when cronjob.type
+      # is unset/"sidecar" (the default, and what this deployment actually
+      # runs - no separate CronJob resource exists). Pod-level fsGroup is
+      # already inherited from nextcloud.podSecurityContext above, shared
+      # pod-wide with the sidecar container. runAsNonRoot intentionally NOT
+      # set - the chart's own docs state crond requires root in sidecar mode.
+      sidecar:
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
     nginx:
       enabled: false
       securityContext:

--- a/clusters/kubenuc/apps/sso/manifests/release.yml
+++ b/clusters/kubenuc/apps/sso/manifests/release.yml
@@ -28,9 +28,17 @@ spec:
   values:
     server:
       replicas: 3
+      # Previous value (server.containerSecurityContext.securityContext.*)
+      # was a confirmed no-op - "securityContext" isn't a valid nested field
+      # of v1.SecurityContext, so readOnlyRootFilesystem was never actually
+      # enforced. Correct key is one level shallower.
       containerSecurityContext:
-        securityContext:
-          readOnlyRootFilesystem: true
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
       initContainers:
         - name: check-db-ready
           image: postgres:17@sha256:5c855ad7b85e68e48a62f34662853f38b57c1c1d80f3a927ab58034fd6d31c5e
@@ -99,6 +107,23 @@ spec:
               - ${SSO_AUTHENTIK_HOST}
 
     global:
+      # Required for readOnlyRootFilesystem above: AUTHENTIK_STORAGE__FILE__PATH
+      # defaults to /data (icons, CSV report exports - not mounted by the
+      # chart otherwise), and Django's file-upload handling falls back to
+      # /tmp for uploads over the in-memory threshold. Using emptyDir here
+      # doesn't change persistence characteristics: without this mount,
+      # writes to these paths already went to the container's ephemeral
+      # writable layer, lost on restart exactly the same as an emptyDir.
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: data
+          emptyDir: {}
+      volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: data
+          mountPath: /data
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone
@@ -142,6 +167,13 @@ spec:
 
     worker:
       replicas: 3
+      containerSecurityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
       requests:
         cpu: 500m
         memory: 1Gi

--- a/clusters/kubenuc/apps/sso/manifests/zitadel.yml
+++ b/clusters/kubenuc/apps/sso/manifests/zitadel.yml
@@ -27,6 +27,19 @@ spec:
     remediation:
       retries: 5
   values:
+    # Chart-wide root key, not zitadel.securityContext - Helm's normal deep
+    # merge combines these with the chart's own existing defaults
+    # (runAsNonRoot, runAsUser:1000, readOnlyRootFilesystem:true,
+    # privileged:false - already safe today, no local PVC) rather than the
+    # component-level zitadel.securityContext key, which is a full replace
+    # not a merge. Root level also automatically covers the login
+    # Deployment and every init/setup/cleanup Job, which have no
+    # component-level override of their own.
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
     login:
       enabled: false
     ingress:


### PR DESCRIPTION
## Summary
Completes the Plan A / A9 securityContext standardization series (batch 3, all 5 remaining complex/high-stakes apps). Verified against real chart source and `helm template` renders (cloned upstream chart repos at the pinned versions, cross-checked with multiple independent research passes given the stakes).

- **jenkins**: the controller (main container, init container, JCasC config-reload sidecar) already runs with `readOnlyRootFilesystem: true`, `allowPrivilegeEscalation: false`, and non-root uid 1000 by **chart default** — no change needed there. The real gap is **build agents**, which get zero securityContext at all by default (agent pod specs are generated dynamically by the Kubernetes plugin at build time, not rendered as a static chart resource). Enabled the chart's own opt-in `agent.restrictedPssSecurityContext: true` toggle.
- **harbor**: audited, **no values change**. The chart applies one shared `containerSecurityContext` key identically to every component and already ships `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`, `runAsNonRoot: true` by default. `readOnlyRootFilesystem` is chart-wide (not per-component) and portal specifically needs a `/tmp` emptyDir the chart doesn't mount (confirmed via its own nginx configmap pointing temp paths there) — jobservice/registry/trivy also need write-path verification. Deferred to a follow-up using per-Deployment Kustomize `postRenderer` patches.
- **nextcloud**: added `allowPrivilegeEscalation: false` + `capabilities.drop: [ALL]` + `runAsNonRoot: true` for the main container. `readOnlyRootFilesystem` skipped — `entrypoint.sh` writes `/usr/local/etc/php/conf.d/redis-session.ini` on every start and Apache writes `/var/run/apache2`/`/var/lock/apache2`, none covered by existing mounts. No UID forced (existing 160Gi PVC owned by the image's default www-data/uid 33). Also fixed a **dead no-op key**: `cronjob.securityContext` was never read by the chart in sidecar mode (the default this deployment runs) — corrected to `cronjob.sidecar.securityContext`, without `runAsNonRoot` since the chart's own docs state crond requires root in sidecar mode.
- **authentik**: fixed a **confirmed no-op bug** — `server.containerSecurityContext.securityContext.readOnlyRootFilesystem` had an invalid extra nesting level and was never actually enforced. Corrected to the real flat key path for both `server` and `worker`, added the full safe profile including `readOnlyRootFilesystem` with the required `/tmp` and `/data` emptyDir mounts (`AUTHENTIK_STORAGE__FILE__PATH` defaults to `/data` for icons/report exports since no S3 backend is configured) — these emptyDirs don't change persistence characteristics since those writes were already ephemeral without them.
- **zitadel**: added `allowPrivilegeEscalation: false` + `capabilities.drop: [ALL]` at the **chart-wide root** `securityContext` key rather than the component-level `zitadel.securityContext` (which does a full replace, not a merge, and would silently regress the chart's own existing hardened defaults — `runAsNonRoot`, `runAsUser: 1000`, `readOnlyRootFilesystem: true` — unless the whole block is restated). Root level merges cleanly and also automatically covers the `login` Deployment and every init/setup/cleanup Job.

## Test plan
- [x] YAML syntax validated
- [x] Values verified against real `helm template` output on cloned upstream chart sources at the exact pinned versions, cross-checked by independent research passes given these are all existing production apps with real data
- [x] CI (yamllint + KubeLinter + kustomize build + kubenuc e2e)
- [ ] Manual verification post-merge: Jenkins agent pods still run pipelines; nextcloud/authentik/zitadel start cleanly and remain reachable through SSO/ingress; authentik icon/report generation and file uploads still work with the new emptyDir mounts
