### PR TITLE
fix(security): restore nextcloud startup - drop runAsNonRoot, add minimal caps

### DIFF
--- a/clusters/kubenuc/apps/nextcloud/manifests/release.yml
+++ b/clusters/kubenuc/apps/nextcloud/manifests/release.yml
@@ -57,15 +57,26 @@ spec:
       # /usr/local/etc/php/conf.d/redis-session.ini on every start (REDIS_HOST
       # is set), and apache2-foreground writes /var/run/apache2 +
       # /var/lock/apache2 - none of these are covered by existing mounts.
-      # runAsUser intentionally not set: the existing 160Gi PVC was written
-      # by the image's default www-data (uid 33, matched by fsGroup above);
-      # no live cluster to verify a UID switch is safe
+      # runAsNonRoot/runAsUser intentionally not set: the apache image must
+      # start as root (entrypoint chown/rsync of app data, apache binds :80,
+      # then drops to www-data itself); kubelet rejects runAsNonRoot outright
+      # because the image USER is root. Same pattern as jellyfin. Capabilities
+      # below are the minimal set for that root->www-data lifecycle; all are
+      # in the PSS "baseline" allowed list.
       securityContext:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
             - ALL
-        runAsNonRoot: true
+          add:
+            - AUDIT_WRITE       # su/PAM session during entrypoint upgrade steps
+            - CHOWN             # entrypoint rsync --chown www-data:root
+            - DAC_OVERRIDE      # root traversing/writing www-data-owned files
+            - FOWNER            # chmod/utime on files owned by www-data
+            - KILL              # apache root parent signals www-data workers
+            - NET_BIND_SERVICE  # apache binds :80
+            - SETGID            # privilege drop to www-data (+ setgroups)
+            - SETUID            # privilege drop to www-data
 
     resources:
       requests:
@@ -141,6 +152,9 @@ spec:
           capabilities:
             drop:
               - ALL
+            add:
+              - SETGID  # busybox crond setgroups/setgid to www-data per job
+              - SETUID  # busybox crond setuid to www-data per job
     nginx:
       enabled: false
       securityContext:


### PR DESCRIPTION
## Problem

PR #1564 (A9 securityContext standardization) added `runAsNonRoot: true` to the nextcloud container securityContext. The `nextcloud:34.0-apache` image starts as **root** by design: the entrypoint chowns/rsyncs app data and writes PHP config, Apache binds port 80, then drops to `www-data` (uid 33) itself. The kubelet's `runAsNonRoot` check sees the image USER is root and refuses to start the container:

```
Error: container has runAsNonRoot and image will run as root
```

**Production Nextcloud on kubenuc is down as a result.** The same PR also gave the cron sidecar `drop: [ALL]` — crond starts (runs as root) but busybox crond needs `SETUID`/`SETGID` to run `cron.php` as www-data, so every 5-minute cron job would fail.

## Fix

Keep the hardening intent (`drop: [ALL]`, `allowPrivilegeEscalation: false`), remove `runAsNonRoot`, and add back only the minimal capabilities the root→www-data lifecycle needs — all in the PSS **baseline** allowed list:

- **Main container**: `AUDIT_WRITE`, `CHOWN`, `DAC_OVERRIDE`, `FOWNER`, `KILL`, `NET_BIND_SERVICE`, `SETGID`, `SETUID`
- **Cron sidecar**: `SETGID`, `SETUID` (busybox crond privilege drop per job)

Same pattern as jellyfin, where `runAsNonRoot`/`runAsUser` are deliberately omitted for a root-starting image. `runAsUser: 33` is not viable: uid 33 can't bind :80 or run the entrypoint's chown/rsync.

The `nextcloud-fastnetserv` namespace has PSS labels at `warn`/`audit` restricted only (no `enforce`), so admission behavior is unchanged — warnings only, same as before #1564.

## Verification

- `yamllint` clean (only pre-existing line-length on the Renovate-pinned image digest)
- `validate-kubenuc.yml` e2e exercises the actual container startup with the new caps
- Post-merge: pod Running with no `CreateContainerConfigError`; sidecar logs free of `crond: can't set groups`/setgid errors; background jobs executing in the admin UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)