### PR TITLE
fix(backup): add writable workingDir for pg_dump under readOnlyRootFilesystem

### DIFF
--- a/clusters/kubenuc/apps/harbor/manifests/backup.yml
+++ b/clusters/kubenuc/apps/harbor/manifests/backup.yml
@@ -18,6 +18,11 @@ spec:
           - name: pgbackup
             image: ghcr.io/solectrus/postgres-s3-backup:17@sha256:3a5d281955fd6bcdbb97628979ab4df83243253e1f5ebe90b2db13b05d65eda5
             imagePullPolicy: IfNotPresent
+            # backup.sh writes `pg_dump ... > db.dump` as a relative path with
+            # no WORKDIR set in the image (inherits the postgres:alpine base's
+            # default, effectively /) - readOnlyRootFilesystem needs an
+            # explicit writable workingDir for that write to land somewhere
+            workingDir: /backup
             env:
             - name: S3_REGION
               value: "eu-south-1"
@@ -61,4 +66,10 @@ spec:
               readOnlyRootFilesystem: true
               runAsNonRoot: true
               runAsUser: 65532
+            volumeMounts:
+            - name: backup
+              mountPath: /backup
+          volumes:
+          - name: backup
+            emptyDir: {}
           restartPolicy: OnFailure

--- a/clusters/kubenuc/apps/nextcloud/manifests/backup.yml
+++ b/clusters/kubenuc/apps/nextcloud/manifests/backup.yml
@@ -14,6 +14,11 @@ spec:
           - name: pgbackup
             image: ghcr.io/solectrus/postgres-s3-backup:17@sha256:3a5d281955fd6bcdbb97628979ab4df83243253e1f5ebe90b2db13b05d65eda5
             imagePullPolicy: IfNotPresent
+            # backup.sh writes `pg_dump ... > db.dump` as a relative path with
+            # no WORKDIR set in the image (inherits the postgres:alpine base's
+            # default, effectively /) - readOnlyRootFilesystem needs an
+            # explicit writable workingDir for that write to land somewhere
+            workingDir: /backup
             env:
             - name: S3_REGION
               value: "eu-south-1"
@@ -66,4 +71,10 @@ spec:
               readOnlyRootFilesystem: true
               runAsNonRoot: true
               runAsUser: 65532
+            volumeMounts:
+            - name: backup
+              mountPath: /backup
+          volumes:
+          - name: backup
+            emptyDir: {}
           restartPolicy: OnFailure


### PR DESCRIPTION
## Summary
Plan C, item C4 — the highest-priority remaining item due to data-loss risk (silent weekly DB-backup failure). Diagnosed with the actual failure log from a recent run:

```
backup.sh: line 9: can't create db.dump: Read-only file system
```

Root cause confirmed against the actual `postgres-s3-backup` image source (`github.com/solectrus/postgres-s3-backup`): `backup.sh` does `pg_dump ... > db.dump` as a relative path, and the image's Dockerfile sets no `WORKDIR` (inherits the `postgres:alpine` base's default, effectively `/`). Both `nextcloud-db-backup` and `harbor-db-backup` CronJobs already set `readOnlyRootFilesystem: true` with no writable volume anywhere in the pod spec, so every run has been failing identically on both jobs — not an S3 credentials, postgres auth, or DNS issue as originally suspected.

**Fix**: explicit `workingDir: /backup` on the container, backed by a pod-level `emptyDir` mounted at `/backup`. `db.dump` (and `db.dump.gpg`, if `PASSPHRASE` were ever set — it isn't here) now lands on writable storage before being uploaded to S3 and removed by the script's own cleanup step. `emptyDir` volumes get permissive default permissions regardless of the container's `runAsUser`, so no `fsGroup` is needed.

## Test plan
- [x] YAML syntax + `kubeconform -strict` validated on both files
- [x] CI (yamllint + KubeLinter + kustomize build + kubenuc e2e)
- [ ] **Required before considering this fully resolved**: manually trigger `kubectl create job --from=cronjob/nextcloud-db-backup` and `.../harbor-db-backup` on the live cluster, confirm both complete successfully and the dump lands in S3, then confirm the next scheduled Sunday run is green


---
_Generated by [Claude Code](https://claude.ai/code/session_013E8ocpdkiRcfaAGXUwqTiy)_