### PR TITLE
feat(reloader): install stakater/reloader on both clusters

### DIFF
--- a/clusters/k8s-vms-daniele/apps/reloader/deploy.yaml
+++ b/clusters/k8s-vms-daniele/apps/reloader/deploy.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: reloader
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: charts
+  interval: 15m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./clusters/k8s-vms-daniele/apps/reloader/manifests
+  prune: true
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: reloader
+      namespace: reloader

--- a/clusters/k8s-vms-daniele/apps/reloader/manifests/namespace.yml
+++ b/clusters/k8s-vms-daniele/apps/reloader/manifests/namespace.yml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: reloader
+  labels:
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: v1.32
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: v1.32
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/clusters/k8s-vms-daniele/apps/reloader/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/reloader/manifests/release.yml
@@ -1,0 +1,55 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: reloader
+  namespace: reloader
+spec:
+  interval: 15m
+  maxHistory: 20
+  chart:
+    spec:
+      chart: reloader
+      version: "2.2.14"
+      sourceRef:
+        kind: HelmRepository
+        name: reloader
+        namespace: flux-system
+      interval: 15m
+  install:
+    createNamespace: true
+    remediation:
+      retries: 5
+  upgrade:
+    remediation:
+      retries: 5
+  values:
+    reloader:
+      # serviceMonitor.enabled already defaults to false in the chart - no
+      # override needed to keep this out of the Grafana Cloud active-series
+      # budget (see the grafana-cardinality-guard skill).
+      # Dedicated top-level flag (not deployment.containerSecurityContext) -
+      # the chart auto-adds the required /tmp emptyDir mount only when this
+      # exact flag is set, confirmed in templates/deployment.yaml.
+      readOnlyRootFileSystem: true
+      deployment:
+        # Chart default already sets runAsNonRoot/runAsUser 65534 - pinned
+        # to house style's 65532 instead (fresh install, no existing PVC
+        # data to worry about UID ownership for)
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 65532
+        containerSecurityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+        # Conservative documented estimate (not sized from live usage - no
+        # Grafana access this session); single lightweight controller
+        # watching/patching workloads via the K8s API, no local state.
+        resources:
+          requests:
+            cpu: 20m
+            memory: 32Mi
+          limits:
+            memory: 128Mi

--- a/clusters/k8s-vms-daniele/charts/reloader.yml
+++ b/clusters/k8s-vms-daniele/charts/reloader.yml
@@ -1,0 +1,9 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: reloader
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://stakater.github.io/stakater-charts
+  timeout: 3m

--- a/clusters/kubenuc/apps/reloader/deploy.yaml
+++ b/clusters/kubenuc/apps/reloader/deploy.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: reloader
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: charts
+  interval: 15m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./clusters/kubenuc/apps/reloader/manifests
+  prune: true
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: reloader
+      namespace: reloader

--- a/clusters/kubenuc/apps/reloader/manifests/namespace.yml
+++ b/clusters/kubenuc/apps/reloader/manifests/namespace.yml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: reloader
+  labels:
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: v1.33
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: v1.33
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/clusters/kubenuc/apps/reloader/manifests/release.yml
+++ b/clusters/kubenuc/apps/reloader/manifests/release.yml
@@ -1,0 +1,55 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: reloader
+  namespace: reloader
+spec:
+  interval: 15m
+  maxHistory: 20
+  chart:
+    spec:
+      chart: reloader
+      version: "2.2.14"
+      sourceRef:
+        kind: HelmRepository
+        name: reloader
+        namespace: flux-system
+      interval: 15m
+  install:
+    createNamespace: true
+    remediation:
+      retries: 5
+  upgrade:
+    remediation:
+      retries: 5
+  values:
+    reloader:
+      # serviceMonitor.enabled already defaults to false in the chart - no
+      # override needed to keep this out of the Grafana Cloud active-series
+      # budget (see the grafana-cardinality-guard skill).
+      # Dedicated top-level flag (not deployment.containerSecurityContext) -
+      # the chart auto-adds the required /tmp emptyDir mount only when this
+      # exact flag is set, confirmed in templates/deployment.yaml.
+      readOnlyRootFileSystem: true
+      deployment:
+        # Chart default already sets runAsNonRoot/runAsUser 65534 - pinned
+        # to house style's 65532 instead (fresh install, no existing PVC
+        # data to worry about UID ownership for)
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 65532
+        containerSecurityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+        # Conservative documented estimate (not sized from live usage - no
+        # Grafana access this session); single lightweight controller
+        # watching/patching workloads via the K8s API, no local state.
+        resources:
+          requests:
+            cpu: 20m
+            memory: 32Mi
+          limits:
+            memory: 128Mi

--- a/clusters/kubenuc/charts/reloader.yml
+++ b/clusters/kubenuc/charts/reloader.yml
@@ -1,0 +1,9 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: reloader
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://stakater.github.io/stakater-charts
+  timeout: 3m


### PR DESCRIPTION
## Summary
Plan C, C6 (part 1/2 — installing Reloader itself; annotating existing apps with `reloader.stakater.com/auto` is a follow-up, since which apps have 1Password-synced secrets that never trigger a pod restart on rotation is a per-app audit). Lands after C3 (resource limits) since Reloader causes restarts — no restarts from this PR alone though, since nothing is annotated yet.

New HelmRelease on both `kubenuc` and `k8s-vms-daniele` (chart `stakater/reloader` v2.2.14, repo `https://stakater.github.io/stakater-charts`), verified via a real `helm template` render against the actual chart source rather than guessed:

- `serviceMonitor.enabled` already defaults to `false` in the chart — no override needed to stay out of the Grafana Cloud active-series budget (per the `grafana-cardinality-guard` skill's check).
- Hardening: `reloader.readOnlyRootFileSystem: true` — a **dedicated top-level chart flag**, not `deployment.containerSecurityContext.readOnlyRootFilesystem`. The chart only auto-adds the required `/tmp` `emptyDir` mount when this exact flag is set (confirmed by reading `templates/deployment.yaml` and proven with a real render — setting the container-level field directly would have skipped that mount). Also `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`, `runAsNonRoot`/`runAsUser` 65532 (fresh install, no existing PVC data to worry about UID ownership for).
- Conservative documented resource estimate (not sized from live usage — no Grafana access this session): requests 20m/32Mi, memory limit 128Mi, no CPU limit per this repo's policy.

PSS labels applied to the new namespace per the A7 pattern (v1.33 on kubenuc, v1.32 on k8s-vms-daniele).

## Test plan
- [x] YAML syntax validated on all 8 files
- [x] `kubeconform -strict` on the Namespace manifests (Kustomization/HelmRelease CRDs show the same benign "no schema" limitation as every prior Flux PR in this series)
- [x] Verified end-to-end with a real `helm template` render against the cloned chart source — confirmed securityContext, resources, and the auto-added `/tmp` emptyDir mount all render correctly
- [x] CI (yamllint + KubeLinter + kustomize build + kubenuc/k8s-vms e2e)
- [ ] Manual verification post-merge: Reloader pod starts cleanly on both clusters


---
_Generated by [Claude Code](https://claude.ai/code/session_013E8ocpdkiRcfaAGXUwqTiy)_