### PR TITLE
feat(reloader): annotate external-dns, harbor, nextcloud, sso for auto-restart

### DIFF
--- a/clusters/k8s-vms-daniele/apps/external-dns/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/external-dns/manifests/release.yml
@@ -23,6 +23,13 @@ spec:
     remediation:
       retries: 5
   values:
+    # CF_API_TOKEN below is only read at container startup - without this,
+    # rotating the 1Password-synced cloudflare-api-token secret never
+    # restarts the pod (Reloader watches the Secret referenced in env,
+    # scoped to secrets only so a config-only chart bump doesn't also
+    # trigger a redundant restart).
+    podAnnotations:
+      secret.reloader.stakater.com/auto: "true"
     # Conservative documented estimate (not sized from live usage - no
     # Grafana access this session), generous headroom since this instance
     # currently manages zero records (annotationFilter opt-in gate above).

--- a/clusters/kubenuc/apps/external-dns/manifests/release.yml
+++ b/clusters/kubenuc/apps/external-dns/manifests/release.yml
@@ -23,6 +23,13 @@ spec:
     remediation:
       retries: 5
   values:
+    # CF_API_TOKEN below is only read at container startup - without this,
+    # rotating the 1Password-synced cloudflare-api-token secret never
+    # restarts the pod (Reloader watches the Secret referenced in env,
+    # scoped to secrets only so a config-only chart bump doesn't also
+    # trigger a redundant restart).
+    podAnnotations:
+      secret.reloader.stakater.com/auto: "true"
     # Conservative documented estimate (not sized from live usage - no
     # Grafana access this session), generous headroom since this instance
     # currently manages zero records (annotationFilter opt-in gate above).

--- a/clusters/kubenuc/apps/harbor/manifests/release.yml
+++ b/clusters/kubenuc/apps/harbor/manifests/release.yml
@@ -32,6 +32,13 @@ spec:
     externalURL: ${HARBOR_URL}
     core:
       replicas: 2
+      # POSTGRESQL_PASSWORD below (database.external.existingSecret) is only
+      # read at container startup - without this, rotating the
+      # 1Password-synced harbor-secrets secret never restarts core. Scoped
+      # to secrets only so a config-only chart bump doesn't also trigger a
+      # redundant restart.
+      podAnnotations:
+        secret.reloader.stakater.com/auto: "true"
       resources:
         requests:
           memory: 512Mi

--- a/clusters/kubenuc/apps/nextcloud/manifests/release.yml
+++ b/clusters/kubenuc/apps/nextcloud/manifests/release.yml
@@ -33,6 +33,12 @@ spec:
       pullPolicy: IfNotPresent
     podAnnotations:
       backup.velero.io/backup-volumes: "nextcloud-main"
+      # nextcloud.existingSecret (admin) and externalDatabase.existingSecret
+      # (DB) below are only read at container startup - without this,
+      # rotating either 1Password-synced secret never restarts the pod.
+      # Scoped to secrets only so a config-only chart bump doesn't also
+      # trigger a redundant restart.
+      secret.reloader.stakater.com/auto: "true"
     ingress:
       enabled: true
       className: haproxy

--- a/clusters/kubenuc/apps/sso/manifests/release.yml
+++ b/clusters/kubenuc/apps/sso/manifests/release.yml
@@ -107,6 +107,14 @@ spec:
               - ${SSO_AUTHENTIK_HOST}
 
     global:
+      # PG_PASS/AUTHENTIK_SECRET_KEY below (global.env) are only read at
+      # container startup - without this, rotating the 1Password-synced
+      # sso-secrets secret never restarts server/worker. Set on global so it
+      # merges into both server and worker deployments (they share
+      # global.env). Scoped to secrets only so a config-only chart bump
+      # doesn't also trigger a redundant restart.
+      podAnnotations:
+        secret.reloader.stakater.com/auto: "true"
       # Required for readOnlyRootFilesystem above: AUTHENTIK_STORAGE__FILE__PATH
       # defaults to /data (icons, CSV report exports - not mounted by the
       # chart otherwise), and Django's file-upload handling falls back to

--- a/clusters/kubenuc/apps/sso/manifests/zitadel.yml
+++ b/clusters/kubenuc/apps/sso/manifests/zitadel.yml
@@ -136,6 +136,13 @@ spec:
             MaxIdleConns: 10
             MaxConnLifetime: 30m
             MaxConnIdleTime: 5m
+    # env below (zitadel-db-credentials, sso-secrets) and masterkeySecretName
+    # above (zitadel-master-secrets) are only read at container startup -
+    # without this, rotating any of these 1Password-synced secrets never
+    # restarts the pod. Scoped to secrets only so a config-only chart bump
+    # doesn't also trigger a redundant restart.
+    podAnnotations:
+      secret.reloader.stakater.com/auto: "true"
     env:
       - name: ZITADEL_DATABASE_POSTGRES_USER_SSL_MODE
         value: prefer


### PR DESCRIPTION
## Summary
- C6 part 2: opts a first batch of apps into Reloader (installed in #1584, nothing used it yet)
- Adds `secret.reloader.stakater.com/auto: "true"` (secret-scoped, not the generic annotation, to avoid a redundant restart on every config-only chart bump) to `external-dns` (both clusters), `harbor` core, `nextcloud`, and `sso`'s `authentik`+`zitadel` releases
- Each was individually verified against the real chart template source to confirm its 1Password-synced secret is actually read via `env`/`secretKeyRef` in the running pod (not just consumed at Helm-render time), and that the `podAnnotations` key path used actually reaches the right Deployment

## Scope / exclusions (with reasons)
- **falco/falcosidekick, grafana-alloy, semaphore**: their 1Password secrets are only consumed via Flux `HelmRelease.spec.valuesFrom`, never appearing in the rendered pod spec — Reloader has nothing to watch there, and Flux already re-renders on the next reconcile regardless
- **harbor `jobservice`/`registry`**: verified against the chart's templates that neither actually reads `harbor-secrets` (jobservice reads its own chart-generated secret; registry reads unset chart-generated secrets) — only `core` does
- **awx, postgresql**: both are ultimately managed by a continuously-reconciling operator (awx-operator, Zalando postgres-operator) — annotating the operator-managed Deployment risks fighting the operator's own reconcile loop; deferred pending live verification
- **teleport-agent, semaphore's admin secret, portainer**: teleport's join-token doesn't need a restart on rotation; portainer's chart has no annotation hook on its Deployment template at all (verified — no `podAnnotations`/`annotations` key reaches the pod template)
- **bareos, film-tv-exporter**: bareos is fully commented out; film-tv-exporter's three Deployments are all scaled to 0 replicas

## Impact
Merging triggers one rolling restart each for `authentik` (3 replicas), `zitadel`, `harbor core` (2 replicas), and `nextcloud` — pod template hash changes due to the new annotation, all rolling/non-disruptive.

## Test plan
- [x] `pre-commit run` (trailing-whitespace, end-of-file-fixer, check-yaml, gitleaks) passes on all changed files
- [x] `helm template` against a real clone of the `external-dns` chart confirms the annotation renders onto the pod template as expected
- [x] Each `podAnnotations` key path verified against the real chart source (authentik `global.podAnnotations` merge into both `server/` and `worker/` deployment templates; harbor `core.podAnnotations`; zitadel/external-dns root `podAnnotations`)
- [x] CI (kubenuc-full-cluster-e2e / k8s-vms-e2e)