### PR TITLE
feat(mcp): add project-scoped .mcp.json for graylog/grafana/netbox

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,28 @@
+{
+  "mcpServers": {
+    "graylog": {
+      "type": "http",
+      "url": "http://127.0.0.1:19000/api/mcp",
+      "headers": {
+        "Authorization": "Bearer ${GRAYLOG_MCP_TOKEN}"
+      }
+    },
+    "grafana": {
+      "type": "stdio",
+      "command": "mcp-grafana",
+      "env": {
+        "GRAFANA_URL": "${GRAFANA_URL}",
+        "GRAFANA_API_KEY": "${GRAFANA_API_KEY}"
+      }
+    },
+    "netbox": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["netbox-mcp-server"],
+      "env": {
+        "NETBOX_URL": "${NETBOX_URL}",
+        "NETBOX_TOKEN": "${NETBOX_TOKEN}"
+      }
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,12 @@ This repository uses **1Password** for all secrets:
 
 ---
 
+## Claude Code MCP Servers
+
+The project-scoped `.mcp.json` at the repo root configures Graylog, Grafana, and NetBox MCP servers for observability/troubleshooting and infra-inventory lookups. It references credentials via env vars only (`${GRAYLOG_MCP_TOKEN}`, `${GRAFANA_URL}`, `${GRAFANA_API_KEY}`, `${NETBOX_URL}`, `${NETBOX_TOKEN}`) — no tokens are committed. See the README's "Claude Code MCP Setup" section for how to export them from 1Password before starting a session. NetBox access through this MCP is **read-only** by convention — inventory writes always go through `terraform/netbox/*.tf` PRs, never a direct MCP write (see the `documentation` skill).
+
+---
+
 ## Commit Message Conventions
 
 Follow semantic commit format (consistent with Renovate and existing history):

--- a/README.md
+++ b/README.md
@@ -67,6 +67,20 @@ Reusable modules published as standalone repositories:
 | Hetzner Server | [dark-vex/terraform-hetzner-server](https://github.com/dark-vex/terraform-hetzner-server) | `github.com/dark-vex/terraform-hetzner-server?ref=vX.Y.Z` |
 | Cloudflare DNS | [dark-vex/terraform-cloudflare-dns](https://github.com/dark-vex/terraform-cloudflare-dns) | `github.com/dark-vex/terraform-cloudflare-dns?ref=vX.Y.Z` |
 
+## Claude Code MCP Setup
+
+This repo ships a project-scoped `.mcp.json` (Graylog, Grafana, NetBox) with env-var references only — no tokens are committed. Export the required variables before starting Claude Code, e.g. from 1Password:
+
+```sh
+export GRAYLOG_MCP_TOKEN="$(op read op://<vault>/<graylog-item>/token)"
+export GRAFANA_URL="$(op read op://<vault>/<grafana-item>/url)"
+export GRAFANA_API_KEY="$(op read op://<vault>/<grafana-item>/api-key)"
+export NETBOX_URL="$(op read op://<vault>/<netbox-item>/url)"
+export NETBOX_TOKEN="$(op read op://<vault>/<netbox-item>/token)"
+```
+
+Replace the placeholder `op://` paths above with your actual 1Password vault/item names — real paths aren't committed here since internal identifiers are treated as sensitive per this repo's conventions. `mcp-grafana` must be installed and on `PATH`; the NetBox MCP server runs via `uvx netbox-mcp-server` (no separate install needed beyond `uv`).
+
 ## TODO
 
 - Implement ExternalDNS — in progress, dev cluster (`k8s-vms-daniele`) deployed in PR #1536; see the [External DNS runbook](https://fastnetserv.atlassian.net/wiki/spaces/IT/pages/774012929/External+DNS)


### PR DESCRIPTION
## Summary
Fourth PR of Plan B (per the plan's priority order B1 > B2 > B4 > B3 > B5 > B6 > B7, and lands after A3's gitleaks as an interlock against token commits).

Adds a root `.mcp.json` configuring 3 MCP servers, env-var references only — no literal tokens or internal hostnames committed:
- **graylog**: http transport, local endpoint (`127.0.0.1:19000/api/mcp`), bearer auth via `${GRAYLOG_MCP_TOKEN}`
- **grafana**: `mcp-grafana` stdio binary (must be on `PATH`), `${GRAFANA_URL}` + `${GRAFANA_API_KEY}`
- **netbox**: `uvx netbox-mcp-server`, `${NETBOX_URL}` + `${NETBOX_TOKEN}`

Documented the 1Password env-var export pattern in a new "Claude Code MCP Setup" section in `README.md`, cross-referenced from root `CLAUDE.md`, using placeholder `op://` vault/item paths only (per this repo's policy on internal identifiers).

**Note**: no `clusters/.claude/settings.local.json` exists in this repo to migrate a Grafana/Loki tool allowlist from — checked, that part of the original plan was based on a different environment's local state, so it's a no-op here.

## Test plan
- [x] JSON syntax validated
- [x] `gitleaks detect` run locally on the full working tree — no leaks found
- [x] CI (gitleaks workflow + yamllint/KubeLinter, though this PR touches no cluster manifests)
- [ ] Manual verification: `.mcp.json` loads successfully with the env vars exported


---
_Generated by [Claude Code](https://claude.ai/code/session_013E8ocpdkiRcfaAGXUwqTiy)_