### PR TITLE
feat(agents): add tools/model frontmatter to the 3 agents

### DIFF
--- a/.claude/agents/ansible-agent.md
+++ b/.claude/agents/ansible-agent.md
@@ -1,6 +1,8 @@
 ---
 name: ansible-agent
 description: Ansible specialist agent. Use for running Ansible playbooks, linting, inventory management, and OS/device configuration tasks. Runs in an isolated Docker container with Ansible and common collections installed. Replaces AWX for ad-hoc automation tasks.
+tools: Bash, Read, Grep, Glob
+model: haiku
 ---
 
 # Ansible Agent

--- a/.claude/agents/kubernetes-agent.md
+++ b/.claude/agents/kubernetes-agent.md
@@ -1,6 +1,8 @@
 ---
 name: kubernetes-agent
 description: Kubernetes/Helm/FluxCD specialist agent. Use for kubectl operations, helm template rendering, flux manifest validation, kustomize builds, and GitOps troubleshooting. Runs in an isolated Docker container with kubectl, helm, flux, and kustomize installed.
+tools: Bash, Read, Grep, Glob, mcp__grafana__query_loki_logs, mcp__grafana__query_prometheus, mcp__grafana__search_dashboards, mcp__graylog
+model: sonnet
 ---
 
 # Kubernetes / Helm / FluxCD Agent
@@ -42,6 +44,10 @@ All cluster configs mounted read-only at `/workspace/clusters/`:
 - `/workspace/clusters/k8s-vms-daniele/`
 - `/workspace/clusters/k3s-prod-test/`
 - `/workspace/clusters/common/`
+
+## Observability routing
+
+For diagnosing a down/crashlooping/erroring/slow app, follow the `app-troubleshooting` skill's decision tree rather than improvising a log/metrics query order — it covers Graylog vs. Loki routing per cluster, Prometheus label-scoping (10K active-series budget), and the Flux-state correlation steps. This agent's role in that flow is the kubectl/kustomize/helm/flux fallback (`describe pod`, `get events`, `logs --previous`, `kustomize build`) when the pod never reached a log pipeline at all.
 
 ## Notes
 

--- a/.claude/agents/terraform-agent.md
+++ b/.claude/agents/terraform-agent.md
@@ -1,6 +1,8 @@
 ---
 name: terraform-agent
 description: Terraform specialist agent. Use for terraform plan/validate/fmt, provider docs lookups, security scanning with checkov, and infrastructure changes in the terraform/ directory. Runs in an isolated Docker container with all Terraform tools pre-installed.
+tools: Bash, Read, Grep, Glob, mcp__netbox__netbox_get_objects, mcp__netbox__netbox_search_objects, mcp__grafana__get_dashboard_by_uid
+model: sonnet
 ---
 
 # Terraform Agent
@@ -52,6 +54,8 @@ All Terraform environments are mounted read-only at `/workspace/terraform/`:
 
 ## Notes
 
+- Use the NetBox MCP tools (read-only) to verify current inventory state before editing `terraform/netbox/*.tf` — NetBox writes always go through a Terraform PR, never a direct MCP write (see the `documentation` skill)
+- Use `mcp__grafana__get_dashboard_by_uid` to check existing dashboards before adding new ones under `terraform/grafana/`
 - Terraform state is in Terraform Cloud (Fastnetserv org) — `terraform init` requires `TF_API_TOKEN`
 - 1Password provider requires `OP_TOKEN` and `OP_ENDPOINT` env vars
 - Always run `terraform fmt -check` before committing


### PR DESCRIPTION
## Summary
Third PR of Plan B (per priority order B1 > B2 > B4 > B3 > B5 > B6 > B7). None of the 3 agents had `tools:`/`model:` frontmatter before.

- **kubernetes-agent**: `Bash, Read, Grep, Glob` + Grafana Loki/Prometheus/dashboard-search + graylog (kubenuc log source). `model: sonnet`. Added an "Observability routing" section that references the `app-troubleshooting` skill's decision tree rather than duplicating it — this agent's role there is the kubectl/kustomize/helm/flux fallback for when a pod never reached a log pipeline at all.
- **terraform-agent**: `Bash, Read, Grep, Glob` + NetBox read-only lookups (verify inventory state before editing `terraform/netbox/*.tf` — writes always go through a Terraform PR, never a direct MCP write, per the `documentation` skill) + Grafana dashboard lookup for `terraform/grafana/`. `model: sonnet`.
- **ansible-agent**: `Bash, Read, Grep, Glob` only, no MCP write tools. `model: haiku` (simpler playbook/inventory tasks, no observability routing needed).

## Test plan
- [x] Frontmatter YAML validated for all 3 files
- [x] CI (docs-only change, no functional cluster/terraform impact expected)


---
_Generated by [Claude Code](https://claude.ai/code/session_013E8ocpdkiRcfaAGXUwqTiy)_