### PR TITLE
feat(flux): enable HelmRelease drift detection (warn mode) - batch 2

### DIFF
--- a/clusters/k8s-vms-daniele/apps/1password/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/1password/manifests/release.yml
@@ -25,6 +25,12 @@ spec:
     remediation:
       retries: 10
     timeout: 10m
+  # Audit-first: warn only logs/events on drift between the Helm release and
+  # live cluster state, it never corrects it - a safe first step before any
+  # app is promoted to mode: enabled (which would actively revert manual or
+  # external changes).
+  driftDetection:
+    mode: warn
   values:
     # Resource values below are conservative documented estimates (not sized
     # from live usage - no Grafana access this session) with headroom built

--- a/clusters/k8s-vms-daniele/apps/awx/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/awx/manifests/release.yml
@@ -24,6 +24,12 @@ spec:
     crds: CreateReplace
     remediation:
       retries: 10
+  # Audit-first: warn only logs/events on drift between the Helm release and
+  # live cluster state, it never corrects it - a safe first step before any
+  # app is promoted to mode: enabled (which would actively revert manual or
+  # external changes).
+  driftDetection:
+    mode: warn
   values:
     AWX:
       enabled: true

--- a/clusters/k8s-vms-daniele/apps/blackbox/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/blackbox/manifests/release.yml
@@ -22,6 +22,12 @@ spec:
   upgrade:
     remediation:
       retries: 5
+  # Audit-first: warn only logs/events on drift between the Helm release and
+  # live cluster state, it never corrects it - a safe first step before any
+  # app is promoted to mode: enabled (which would actively revert manual or
+  # external changes).
+  driftDetection:
+    mode: warn
   values:
     nameOverride: blackbox-exporter
     podAnnotations: {}

--- a/clusters/k8s-vms-daniele/apps/cert-manager/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/cert-manager/manifests/release.yml
@@ -23,6 +23,12 @@ spec:
     crds: CreateReplace
     remediation:
       retries: 5
+  # Audit-first: warn only logs/events on drift between the Helm release and
+  # live cluster state, it never corrects it - a safe first step before any
+  # app is promoted to mode: enabled (which would actively revert manual or
+  # external changes).
+  driftDetection:
+    mode: warn
   values:
     crds:
       enabled: true

--- a/clusters/k8s-vms-daniele/apps/external-dns/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/external-dns/manifests/release.yml
@@ -22,6 +22,12 @@ spec:
   upgrade:
     remediation:
       retries: 5
+  # Audit-first: warn only logs/events on drift between the Helm release and
+  # live cluster state, it never corrects it - a safe first step before any
+  # app is promoted to mode: enabled (which would actively revert manual or
+  # external changes).
+  driftDetection:
+    mode: warn
   values:
     # CF_API_TOKEN below is only read at container startup - without this,
     # rotating the 1Password-synced cloudflare-api-token secret never

--- a/clusters/k8s-vms-daniele/apps/falco/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/falco/manifests/release.yml
@@ -24,6 +24,12 @@ spec:
   upgrade:
     remediation:
       retries: 5
+  # Audit-first: warn only logs/events on drift between the Helm release and
+  # live cluster state, it never corrects it - a safe first step before any
+  # app is promoted to mode: enabled (which would actively revert manual or
+  # external changes).
+  driftDetection:
+    mode: warn
   valuesFrom:
     - kind: Secret
       name: falcosidekick-credentials

--- a/clusters/k8s-vms-daniele/apps/grafana-alloy/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/grafana-alloy/manifests/release.yml
@@ -24,6 +24,12 @@ spec:
   upgrade:
     remediation:
       retries: 6
+  # Audit-first: warn only logs/events on drift between the Helm release and
+  # live cluster state, it never corrects it - a safe first step before any
+  # app is promoted to mode: enabled (which would actively revert manual or
+  # external changes).
+  driftDetection:
+    mode: warn
   valuesFrom:
     # --- Destination passwords ---
     - kind: Secret

--- a/clusters/k8s-vms-daniele/apps/node-exporter/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/node-exporter/manifests/release.yml
@@ -25,4 +25,10 @@ spec:
         kind: HelmRepository
         name: prometheus-community-charts
         namespace: flux-system
+  # Audit-first: warn only logs/events on drift between the Helm release and
+  # live cluster state, it never corrects it - a safe first step before any
+  # app is promoted to mode: enabled (which would actively revert manual or
+  # external changes).
+  driftDetection:
+    mode: warn
   values: {}

--- a/clusters/k8s-vms-daniele/apps/reloader/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/reloader/manifests/release.yml
@@ -23,6 +23,12 @@ spec:
   upgrade:
     remediation:
       retries: 5
+  # Audit-first: warn only logs/events on drift between the Helm release and
+  # live cluster state, it never corrects it - a safe first step before any
+  # app is promoted to mode: enabled (which would actively revert manual or
+  # external changes).
+  driftDetection:
+    mode: warn
   values:
     reloader:
       # serviceMonitor.enabled already defaults to false in the chart - no

--- a/clusters/k8s-vms-daniele/apps/semaphore/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/semaphore/manifests/release.yml
@@ -23,6 +23,12 @@ spec:
   upgrade:
     remediation:
       retries: 5
+  # Audit-first: warn only logs/events on drift between the Helm release and
+  # live cluster state, it never corrects it - a safe first step before any
+  # app is promoted to mode: enabled (which would actively revert manual or
+  # external changes).
+  driftDetection:
+    mode: warn
   # Credentials injected from 1Password via semaphore-credentials secret.
   # The secret must contain:
   #   admin-username  - Initial admin username

--- a/clusters/k8s-vms-daniele/apps/teleport-agent/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/teleport-agent/manifests/release.yml
@@ -22,6 +22,12 @@ spec:
   upgrade:
     remediation:
       retries: 6
+  # Audit-first: warn only logs/events on drift between the Helm release and
+  # live cluster state, it never corrects it - a safe first step before any
+  # app is promoted to mode: enabled (which would actively revert manual or
+  # external changes).
+  driftDetection:
+    mode: warn
   values:
     proxyAddr: ${TELEPORT_HOST}:443
     kubeClusterName: "k8s-vms-daniele"


### PR DESCRIPTION
## Summary
- C8 batch 2 (follows #1594): adds `driftDetection: {mode: warn}` to all 11 HelmReleases on `k8s-vms-daniele` — 1password, awx, blackbox, cert-manager, external-dns, falco, grafana-alloy, node-exporter, reloader, semaphore, teleport-agent
- `warn` mode only emits Kubernetes Events/logs when the live cluster state differs from the Helm release, it never corrects/reverts anything — audit-first before any app is promoted to `mode: enabled`

## Notes
- awx and cert-manager both have resources created dynamically by their own controllers downstream of the chart (awx-operator's `AWX` CR → its own Deployment; cert-manager's issued Certificates/CAs) — those aren't part of the Helm-rendered manifest so they're outside driftDetection's scope regardless, no conflict
- `kubenuc` (21 apps, largest/most production-critical) is the remaining batch, done last

## Test plan
- [x] All 11 files pass `yq eval` YAML validation
- [x] `pre-commit run` (trailing-whitespace, end-of-file-fixer, check-yaml, gitleaks) passes
- [ ] CI (k8s-vms-e2e cluster-test)