### PR TITLE
feat(scheduling): add cluster-infra-critical PriorityClass for foundational apps

### DIFF
--- a/.github/workflows/validate-kubenuc.yml
+++ b/.github/workflows/validate-kubenuc.yml
@@ -255,6 +255,18 @@ jobs:
 
           kubectl -n flux-system wait kustomization/charts --for=condition=ready --timeout=10m
 
+      - name: Deploy priority classes
+        run: |
+          flux create kustomization priority-classes \
+            --source=flux-system \
+            --path=./clusters/kubenuc/priority-classes \
+            --interval=5m \
+            --prune=true \
+            --timeout=5m \
+            --wait
+
+          kubectl -n flux-system wait kustomization/priority-classes --for=condition=ready --timeout=5m
+
       - name: Create SOPS age secret and cluster-vars
         run: |
           kubectl create secret generic sops-age \

--- a/clusters/kubenuc/apps/1password/deploy.yaml
+++ b/clusters/kubenuc/apps/1password/deploy.yaml
@@ -32,3 +32,4 @@ spec:
   interval: 15m
   dependsOn:
     - name: 1password-secrets
+    - name: priority-classes

--- a/clusters/kubenuc/apps/1password/manifests/release.yml
+++ b/clusters/kubenuc/apps/1password/manifests/release.yml
@@ -38,6 +38,7 @@ spec:
     # data is available. Policy: requests + memory limits, no CPU limits.
     connect:
       create: true
+      priorityClassName: cluster-infra-critical
       credentialsName: 1password-connect-credentials
       credentialsKey: credentials
       hpa:
@@ -61,6 +62,7 @@ spec:
             memory: 128Mi
     operator:
       create: true
+      priorityClassName: cluster-infra-critical
       token:
         name: 1password-connect-credentials
         key: token

--- a/clusters/kubenuc/apps/cert-manager/deploy.yaml
+++ b/clusters/kubenuc/apps/cert-manager/deploy.yaml
@@ -8,6 +8,7 @@ spec:
   dependsOn:
     - name: cluster-vars
     - name: charts
+    - name: priority-classes
   interval: 15m
   sourceRef:
     kind: GitRepository

--- a/clusters/kubenuc/apps/cert-manager/manifests/release.yml
+++ b/clusters/kubenuc/apps/cert-manager/manifests/release.yml
@@ -30,6 +30,11 @@ spec:
   driftDetection:
     mode: warn
   values:
+    # Applies to all 3 components (controller/webhook/cainjector) - webhook
+    # gates every resource admission cluster-wide, cainjector feeds every
+    # cert-manager CA bundle, so both need the same protection as controller.
+    global:
+      priorityClassName: cluster-infra-critical
     crds:
       enabled: true
       keep: true

--- a/clusters/kubenuc/apps/haproxy-ingress/deploy.yaml
+++ b/clusters/kubenuc/apps/haproxy-ingress/deploy.yaml
@@ -5,6 +5,8 @@ metadata:
   name: haproxy-ingress
   namespace: flux-system
 spec:
+  dependsOn:
+    - name: priority-classes
   interval: 15m
   sourceRef:
     kind: GitRepository

--- a/clusters/kubenuc/apps/haproxy-ingress/manifests/release.yml
+++ b/clusters/kubenuc/apps/haproxy-ingress/manifests/release.yml
@@ -31,6 +31,7 @@ spec:
     mode: warn
   values:
     controller:
+      priorityClassName: cluster-infra-critical
       kind: Deployment
       ingressClass: haproxy
       ingressClassResource:

--- a/clusters/kubenuc/kustomization.yaml
+++ b/clusters/kubenuc/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - charts.yaml
   - cluster-vars.yaml
   - flux-instance.yaml
+  - priority-classes.yaml

--- a/clusters/kubenuc/priority-classes.yaml
+++ b/clusters/kubenuc/priority-classes.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: priority-classes
+  namespace: flux-system
+spec:
+  interval: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./clusters/kubenuc/priority-classes
+  prune: true

--- a/clusters/kubenuc/priority-classes/cluster-infra-critical.yaml
+++ b/clusters/kubenuc/priority-classes/cluster-infra-critical.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: cluster-infra-critical
+# Well above regular app pods (default 0) so kubelet protects these first
+# under node pressure, but far below the built-in system-cluster-critical
+# (2000000000) reserved for kube-system. preemptionPolicy: Never - a
+# pending pod at this priority will queue ahead of lower-priority pods but
+# will NOT evict already-running ones to make room. Scheduling-order +
+# eviction-order protection without the active disruption risk of
+# preemption, matching the audit-first spirit of driftDetection: warn.
+value: 1000000
+globalDefault: false
+preemptionPolicy: Never
+description: >-
+  Foundational cluster infrastructure that other apps depend on
+  (ingress, cert issuance, secrets access) - never preempts other pods,
+  only ranks ahead of them for scheduling order and node-pressure eviction.


### PR DESCRIPTION
## Summary
- C7: adds a new `cluster-infra-critical` PriorityClass (value `1000000`, `preemptionPolicy: Never`, `globalDefault: false`) and wires it into `haproxy-ingress`, `cert-manager`, and `1password` — apps everything else on the cluster ultimately depends on (ingress entry point, TLS/webhook admission, secrets access)
- Design: **`preemptionPolicy: Never`** — pods at this priority queue ahead of others for scheduling and are protected first under kubelet node-pressure eviction, but never evict already-running lower-priority pods to make room. This is the audit-first analog of `driftDetection: mode: warn` — observation/ordering benefit without the active-disruption risk of real preemption, which matters given this repo's own CI has repeatedly hit resource-constrained-runner symptoms (see recent #1594-#1596 investigations)
- Each `priorityClassName` key verified against the real chart template source via `helm template` before committing (not assumed from `values.yaml` alone):
  - cert-manager: `global.priorityClassName` → confirmed on controller/webhook/cainjector Deployments + the startupapicheck Job
  - 1password: separate `connect.priorityClassName` + `operator.priorityClassName` → confirmed on both Deployments
  - haproxy-ingress: `controller.priorityClassName` → confirmed on the controller Deployment
- The `priority-classes` Kustomization is a new top-level resource (sibling to `charts.yaml`) so it reconciles independently; the 3 target apps' Kustomizations now `dependsOn: [priority-classes]` since the API server rejects a pod naming a PriorityClass that doesn't exist yet

## Scope / exclusions
- **coredns**: not Flux-managed — it's the cluster distribution's built-in `kube-system` Deployment; this repo only adds an HPA/PDB for it (from C5), no HelmRelease to attach a priorityClassName to
- **openebs**: verified the chart exposes no `priorityClassName` value anywhere in its template tree (not assumed — grepped the whole chart source)
- Database/application-tier pods deferred to a later pass — this batch is the narrow "foundational infra" tier only

## Test plan
- [x] `helm template` against real cloned chart sources confirms `priorityClassName` renders on every target Deployment/Job
- [x] All 9 files pass `yq eval` YAML validation
- [x] `pre-commit run` (trailing-whitespace, end-of-file-fixer, check-yaml, gitleaks) passes
- [x] CI (kubenuc-full-cluster-e2e)