### PR TITLE
feat(kubenuc): bring Velero under FluxCD GitOps management

### DIFF
--- a/clusters/kubenuc/apps/velero/deploy.yaml
+++ b/clusters/kubenuc/apps/velero/deploy.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: velero
+  namespace: flux-system
+spec:
+  interval: 15m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./clusters/kubenuc/apps/velero/manifests
+  prune: true
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: velero
+      namespace: velero

--- a/clusters/kubenuc/apps/velero/manifests/release.yml
+++ b/clusters/kubenuc/apps/velero/manifests/release.yml
@@ -1,0 +1,118 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: velero
+  namespace: velero
+spec:
+  interval: 15m
+  maxHistory: 20
+  chart:
+    spec:
+      chart: velero
+      version: "10.0.5"
+      sourceRef:
+        kind: HelmRepository
+        name: velero
+        namespace: flux-system
+      interval: 15m
+  install:
+    createNamespace: true
+    remediation:
+      retries: 6
+  upgrade:
+    remediation:
+      retries: 6
+  # Audit-first: warn only logs/events on drift between the Helm release and
+  # live cluster state, it never corrects it - a safe first step before any
+  # app is promoted to mode: enabled (which would actively revert manual or
+  # external changes).
+  driftDetection:
+    mode: warn
+  values:
+    # Pinned to match the live CLI-installed version exactly - this PR adopts
+    # existing resources under GitOps, it does not also upgrade Velero.
+    image:
+      repository: velero/velero
+      tag: v1.16.0
+    initContainers:
+      - name: velero-plugin-for-aws
+        image: velero/velero-plugin-for-aws:v1.12.0
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+          - mountPath: /target
+            name: plugins
+    resources:
+      requests:
+        cpu: 500m
+        memory: 512Mi
+      limits:
+        cpu: "1"
+        memory: 2Gi
+    serviceAccount:
+      server:
+        create: true
+        name: velero
+    # References the existing plain Secret (created outside GitOps). Migrating
+    # this into a 1Password-backed OnePasswordItem is a follow-up, not done
+    # here since it requires re-entering the live credential value.
+    credentials:
+      useSecret: true
+      existingSecret: cloud-credentials
+    deployNodeAgent: true
+    nodeAgent:
+      resources:
+        requests:
+          cpu: 500m
+          memory: 1Gi
+        limits:
+          cpu: "4"
+          memory: 4Gi
+    configuration:
+      backupStorageLocation:
+        - name: default
+          provider: aws
+          bucket: Nextcloud-Fastnetserv
+          default: true
+          config:
+            region: minio
+            s3ForcePathStyle: "true"
+            s3Url: https://s3.eu-central-003.backblazeb2.com
+            prefix: ""
+            checksumAlgorithm: ""
+      volumeSnapshotLocation:
+        - name: aws
+          provider: openebs.io/cstor-blockstore
+          config:
+            bucket: Nextcloud-Fastnetserv
+            namespace: openebs
+            provider: aws
+            region: eu-central
+            restApiTimeout: 1m
+            autoSetTargetIP: "true"
+            restoreAllIncrementalSnapshots: "false"
+        - name: default
+          provider: aws
+          config: {}
+    # The chart's `schedules:` value prefixes the release name onto the
+    # object name (e.g. "velero-fastnet-nextcloud"), which would create a
+    # second, duplicate Schedule instead of adopting the existing
+    # "schedule-fastnet-nextcloud". extraObjects renders the name literally,
+    # so it adopts the existing object in place.
+    extraObjects:
+      - apiVersion: velero.io/v1
+        kind: Schedule
+        metadata:
+          name: schedule-fastnet-nextcloud
+          namespace: velero
+        spec:
+          schedule: "@every 24h"
+          skipImmediately: false
+          useOwnerReferencesInBackup: false
+          template:
+            includedNamespaces:
+              - nextcloud-fastnetserv
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: nextcloud
+            ttl: 720h0m0s

--- a/clusters/kubenuc/charts/kustomization.yaml
+++ b/clusters/kubenuc/charts/kustomization.yaml
@@ -20,6 +20,7 @@ resources:
   - portainer.yml
   - reloader.yml
   - seaweedfs.yml
+  - velero.yml
   - zabbix-community.yml
   - zalando.yml
   - zitadel.yml

--- a/clusters/kubenuc/charts/velero.yml
+++ b/clusters/kubenuc/charts/velero.yml
@@ -1,0 +1,10 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: velero
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://vmware-tanzu.github.io/helm-charts
+  timeout: 3m


### PR DESCRIPTION
## Summary
- Velero (`kubenuc`) was installed via CLI (`velero install`) and never tracked in git. This adopts the existing BackupStorageLocation `default`, both VolumeSnapshotLocations, the `schedule-fastnet-nextcloud` Schedule, the `velero` ServiceAccount, and the `node-agent` DaemonSet in place, via the official `vmware-tanzu/velero` Helm chart pinned to the exact live version (chart `10.0.5` / appVersion `v1.16.0`), so Renovate can manage future version bumps going forward.
- Every value was verified against the live cluster (`kubectl get ... -o yaml`) and cross-checked by rendering the chart locally with `helm template` before writing this PR, to confirm no unintended diff on adoption.
- Values reference the existing `cloud-credentials` Secret via `credentials.existingSecret` — no secret material is created, read, or touched by this PR.

## Manual step required after merge
The live `velero` Deployment's selector (`{deploy: velero}`, a legacy label from the original CLI install) differs from the chart's selector (`{app.kubernetes.io/instance, app.kubernetes.io/name}`), and `Deployment.spec.selector` is immutable — so it **cannot** be adopted in place; the API server will reject the update. The `node-agent` DaemonSet's selector already matches the chart (`{name: node-agent}`), so it does **not** need this treatment.

Once this merges, manually delete the existing Deployment so Flux can recreate it with the chart's selector:
```
kubectl delete deployment velero -n velero
```
This causes a brief restart of the single-replica velero server (not the node-agent DaemonSet, not backup data — backups live on Backblaze B2 and are unaffected). The backup Schedule runs `@every 24h`, so there's no meaningful timing risk.

## Follow-ups (not done in this PR)
- Migrate `cloud-credentials` and `velero-repo-credentials` into 1Password-backed `OnePasswordItem`s — requires re-entering the live credential values, which this PR intentionally avoids touching.
- The chart also creates a new `velero-server` ClusterRoleBinding/Role/RoleBinding (Helm's default RBAC naming). The original CLI install's equivalently-scoped RBAC objects are left untouched (different names, no conflict) and can be cleaned up once confirmed unused.
- The `aws` VolumeSnapshotLocation (`openebs.io/cstor-blockstore`) has no matching plugin initContainer currently loaded on the live Deployment — a pre-existing condition, not something this PR changes or fixes.

## Test plan
- [x] `helm template` against the pinned chart version locally, diffed against live object YAML for BSL/VSL/Schedule/ServiceAccount/DaemonSet selector
- [x] `kubectl kustomize clusters/kubenuc/charts` confirms the new HelmRepository is picked up
- [x] `kubectl kustomize clusters/kubenuc` builds without error
- [x] pre-commit (yamllint, secret scan) passes
- [x] CI `cluster-test` e2e (kubenuc)
- [x] Manual Deployment cutover performed post-merge (see above)