### PR TITLE
feat(skills): add renovate-pr-review and grafana-cardinality-guard skills

### DIFF
--- a/.claude/skills/grafana-cardinality-guard/SKILL.md
+++ b/.claude/skills/grafana-cardinality-guard/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: grafana-cardinality-guard
+description: Before adding any new Prometheus scrape target or exporter, check the active-series budget in Grafana Cloud and propose write_relabel drops if needed. Triggers on "add a scrape config", "add an exporter", "enable metrics for X", "add a ServiceMonitor". Gates any change that could grow active series count.
+---
+
+# Grafana Cardinality Guard Skill
+
+This repo has a **hard 10K active-series budget** in Grafana Cloud (kubenuc's `grafana-alloy` HelmRelease already carries an extensive `write_relabel_config` drop-list purely to stay under it — see `clusters/kubenuc/apps/grafana-alloy/manifests/release.yml`). Use this skill **before** any PR adds a new Prometheus scrape target, exporter, `ServiceMonitor`, or enables `metrics.enabled` on a chart that was previously unscraped.
+
+## Steps
+
+1. **Query current active series.** Use `mcp__grafana__query_prometheus` against `count({__name__=~".+"})` (or the equivalent cardinality query for this Grafana Cloud stack) to get today's baseline before making any change.
+2. **Estimate the delta.** For a new exporter/scrape target, estimate how many distinct series it will add — check the exporter's own `/metrics` endpoint cardinality if reachable, or a documented series count from the exporter's project docs. Multiply by label cardinality if the target has per-pod/per-namespace label dimensions that will fan out.
+3. **Compare against the cap.** If baseline + estimated delta would approach or exceed 10K, this is a blocker, not a nice-to-have fix later.
+4. **Propose `write_relabel_config` drops.** Follow the existing pattern in `clusters/kubenuc/apps/grafana-alloy/manifests/release.yml`'s `destinations.grafanaCloudMetrics.metricProcessingRules` — each rule is a `write_relabel_config` block with `source_labels`, a `regex`, and `action = "drop"`. Propose the minimal drop-list needed to keep the new target's contribution small (e.g. drop per-container histogram buckets, drop high-cardinality debug/internal metrics) rather than dropping the whole target's metrics wholesale if only some of them matter.
+5. **Mirror to k8s-vms-daniele if relevant** — that cluster has its own, smaller `grafana-alloy` HelmRelease with its own `metricProcessingRules` block; a shared exporter added to both clusters needs the drop-list considered for each independently, since the budgets are not pooled.
+
+## When this skill gates other work
+
+Per this repo's Cluster Optimization plan, several changes are explicitly blocked on this check before being enabled:
+- Reloader (stakater) — disabling its own `ServiceMonitor` when installed, or confirming it doesn't add scrape targets
+- node-problem-detector — must be deployed **unscraped** (no `ServiceMonitor`), verified via this skill before install
+- Any VPA-recommender/right-sizing exercise — metrics-server is bundled in k3s already; adding a *new* scrape path for right-sizing needs this check first
+
+## Output contract
+
+Report: current baseline series count, estimated delta from the proposed change, whether it fits the budget, and (if not) the specific `write_relabel_config` blocks to add — as a diff against the target `release.yml`, not just a description.

--- a/.claude/skills/renovate-pr-review/SKILL.md
+++ b/.claude/skills/renovate-pr-review/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: renovate-pr-review
+description: Review a Renovate PR before merging — read the changelog, diff values against this repo's overrides, check e2e status, flag major bumps, and produce a merge checklist. Triggers on "review this renovate PR", "should I merge this chart bump", "is this renovate PR safe".
+---
+
+# Renovate PR Review Skill
+
+Use this skill when asked to review a Renovate-authored PR (Helm chart bump, Terraform provider/module bump, GitHub Action digest bump) before merging.
+
+## Review steps
+
+1. **Read the changelog.** Renovate PR bodies link the upstream release notes/changelog for the version range being bumped — follow that link (or `mcp__github__get_release_by_tag` / `search_commits` on the upstream repo if the PR body doesn't include one) and read what actually changed, not just the version numbers.
+2. **Diff values against this repo's overrides.** For a HelmRelease bump, check whether any values key this repo explicitly sets (`.spec.values` in the `release.yml`) was renamed, deprecated, or had its default/schema changed in the new chart version — a values key silently becoming a no-op is a real, historically-seen failure mode in this repo (see the `secrets-management` skill's example, and the A9 securityContext work, where wrong/renamed keys silently dropped intended config). For a Terraform provider bump, check the provider's changelog for breaking schema changes to resources/data sources this repo actually uses.
+3. **Check e2e status.** For anything touching `clusters/**`, confirm `validate-kubenuc.yml` / `validate-k8s-vms.yml` ran and passed — a green Renovate PR without e2e having run at all is not evidence of safety.
+4. **Flag majors.** A major version bump (chart `vX.0.0`, provider major) needs more scrutiny than a patch/minor — call this out explicitly in the review rather than treating all Renovate PRs the same.
+5. **Merge checklist.** Summarize as a short checklist: changelog reviewed (yes/no + any breaking changes found), values/schema compatibility checked, e2e status, major-bump flag, recommendation (merge / merge with a follow-up values fix / hold for manual testing).
+
+## Scope notes
+
+- Don't manually edit chart versions Renovate owns (see root `CLAUDE.md` rule 6) — this skill is for *reviewing* Renovate's own PRs, not hand-bumping versions.
+- If review turns up a required values change (e.g. a renamed key), make that fix as a **follow-up commit on the Renovate PR's branch** (or a separate PR if Renovate doesn't allow pushes to its branch) rather than blocking the bump indefinitely — see the `flux-operations` and chart-specific patterns in `terraform-operations`/`op-terraform` for the values conventions to preserve.


### PR DESCRIPTION
## Summary
Seventh and final PR of Plan B (optional, capped at 2 extra skills per the plan).

- **renovate-pr-review**: changelog read → values/schema diff against this repo's overrides → e2e status check → major-bump flag → merge checklist. Guards against a failure mode already seen in this repo — a chart's values key silently becoming a no-op across a version bump (the exact bug found and fixed twice during the A9 securityContext work).
- **grafana-cardinality-guard**: checks the 10K active-series budget before any PR adds a scrape target/exporter/`ServiceMonitor`, and proposes `write_relabel_config` drops following the existing pattern already used in `grafana-alloy`'s `release.yml`. This is a deliberate gate for the not-yet-started Cluster Optimization plan — Reloader, node-problem-detector, and the right-sizing exercise all need a cardinality check before landing, so building this now avoids a mid-plan detour later.

This completes **Plan B** (Claude Code Skills & Agents) in full: B1 (app-troubleshooting), B2 (documentation routing), B3 (agent frontmatter), B4 (`.mcp.json`), B5 (`clusters/CLAUDE.md` rewrite), B6 (skill migration/de-dup), B7 (this PR).

## Test plan
- [x] Frontmatter YAML validated for both skills
- [x] Confirmed both skills load and appear in the available-skills list in this session


---
_Generated by [Claude Code](https://claude.ai/code/session_013E8ocpdkiRcfaAGXUwqTiy)_