### PR TITLE
feat(grafana): alert on failed weekly DB backup CronJobs

### DIFF
--- a/terraform/grafana/alerting.tf
+++ b/terraform/grafana/alerting.tf
@@ -113,3 +113,97 @@ resource "grafana_rule_group" "active_series_guard" {
     }
   }
 }
+
+# ---------------------------------------------------------------------------
+# Weekly Postgres DB backup CronJobs (nextcloud-db-backup, harbor-db-backup)
+# failed silently for an extended period before being caught manually (see
+# clusters/kubenuc/apps/{nextcloud,harbor}/manifests/backup.yml). This alert
+# closes that gap using kube_job_status_failed, which kube-state-metrics
+# already emits for every Job object - zero new scrape targets/series added.
+# no_data_state is OK: the series only exists while the (already-failed) Job
+# object exists in the cluster, so its absence means no failure to report.
+# ---------------------------------------------------------------------------
+resource "grafana_rule_group" "backup_cronjob_guard" {
+  name             = "backup-cronjob-guard"
+  folder_uid       = grafana_folder.alerting.uid
+  interval_seconds = 300
+
+  rule {
+    name           = "WeeklyDbBackupFailed"
+    condition      = "B"
+    for            = "5m"
+    no_data_state  = "OK"
+    exec_err_state = "Alerting"
+
+    data {
+      ref_id = "A"
+
+      relative_time_range {
+        from = 600
+        to   = 0
+      }
+
+      datasource_uid = "grafanacloud-prom"
+      model = jsonencode({
+        refId         = "A"
+        expr          = "max(kube_job_status_failed{job_name=~\"nextcloud-db-backup-.*|harbor-db-backup-.*\"})"
+        instant       = true
+        range         = false
+        intervalMs    = 1000
+        maxDataPoints = 43200
+      })
+    }
+
+    data {
+      ref_id = "B"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "-100"
+      model = jsonencode({
+        refId = "B"
+        type  = "classic_conditions"
+        datasource = {
+          type = "__expr__"
+          uid  = "-100"
+        }
+        conditions = [
+          {
+            evaluator = {
+              type   = "gt"
+              params = [0]
+            }
+            operator = {
+              type = "and"
+            }
+            query = {
+              params = ["A"]
+            }
+            reducer = {
+              type   = "last"
+              params = []
+            }
+            type = "query"
+          }
+        ]
+      })
+    }
+
+    labels = {
+      severity = "critical"
+    }
+
+    annotations = {
+      summary     = "Weekly Postgres DB backup CronJob failed"
+      description = "kube_job_status_failed is 1 for a Job matching nextcloud-db-backup-* or harbor-db-backup-* - the weekly pg_dump->S3 backup did not complete. Check `kubectl get jobs -n nextcloud-fastnetserv` / `-n harbor` and the pod logs."
+    }
+
+    notification_settings {
+      contact_point = grafana_contact_point.infra_slack.name
+      group_by      = ["alertname"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Plan C, C4 continued (part 2/4: failure alerting). Adds a `grafana_rule_group` alerting on `kube_job_status_failed` for `nextcloud-db-backup-*` / `harbor-db-backup-*` jobs, so a future backup failure can't go unnoticed the way this one did (fixed in #1574).

Chose this over a CronJob-side Slack-webhook wrapper because `kube_job_status_failed` is already emitted by kube-state-metrics for every Job object — **zero new scrape targets or series added**, no cardinality budget impact (per the `grafana-cardinality-guard` skill's check: this metric is already flowing, confirmed no exclude rule for `kube_job_.*` in `grafana-alloy`'s `release.yml`). Reuses the existing `infra_slack` contact point and `alerting` folder already set up for the `active_series_guard` alert in this same file.

`no_data_state: OK` — the series only exists while the (already-failed) Job object is still present in the cluster (bounded by the default `failedJobsHistoryLimit`), so its absence means there's no failure to report, not a scrape gap to worry about.

## Test plan
- [x] `terraform fmt -check` passes
- [ ] **Caveat**: `terraform validate`/`plan` couldn't run locally — `registry.terraform.io` is blocked in this sandbox (same as prior Terraform PRs in this series). The `datasource_uid = "grafanacloud-prom"` is inferred from this same file's existing comment referencing that datasource by name; CI's real plan/apply will confirm or reject it.
- [ ] CI (`terraform-grafana.yml`: fmt/init/validate/plan/apply)
- [ ] Manual verification post-merge: trigger a test failure (or wait for the next real one) and confirm the Slack alert fires


---
_Generated by [Claude Code](https://claude.ai/code/session_013E8ocpdkiRcfaAGXUwqTiy)_