### PR TITLE
feat(resources): add resource limits for grafana-alloy, falco

### DIFF
--- a/clusters/k8s-vms-daniele/apps/falco/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/falco/manifests/release.yml
@@ -38,6 +38,18 @@ spec:
       valuesKey: loki-password
       targetPath: falcosidekick.config.loki.apikey
   values:
+    # Pinned explicitly for stability across chart version bumps (chart is
+    # tracked on a floating "9.x" range) rather than relying on the chart's
+    # own default drifting silently. requests/memory limit match the
+    # chart's own documented sane-default; cpu limit removed per this
+    # repo's no-CPU-limits policy.
+    resources:
+      requests:
+        cpu: 100m
+        memory: 512Mi
+      limits:
+        cpu: null
+        memory: 1024Mi
     driver:
       kind: modern_ebpf
 
@@ -77,6 +89,14 @@ spec:
     falcosidekick:
       enabled: true
       replicaCount: 1
+      # Conservative documented estimate (not sized from live usage - no
+      # Grafana access this session); lightweight event-relay component
+      resources:
+        requests:
+          cpu: 20m
+          memory: 32Mi
+        limits:
+          memory: 128Mi
       config:
         loki:
           hostport: "${GRAFANA_LOKI_HOST}"

--- a/clusters/k8s-vms-daniele/apps/grafana-alloy/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/grafana-alloy/manifests/release.yml
@@ -65,6 +65,17 @@ spec:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65532
+          # Conservative documented estimate (not sized from live usage - no
+          # Grafana access this session), applied uniformly to all collector
+          # instances even though alloy-singleton is lighter than
+          # alloy-metrics/-logs - flagged for a follow-up tune with
+          # per-collector overrides once real usage data is available.
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              memory: 512Mi
           mounts:
             extra:
               - name: alloy-data
@@ -154,6 +165,12 @@ spec:
           fsGroup: 65532
         containerSecurityContext:
           runAsUser: 65532
+        resources:
+          requests:
+            cpu: 20m
+            memory: 64Mi
+          limits:
+            memory: 128Mi
 
     clusterMetrics:
       enabled: true

--- a/clusters/kubenuc/apps/falco/manifests/release.yml
+++ b/clusters/kubenuc/apps/falco/manifests/release.yml
@@ -38,6 +38,18 @@ spec:
       valuesKey: loki-password
       targetPath: falcosidekick.config.loki.apikey
   values:
+    # Pinned explicitly for stability across chart version bumps (chart is
+    # tracked on a floating "9.x" range) rather than relying on the chart's
+    # own default drifting silently. requests/memory limit match the
+    # chart's own documented sane-default; cpu limit removed per this
+    # repo's no-CPU-limits policy.
+    resources:
+      requests:
+        cpu: 100m
+        memory: 512Mi
+      limits:
+        cpu: null
+        memory: 1024Mi
     driver:
       kind: modern_ebpf
 
@@ -100,6 +112,14 @@ spec:
     falcosidekick:
       enabled: true
       replicaCount: 1
+      # Conservative documented estimate (not sized from live usage - no
+      # Grafana access this session); lightweight event-relay component
+      resources:
+        requests:
+          cpu: 20m
+          memory: 32Mi
+        limits:
+          memory: 128Mi
       tolerations:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists

--- a/clusters/kubenuc/apps/grafana-alloy/manifests/release.yml
+++ b/clusters/kubenuc/apps/grafana-alloy/manifests/release.yml
@@ -236,6 +236,17 @@ spec:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65532
+          # Conservative documented estimate (not sized from live usage - no
+          # Grafana access this session), applied uniformly to all 4
+          # collector instances even though alloy-singleton is lighter than
+          # alloy-metrics/-logs/-receiver - flagged for a follow-up tune
+          # with per-collector overrides once real usage data is available.
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              memory: 512Mi
           mounts:
             extra:
               - name: alloy-data
@@ -268,6 +279,12 @@ spec:
           fsGroup: 65532
         containerSecurityContext:
           runAsUser: 65532
+        resources:
+          requests:
+            cpu: 20m
+            memory: 64Mi
+          limits:
+            memory: 128Mi
 
     clusterMetrics:
       enabled: true


### PR DESCRIPTION
## Summary
Plan C, C3 batch 1 completion (grafana-alloy + falco, deferred from #1581 due to higher sizing complexity). Completes the 5-app batch 1 scope (1password, cert-manager, external-dns already merged in #1581).

- **grafana-alloy**: `collectorCommon.alloy.alloy.resources` (verified key path against the upstream `grafana/alloy` chart's own `alloy-values.yaml`, sibling to the `securityContext` key already added in A9) applies one conservative estimate uniformly to all collector instances (metrics/singleton/logs/receiver on kubenuc; metrics/singleton/logs on k8s-vms-daniele) — flagged for a follow-up tune with per-collector overrides once real usage data shows the lighter singleton collector doesn't need as much headroom as metrics/logs/receiver. Also added `telemetryServices.kube-state-metrics.resources` (lightweight, low footprint).
- **falco**: pinned the chart's **own already-reasonable default resources** (requests: 100m/512Mi — the chart's own documented sane default) explicitly in our values for stability across the floating `"9.x"` version range, removing the chart-default CPU limit (1000m) per this repo's no-CPU-limits policy. Added resources for the `falcosidekick` event-relay sidecar (chart default is empty, no prior sizing at all).

No Grafana MCP access this session to size from real usage as the plan specifies — all values are conservative documented estimates (chart defaults where they existed, generous headroom otherwise), explicitly flagged inline for a follow-up tune.

## Test plan
- [x] YAML syntax validated on all 4 files
- [x] `collectorCommon.alloy.alloy.resources` and falco's `resources`/`falcosidekick.resources` key paths verified against real chart source (not guessed)
- [ ] CI (yamllint + KubeLinter + kustomize build + kubenuc/k8s-vms e2e)
- [ ] Manual verification post-merge: confirm no Alloy collector or falco pod hits OOMKilled or sustained CPU throttling; revisit sizing once Grafana access is available


---
_Generated by [Claude Code](https://claude.ai/code/session_013E8ocpdkiRcfaAGXUwqTiy)_