### PR TITLE
fix(kubenuc): pin velero's kubectl sidecar to a real bitnamilegacy tag

### DIFF
--- a/clusters/kubenuc/apps/velero/manifests/release.yml
+++ b/clusters/kubenuc/apps/velero/manifests/release.yml
@@ -35,6 +35,16 @@ spec:
     image:
       repository: velero/velero
       tag: v1.16.0
+    # The chart's default kubectl sidecar (used by the pre-install/pre-upgrade
+    # upgrade-crds Job) derives its tag from the live cluster's Kubernetes
+    # minor version, but docker.io/bitnami/kubectl no longer publishes
+    # versioned tags on the free tier (only `latest` + digest artifacts) -
+    # the computed "1.33" tag 404s. bitnamilegacy/kubectl still mirrors real
+    # versioned tags, pinned here to the cluster's actual minor version.
+    kubectl:
+      image:
+        repository: bitnamilegacy/kubectl
+        tag: "1.33.4"
     initContainers:
       - name: velero-plugin-for-aws
         image: velero/velero-plugin-for-aws:v1.12.0


### PR DESCRIPTION
## Summary
- Follow-up to #1606. The velero-upgrade-crds pre-install Job is stuck in `ImagePullBackOff` on the live cluster right now: the chart derives the `kubectl` sidecar's tag from the live cluster's Kubernetes minor version (`1.33` on kubenuc, a k3s cluster), but `docker.io/bitnami/kubectl` no longer publishes versioned tags on the free tier — only `latest` and digest artifacts remain (Bitnami's 2025 Secure Images catalog migration). The computed `1.33` tag simply doesn't exist.
- `bitnamilegacy/kubectl` still mirrors real versioned tags (confirmed `1.33.4` exists, amd64+arm64, published 2025-08-22). Pinned explicitly to match the live cluster's actual minor version.
- Verified locally with `helm template ... --kube-version 1.33` before pushing.

This wasn't (and couldn't be) caught by local `helm template` verification during #1606's review, since the tag is computed from `.Capabilities.KubeVersion`, which only reflects the real value when rendered by a controller with actual cluster access (or via `--kube-version` matching the live cluster, which I didn't think to pass at the time).

## Test plan
- [x] `helm template` with `--kube-version 1.33` renders `bitnamilegacy/kubectl:1.33.4`
- [x] `kubectl kustomize clusters/kubenuc` builds without error
- [x] pre-commit passes
- [x] CI `cluster-test` e2e
- [ ] Confirm the stuck `velero-upgrade-crds` Job pod recovers on the live cluster once this merges and reconciles