### PR TITLE
docs(security): A10 low-priority sweep - seaweedfs SSH, multitenancy, RBAC audit

### DIFF
--- a/ansible/seaweedfs/inventory.yml
+++ b/ansible/seaweedfs/inventory.yml
@@ -2,6 +2,14 @@ all:
   children:
     seaweedfs:
       hosts:
+        # TODO(security): these are the only hosts in the repo using
+        # ansible_user: root directly. No non-root sudo user with SSH key
+        # access exists on either host yet (confirmed 2026-07) - switching
+        # to a sudo user + become requires provisioning that user
+        # out-of-band first (root SSH access to create it, distribute an
+        # SSH key, and grant passwordless sudo), which can't be done from
+        # this environment. Provision the user, then flip ansible_user
+        # here and add `become: true` to the seaweedfs playbook.
         seaweedfs-rabbit:
           ansible_host: 10.10.20.106
           ansible_user: root

--- a/clusters/k3s-rabbit/flux-instance.yaml
+++ b/clusters/k3s-rabbit/flux-instance.yaml
@@ -33,6 +33,10 @@ spec:
     - notification-controller
   cluster:
     type: kubernetes
+    # Single-tenant by design: one team/owner operates this cluster, no
+    # per-namespace Flux RBAC isolation between tenants is required.
+    # Multi-tenant mode would add tenant-scoped ServiceAccounts/RBAC that
+    # this repo's single-operator model doesn't need.
     multitenant: false
     networkPolicy: true
     domain: "cluster.local"

--- a/clusters/k8s-vms-daniele/flux-instance.yaml
+++ b/clusters/k8s-vms-daniele/flux-instance.yaml
@@ -14,6 +14,10 @@ spec:
     - notification-controller
   cluster:
     type: kubernetes
+    # Single-tenant by design: one team/owner operates this cluster, no
+    # per-namespace Flux RBAC isolation between tenants is required.
+    # Multi-tenant mode would add tenant-scoped ServiceAccounts/RBAC that
+    # this repo's single-operator model doesn't need.
     multitenant: false
     networkPolicy: true
     domain: "cluster.local"

--- a/clusters/kubenuc/flux-instance.yaml
+++ b/clusters/kubenuc/flux-instance.yaml
@@ -14,6 +14,10 @@ spec:
     - notification-controller
   cluster:
     type: kubernetes
+    # Single-tenant by design: one team/owner operates this cluster, no
+    # per-namespace Flux RBAC isolation between tenants is required.
+    # Multi-tenant mode would add tenant-scoped ServiceAccounts/RBAC that
+    # this repo's single-operator model doesn't need.
     multitenant: false
     networkPolicy: true
     domain: "cluster.local"

--- a/clusters/oc-ampere/flux-instance.yaml
+++ b/clusters/oc-ampere/flux-instance.yaml
@@ -14,6 +14,10 @@ spec:
     - notification-controller
   cluster:
     type: kubernetes
+    # Single-tenant by design: one team/owner operates this cluster, no
+    # per-namespace Flux RBAC isolation between tenants is required.
+    # Multi-tenant mode would add tenant-scoped ServiceAccounts/RBAC that
+    # this repo's single-operator model doesn't need.
     multitenant: false
     networkPolicy: true
     domain: "cluster.local"


### PR DESCRIPTION
## Summary
Final PR of the Plan A security hardening series (A10, low-priority sweep).

- **ansible/seaweedfs/inventory.yml**: documented (did not change) the root SSH gap — this is the only inventory in the repo using `ansible_user: root` directly. Confirmed no non-root sudo user with SSH key access exists yet on either host (`seaweedfs-rabbit`, `seaweedfs-hpelvisor`), so switching now would break access. Added a `TODO` explaining the provisioning prerequisite (create the user + distribute an SSH key + grant passwordless sudo, out-of-band) rather than forcing an unverifiable change.
- **clusters/*/flux-instance.yaml** (all 4 clusters — kubenuc, oc-ampere, k8s-vms-daniele, k3s-rabbit): documented the `multitenant: false` decision inline as a comment — single-tenant by design, one operator, no per-namespace Flux RBAC isolation needed. Not added to `clusters/CLAUDE.md` since that file's rewrite is owned by a separate, already-planned change (avoiding a conflict).
- **RBAC audit**: searched the repo for `ClusterRoleBinding`s granting `cluster-admin`. Only two exist, both in the legacy Flux classic-bootstrap manifests for the ephemeral test clusters (`kubenuc-test`, `k3s-prod-test`), both bound exclusively to Flux's own `kustomize-controller`/`helm-controller` ServiceAccounts — the standard, expected Flux RBAC pattern. No unexpected grants found, nothing to trim.

**Noted for the record, explicitly out of scope:**
- cosign/image-verification — no admission controller is in place to enforce it; a separate initiative if pursued.
- Moving local `age-*.agekey` files to `~/.config/sops/age/` is a manual operator hygiene step, not a repo change (the files are gitignored and never in git history already).

This completes **Plan A** (Security Hardening) in full: A1 (fork-PR guard), A3 (gitleaks), A4 (SHA-pinning), A5 (CODEOWNERS/apply gate), A6 (checkov), A7 (Pod Security Standards), A8 (NetworkPolicies, all namespaces), A9 (securityContext standardization, all ~25 HelmReleases), A10 (this PR).

## Test plan
- [x] YAML syntax validated
- [x] CI (yamllint + KubeLinter + kustomize build + kubenuc/k8s-vms e2e — these are comment-only/inline-documentation changes, no functional behavior change expected)


---
_Generated by [Claude Code](https://claude.ai/code/session_013E8ocpdkiRcfaAGXUwqTiy)_