### PR TITLE
feat(flux): enable HelmRelease drift detection (warn mode) - batch 1

### DIFF
--- a/clusters/k3s-prod-test/apps/1password/manifests/release.yml
+++ b/clusters/k3s-prod-test/apps/1password/manifests/release.yml
@@ -25,6 +25,12 @@ spec:
     remediation:
       retries: 10
     timeout: 10m
+  # Audit-first: warn only logs/events on drift between the Helm release and
+  # live cluster state, it never corrects it - a safe first step before any
+  # app is promoted to mode: enabled (which would actively revert manual or
+  # external changes).
+  driftDetection:
+    mode: warn
   values:
     connect:
       create: false

--- a/clusters/k3s-rabbit/apps/teleport-agent/manifests/release.yml
+++ b/clusters/k3s-rabbit/apps/teleport-agent/manifests/release.yml
@@ -22,6 +22,12 @@ spec:
   upgrade:
     remediation:
       retries: 6
+  # Audit-first: warn only logs/events on drift between the Helm release and
+  # live cluster state, it never corrects it - a safe first step before any
+  # app is promoted to mode: enabled (which would actively revert manual or
+  # external changes).
+  driftDetection:
+    mode: warn
   values:
     proxyAddr: ${TELEPORT_HOST}:443
     kubeClusterName: "k3s-rabbit"

--- a/clusters/oc-ampere/apps/teleport-agent/manifests/release.yml
+++ b/clusters/oc-ampere/apps/teleport-agent/manifests/release.yml
@@ -22,6 +22,12 @@ spec:
   upgrade:
     remediation:
       retries: 6
+  # Audit-first: warn only logs/events on drift between the Helm release and
+  # live cluster state, it never corrects it - a safe first step before any
+  # app is promoted to mode: enabled (which would actively revert manual or
+  # external changes).
+  driftDetection:
+    mode: warn
   values:
     proxyAddr: ${TELEPORT_HOST}:443
     kubeClusterName: "oc-ampere"


### PR DESCRIPTION
## Summary
- C8: adds `driftDetection: {mode: warn}` to the 3 independent HelmReleases on the smallest/lowest-risk clusters — `k3s-prod-test/1password`, `k3s-rabbit/teleport-agent`, `oc-ampere/teleport-agent`
- `warn` mode only emits Kubernetes Events/logs when the live cluster state differs from the Helm release, it never corrects/reverts anything — an audit-first step before deciding which apps (if any) should later graduate to `mode: enabled`
- `kubenuc-test` is not touched here since its Kustomizations point directly at `clusters/kubenuc/apps/*/manifests` (overlay pattern) — it inherits this once `kubenuc` itself gets a batch

## Notes
- `clusters/k3s-rabbit/apps/teleport-agent/manifests/release.yml` has pre-existing CRLF line endings (unrelated to this change, an existing repo anomaly) — preserved them rather than normalizing to keep the diff minimal
- Follow-up PRs planned for `k8s-vms-daniele` (11 apps) and `kubenuc` (21 apps, largest/most production-critical, done last)

## Test plan
- [x] `pre-commit run` (trailing-whitespace, end-of-file-fixer, check-yaml, gitleaks) passes on all 3 changed files
- [x] CI (relevant e2e checks)