### PR TITLE
feat(backup): extend Velero volume backup coverage to jenkins, harbor

### DIFF
--- a/clusters/kubenuc/apps/harbor/manifests/release.yml
+++ b/clusters/kubenuc/apps/harbor/manifests/release.yml
@@ -102,6 +102,9 @@ spec:
       #   prometheus.io/scrape: "true"
       #   prometheus.io/path: "/metrics"
       #   prometheus.io/port: "8001"
+    registry:
+      podAnnotations:
+        backup.velero.io/backup-volumes: "registry-data"
     notary:
       enabled: false
     expose:

--- a/clusters/kubenuc/apps/jenkins/manifests/release.yml
+++ b/clusters/kubenuc/apps/jenkins/manifests/release.yml
@@ -25,6 +25,8 @@ spec:
       retries: 5
   values:
     controller:
+      podAnnotations:
+        backup.velero.io/backup-volumes: "jenkins-home"
       resources:
         limits:
           cpu: 2


### PR DESCRIPTION
## Summary
Plan C, C4 continued (part 3/4). Jenkins and Harbor currently have no volume backup at all — only Nextcloud's data folder is covered via `backup.velero.io/backup-volumes` (`release.yml:35`). Adds the same annotation pattern:

- **jenkins**: `controller.podAnnotations` → `backup.velero.io/backup-volumes: "jenkins-home"` (JENKINS_HOME — build history, plugins-at-runtime, workspaces). Confirmed the exact volume name via a live-pod volume listing — the other volumes (`plugins`, `jenkins-config`, `plugin-dir`, `jenkins-secrets`, `jenkins-cache`, `sc-config-volume`, `tmp-volume`) are ConfigMap/Secret/ephemeral mounts, not worth backing up.
- **harbor**: `registry.podAnnotations` → `backup.velero.io/backup-volumes: "registry-data"` (the registry blob-storage PVC, mounted on the `registry` Deployment specifically, not core/portal/jobservice). Confirmed via the same live-pod volume listing (`registry-htpasswd`/`registry-config` are ConfigMap/Secret mounts).

Both `podAnnotations` key paths verified against the actual chart source (`jenkinsci/helm-charts`, `goharbor/harbor-helm`) rather than assumed — `controller.podAnnotations` renders at `jenkins-controller-statefulset.yaml:42-43`, `registry.podAnnotations` renders at `registry-dpl.yaml:43-44`.

The `databases` namespace stays excluded per the plan — the pg_dump CronJobs already cover schemas there, and file-copying a live PG data directory via Velero would be harmful. Nextcloud's existing annotation is untouched.

**Velero GitOps-ification** (bringing the live CLI-installed Velero under `clusters/kubenuc/apps/velero/`) is deferred to a follow-up — still gathering the BSL/schedule details needed to adopt it correctly rather than reinstall.

## Test plan
- [x] YAML syntax validated
- [x] Both `podAnnotations` key paths verified against real chart template source (not guessed)
- [x] CI (yamllint + KubeLinter + kustomize build + kubenuc e2e)
- [ ] Manual verification post-merge: confirm the next Velero backup run picks up both volumes


---
_Generated by [Claude Code](https://claude.ai/code/session_013E8ocpdkiRcfaAGXUwqTiy)_