### PR TITLE
docs: rewrite stale clusters/CLAUDE.md for Flux Operator reality

### DIFF
--- a/clusters/CLAUDE.md
+++ b/clusters/CLAUDE.md
@@ -2,39 +2,47 @@
 
 ## Kubernetes Clusters
 
-| Cluster | Type | Purpose |
-|---|---|---|
-| `kubenuc` | Bare metal (HP ProLiant) | Primary production — 3 control plane + 3 workers |
-| `kubenuc-test` | Bare metal | Pre-production testing |
-| `k3s-prod-test` | k3s | Production-like test environment |
-| `k3s-rabbit` | k3s | Rabbit server cluster |
-| `k8s-vms-daniele` | VMs | Development cluster |
-| `oc-ampere` | OpenShift | Ampere ARM-based cluster |
+| Cluster | Type | Purpose | Flux bootstrap |
+|---|---|---|---|
+| `kubenuc` | Bare metal (HP ProLiant) | Primary production — 3 control plane + 3 workers | Flux Operator (`FluxInstance`) |
+| `kubenuc-test` | Bare metal | Pre-production testing, overlays `kubenuc` manifests | Legacy classic bootstrap (`flux-system/`) |
+| `k3s-prod-test` | k3s | Production-like test environment, independent manifests | Legacy classic bootstrap (`flux-system/`) |
+| `k3s-rabbit` | k3s | Rabbit server cluster | Flux Operator (`FluxInstance`) |
+| `k8s-vms-daniele` | VMs | Development cluster | Flux Operator (`FluxInstance`) |
+| `oc-ampere` | k3s (OCI, ARM/Ampere) | Teleport agent only | Flux Operator (`FluxInstance`) |
 
 ---
 
 ## Cluster Configuration Conventions
 
-Each cluster under `clusters/{cluster-name}/` follows this structure:
+Four of the six clusters (`kubenuc`, `k3s-rabbit`, `k8s-vms-daniele`, `oc-ampere`) are managed by the **Flux Operator** via a `FluxInstance` custom resource — there is no `flux-system/` bootstrap directory for these, and no classic `flux bootstrap`-generated manifests in the repo. `kubenuc-test` and `k3s-prod-test` are the two remaining holdouts still on the legacy classic-bootstrap pattern (`flux-system/gotk-components.yaml` + `gotk-sync.yaml`, committed in-repo); don't assume every cluster has a `flux-system/` directory.
 
 ```
 clusters/{cluster-name}/
-├── flux-system/            # FluxCD bootstrap and Kustomization
-├── apps.yaml               # Top-level app Kustomization
-├── charts.yaml             # HelmRepository Kustomization
+├── flux-instance.yaml      # FluxInstance CRD (Flux Operator clusters only)
+├── flux-system/            # Legacy classic-bootstrap clusters only (kubenuc-test, k3s-prod-test)
+├── cluster-vars.yaml       # Reference to the SOPS-encrypted cluster-vars Secret
+├── vars/
+│   └── cluster-vars.sops.yaml
+├── apps.yaml               # Top-level Kustomization -> ./apps/ (interval: 10m)
+├── charts.yaml             # Top-level Kustomization -> ./charts/ (interval: 5m; 1m on
+│                           # k3s-rabbit/k8s-vms-daniele/oc-ampere is known pending debt,
+│                           # not a documentation error — see Plan C interval-policy work)
+├── charts/
+│   └── {repo-name}.yml     # HelmRepository manifests
 └── apps/
     └── {app-name}/
-        ├── deploy.yaml     # HelmRelease or Kustomization manifest
-        ├── secrets/        # 1Password-backed SecretStore/ExternalSecret
-        └── manifests/      # Additional raw Kubernetes manifests
+        ├── deploy.yaml     # Per-app Kustomization (interval: 15m), healthChecks the HelmRelease
+        ├── secrets/        # 1Password-backed OnePasswordItem CRDs
+        └── manifests/      # HelmRelease (interval: 15m) + any raw Kubernetes manifests
 ```
 
 **Key conventions:**
 - Each application lives in its own directory under `apps/`
-- Dependencies are declared explicitly in Kustomization `.spec.dependsOn`
+- Dependencies are declared explicitly in the per-app Kustomization's `.spec.dependsOn`, not in the HelmRelease
 - Common pattern: storage (OpenEBS) → database (PostgreSQL) → application
-- Sync intervals vary by component: `5m` for apps, `15m` for charts
-- All secrets use 1Password ExternalSecrets — **never commit raw secrets**
+- Sync intervals in practice: `charts.yaml` `5m`, `apps.yaml` `10m`, per-app Kustomization/HelmRelease `15m` — never go below `5m` anywhere without a documented reason
+- All secrets use 1Password `OnePasswordItem`/`ExternalSecret` — **never commit raw secrets**
 
 ---
 
@@ -42,20 +50,22 @@ clusters/{cluster-name}/
 
 ### Add a new application to a cluster
 
-1. Create `clusters/{cluster}/apps/{app-name}/deploy.yaml` with a `HelmRelease` or `Kustomization`
-2. Add secrets under `clusters/{cluster}/apps/{app-name}/secrets/` using `OnePasswordItem` CRDs
-3. Add `dependsOn` if the app requires storage or a database
-4. Reference the new directory in `clusters/{cluster}/apps.yaml` Kustomization
+1. Create `clusters/{cluster}/apps/{app-name}/deploy.yaml` with a per-app `Kustomization` (path -> `./manifests`, `healthChecks` referencing the `HelmRelease`)
+2. Add the `HelmRelease` under `clusters/{cluster}/apps/{app-name}/manifests/release.yml`
+3. Add secrets under `clusters/{cluster}/apps/{app-name}/secrets/` using `OnePasswordItem` CRDs
+4. Add `dependsOn` in the Kustomization if the app requires storage or a database
+5. No `kustomization.yaml` edit needed in most cases — Flux/kustomize auto-discovers all YAML files in a path when no `kustomization.yaml` exists there
 
 ### Add a new Helm repository
 
 1. Add a `HelmRepository` manifest under `clusters/{cluster}/charts/`
-2. Reference it in `clusters/{cluster}/charts.yaml`
+2. It's auto-discovered by `clusters/{cluster}/charts.yaml`'s Kustomization (same auto-discovery as above)
 3. Use the repository source in `HelmRelease` specs via `sourceRef`
 
 ### Update FluxCD components
 
-Renovate auto-PRs FluxCD component bumps — do not manually edit `clusters/{cluster}/flux-system/` files unless fixing a bootstrap issue.
+- **Flux Operator clusters** (`kubenuc`, `k3s-rabbit`, `k8s-vms-daniele`, `oc-ampere`): Renovate auto-PRs `flux-instance.yaml` version bumps (`spec.distribution.version`) — do not manually edit unless fixing a bootstrap issue.
+- **Legacy classic-bootstrap clusters** (`kubenuc-test`, `k3s-prod-test`): Renovate auto-PRs `flux-system/gotk-components.yaml` bumps — same rule, don't hand-edit outside a bootstrap fix.
 
 ---
 
@@ -63,9 +73,10 @@ Renovate auto-PRs FluxCD component bumps — do not manually edit `clusters/{clu
 
 | Workflow | Trigger | Purpose |
 |---|---|---|
-| `validate-kubenuc.yml` | PR | Full cluster E2E validation (2h timeout) |
-| `validate-k8s-vms.yml` | PR | K8s VMs cluster validation |
-| `security-static-analysis.yml` | PR/push to `clusters/**` | KubeLinter static analysis across all cluster apps |
+| `validate-kubenuc.yml` | PR | Full `kubenuc` cluster E2E validation (2h timeout) |
+| `validate-k8s-vms.yml` | PR | `k8s-vms-daniele` cluster validation |
+| `security-static-analysis.yml` | PR/push to `clusters/**` | KubeLinter static analysis + checkov across all cluster apps |
+| `gitleaks.yml` | PR/push to `main` | Secret scanning |
 
 PR validation runs k3s + Flux CD with a 2-hour timeout. Robot Framework E2E tests via `tests/robot/robot-test-job.yaml`.
 


### PR DESCRIPTION
## Summary
Fifth PR of Plan B. The file documented a `flux-system/` bootstrap dir on every cluster and `5m`/`15m` intervals that no longer matched the repo. Rewrote it against the actual manifests rather than trusting the old notes:

- **4 of 6 clusters** (`kubenuc`, `k3s-rabbit`, `k8s-vms-daniele`, `oc-ampere`) use the **Flux Operator** `FluxInstance` CRD — no `flux-system/` dir at all. `kubenuc-test` and `k3s-prod-test` are the only two still on the legacy classic-bootstrap pattern (`flux-system/gotk-components.yaml` + `gotk-sync.yaml`).
- **Real intervals**: `charts.yaml` `5m` (`1m` on `k3s-rabbit`/`k8s-vms-daniele`/`oc-ampere` — noted as known pending debt, not a doc error, tracked separately in Plan C), `apps.yaml` `10m`, per-app Kustomization/HelmRelease `15m`.
- Corrected the cluster table (`oc-ampere` is k3s on OCI/ARM, not OpenShift) and the "add a new application"/"update FluxCD components" recipes to match the actual per-app Kustomization + HelmRelease pattern and Flux's auto-discovery (no `kustomization.yaml` needed in most app directories).
- CI workflow table: added `gitleaks.yml`, noted `security-static-analysis.yml` now also runs checkov (both landed in Plan A).

This file is the sole authority for `clusters/`-level conventions — no other PR in Plan A/B/C touches it; app-specific notes go in the per-cluster `CLAUDE.md` files instead (e.g. `clusters/kubenuc/CLAUDE.md`).

## Test plan
- [x] Verified every claim against real repo state (`ls`/`grep` across all 6 cluster directories, actual interval values, actual workflow files)
- [x] CI (docs-only change, no functional impact expected)


---
_Generated by [Claude Code](https://claude.ai/code/session_013E8ocpdkiRcfaAGXUwqTiy)_