### PR TITLE
feat(reliability): add PDBs for coredns, haproxy-ingress (multi-replica only)

### DIFF
--- a/clusters/kubenuc/CLAUDE.md
+++ b/clusters/kubenuc/CLAUDE.md
@@ -11,3 +11,9 @@ A small Python webhook deployed in `flux-system` pauses the BetterStack uptime m
 - **Unpause triggers:** any terminal HelmRelease reason (`UpgradeSucceeded`, `UpgradeFailed`, `InstallSucceeded`, `RollbackSucceeded`, etc.), or `ReconciliationSucceeded`/`ReconciliationFailed` on `Kustomization/nextcloud` (fast unpause for no-op reconcile cycles where no real upgrade runs).
 - **Debug:** set `DEBUG_EVENTS=1` on the Deployment to log every raw event payload. All bridge logs are timestamped (ISO8601 UTC).
 - **Secret:** 1Password item `betterstack-token` with fields `token` and `monitor-id`, synced via `OnePasswordItem`.
+
+## PodDisruptionBudgets — Multi-Replica Only
+
+PDBs are only added to apps with more than one replica. A `minAvailable: 1` PDB on a single-replica app permanently blocks `kubectl drain` (the only pod can never be evicted without violating the budget), which wedges `system-upgrade-controller` during node upgrades. The vast majority of apps in this cluster run a single replica and have **no PDB** — accepted downtime during node drains/upgrades for those apps is a deliberate tradeoff, not an oversight.
+
+Current PDBs: `coredns` (`kube-system`, `minAvailable: 1`, backed by an HPA with `minReplicas: 2`), `haproxy-ingress` (`controller.PodDisruptionBudget` in the chart's own values, `minAvailable: 1`, already `replicaCount: 3`). The Zalando postgres-operator manages its own PDB per `Postgresql` cluster automatically (`enable_pod_disruption_budget` defaults to `true`, not overridden here) — do not add a duplicate PDB for postgres clusters.

--- a/clusters/kubenuc/apps/coredns/manifests/coredns-pdb.yaml
+++ b/clusters/kubenuc/apps/coredns/manifests/coredns-pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: coredns
+  namespace: kube-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      k8s-app: kube-dns

--- a/clusters/kubenuc/apps/haproxy-ingress/manifests/release.yml
+++ b/clusters/kubenuc/apps/haproxy-ingress/manifests/release.yml
@@ -51,6 +51,12 @@ spec:
 
       replicaCount: 3
 
+      # Already at 3 replicas - just guard against draining down to 0
+      # available during a node drain/upgrade.
+      PodDisruptionBudget:
+        enable: true
+        minAvailable: 1
+
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
## Summary
Plan C, C5. PDBs only for apps with more than one replica — a `minAvailable: 1` PDB on a single-replica app permanently blocks `kubectl drain` (the only pod can never be evicted without violating the budget), wedging `system-upgrade-controller` during node upgrades. The rest of this cluster's apps are single-replica and deliberately get no PDB.

- **coredns**: standalone `PodDisruptionBudget` (`minAvailable: 1`, selector `k8s-app: kube-dns` — k3s's built-in CoreDNS Deployment label; not GitOps-managed as a HelmRelease here, only its HPA is). Backed by the existing coredns HPA (`minReplicas: 2`, `maxReplicas: 10`).
- **haproxy-ingress**: `controller.PodDisruptionBudget` (chart-native key, verified against the actual `haproxytech/helm-charts` source rather than a hand-written manifest, so the selector always matches whatever the chart itself creates) — `minAvailable: 1`, no replica change needed since it's already `replicaCount: 3` in prod.
- **postgres-operator**: verified `enable_pod_disruption_budget` is not overridden in `configKubernetes`, so the Zalando operator's own default (enabled) PDB-per-`Postgresql`-cluster behavior applies already — no duplicate PDB added.

Documented the "accepted downtime during drains for single-replica apps" decision in `clusters/kubenuc/CLAUDE.md` (the kubenuc-specific file, not `clusters/CLAUDE.md` which is a different, already-completed change).

## Test plan
- [x] YAML syntax + `kubeconform -strict` validated
- [ ] CI (yamllint + KubeLinter + kustomize build + kubenuc e2e)
- [ ] Manual verification post-merge: `kubectl drain` a kubenuc-test worker completes without hanging


---
_Generated by [Claude Code](https://claude.ai/code/session_013E8ocpdkiRcfaAGXUwqTiy)_