### PR TITLE
feat(kubenuc): add node-problem-detector

### DIFF
--- a/clusters/kubenuc/apps/node-problem-detector/deploy.yaml
+++ b/clusters/kubenuc/apps/node-problem-detector/deploy.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: node-problem-detector
+  namespace: flux-system
+spec:
+  interval: 15m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./clusters/kubenuc/apps/node-problem-detector/manifests
+  prune: true
+  healthChecks:
+    - apiVersion: apps/v1
+      kind: DaemonSet
+      name: node-problem-detector
+      namespace: kube-system

--- a/clusters/kubenuc/apps/node-problem-detector/manifests/configmap.yml
+++ b/clusters/kubenuc/apps/node-problem-detector/manifests/configmap.yml
@@ -1,0 +1,95 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: node-problem-detector-config
+  namespace: kube-system
+data:
+  kernel-monitor.json: |
+    {
+        "plugin": "kmsg",
+        "logPath": "/dev/kmsg",
+        "lookback": "5m",
+        "bufferSize": 10,
+        "source": "kernel-monitor",
+        "conditions": [
+            {
+                "type": "KernelDeadlock",
+                "reason": "KernelHasNoDeadlock",
+                "message": "kernel has no deadlock"
+            },
+            {
+                "type": "ReadonlyFilesystem",
+                "reason": "FilesystemIsNotReadOnly",
+                "message": "Filesystem is not read-only"
+            }
+        ],
+        "rules": [
+            {
+                "type": "temporary",
+                "reason": "OOMKilling",
+                "pattern": "Kill process \\d+ (.+) score \\d+ or sacrifice child\\nKilled process \\d+ (.+) total-vm:\\d+kB, anon-rss:\\d+kB, file-rss:\\d+kB.*"
+            },
+            {
+                "type": "temporary",
+                "reason": "TaskHung",
+                "pattern": "task \\S+:\\w+ blocked for more than \\w+ seconds\\."
+            },
+            {
+                "type": "temporary",
+                "reason": "UnregisterNetDevice",
+                "pattern": "unregister_netdevice: waiting for \\w+ to become free. Usage count = \\d+"
+            },
+            {
+                "type": "temporary",
+                "reason": "KernelOops",
+                "pattern": "BUG: unable to handle kernel NULL pointer dereference at .*"
+            },
+            {
+                "type": "temporary",
+                "reason": "KernelOops",
+                "pattern": "divide error: 0000 \\[#\\d+\\] SMP"
+            },
+            {
+                "type": "temporary",
+                "reason": "MemoryReadError",
+                "pattern": "CE memory read error .*"
+            },
+            {
+                "type": "permanent",
+                "condition": "KernelDeadlock",
+                "reason": "DockerHung",
+                "pattern": "task docker:\\w+ blocked for more than \\w+ seconds\\."
+            },
+            {
+                "type": "permanent",
+                "condition": "ReadonlyFilesystem",
+                "reason": "FilesystemIsReadOnly",
+                "pattern": "Remounting filesystem read-only"
+            }
+        ]
+    }
+  readonly-monitor.json: |
+    {
+        "plugin": "kmsg",
+        "logPath": "/dev/kmsg",
+        "lookback": "5m",
+        "bufferSize": 10,
+        "source": "readonly-monitor",
+        "metricsReporting": true,
+        "conditions": [
+            {
+                "type": "ReadonlyFilesystem",
+                "reason": "FilesystemIsNotReadOnly",
+                "message": "Filesystem is not read-only"
+            }
+        ],
+        "rules": [
+            {
+                "type": "permanent",
+                "condition": "ReadonlyFilesystem",
+                "reason": "FilesystemIsReadOnly",
+                "pattern": "Remounting filesystem read-only"
+            }
+        ]
+    }

--- a/clusters/kubenuc/apps/node-problem-detector/manifests/daemonset.yml
+++ b/clusters/kubenuc/apps/node-problem-detector/manifests/daemonset.yml
@@ -1,0 +1,94 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-problem-detector
+  namespace: kube-system
+  labels:
+    app: node-problem-detector
+  annotations:
+    # node-problem-detector reads /dev/kmsg for kernel-level fault detection
+    # (OOM kills, deadlocks, filesystem remounts), which requires privileged
+    # mode - this is the standard, documented requirement for this tool
+    # across the ecosystem, not something specific to this deployment.
+    ignore-check.kube-linter.io/privileged-container: "node-problem-detector requires privileged access to read /dev/kmsg for kernel fault detection"
+    ignore-check.kube-linter.io/privilege-escalation-container: "same requirement as privileged-container - inherent to reading /dev/kmsg"
+    ignore-check.kube-linter.io/run-as-non-root: "privileged mode already grants full host access regardless of UID; the upstream image runs as root by design"
+spec:
+  selector:
+    matchLabels:
+      app: node-problem-detector
+  template:
+    metadata:
+      labels:
+        app: node-problem-detector
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+      serviceAccountName: node-problem-detector
+      containers:
+        - name: node-problem-detector
+          image: registry.k8s.io/node-problem-detector/node-problem-detector:v1.35.2
+          imagePullPolicy: IfNotPresent
+          command:
+            - /node-problem-detector
+            - --logtostderr
+            - --config.system-log-monitor=/config/kernel-monitor.json,/config/readonly-monitor.json
+          resources:
+            requests:
+              cpu: 10m
+              memory: 80Mi
+            limits:
+              cpu: 10m
+              memory: 80Mi
+          securityContext:
+            privileged: true
+            readOnlyRootFilesystem: true
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: log
+              mountPath: /var/log
+              readOnly: true
+            - name: kmsg
+              mountPath: /dev/kmsg
+              readOnly: true
+            - name: localtime
+              mountPath: /etc/localtime
+              readOnly: true
+            - name: config
+              mountPath: /config
+              readOnly: true
+      volumes:
+        - name: log
+          hostPath:
+            path: /var/log/
+        - name: kmsg
+          hostPath:
+            path: /dev/kmsg
+        - name: localtime
+          hostPath:
+            path: /etc/localtime
+        - name: config
+          configMap:
+            name: node-problem-detector-config
+            items:
+              - key: kernel-monitor.json
+                path: kernel-monitor.json
+              - key: readonly-monitor.json
+                path: readonly-monitor.json
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists

--- a/clusters/kubenuc/apps/node-problem-detector/manifests/rbac.yml
+++ b/clusters/kubenuc/apps/node-problem-detector/manifests/rbac.yml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: node-problem-detector
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: node-problem-detector
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  # Built-in bootstrap ClusterRole shipped by Kubernetes/k3s itself - not
+  # defined in this repo, confirmed present on kubenuc.
+  name: system:node-problem-detector
+subjects:
+  - kind: ServiceAccount
+    name: node-problem-detector
+    namespace: kube-system


### PR DESCRIPTION
## Summary
- Plan C item C10. Deploys `kubernetes/node-problem-detector` v1.35.2 as a DaemonSet in `kube-system`, sourced from upstream's raw deployment manifests (`deployment/*.yaml` at tag `v1.35.2` — no official Helm chart exists for this project, several unofficial community ones do, deliberately not used here to keep this on an upstream-maintained source).
- Only `kernel-monitor.json` + `readonly-monitor.json` enabled. Upstream's default manifest also ships `docker-monitor.json`, dropped here since kubenuc is a k3s/containerd cluster (confirmed live: `v1.33.11+k3s1`) — that monitor filters journald for a `dockerd` source that will never exist here.
- **Note:** upstream's own `deployment/node-problem-detector.yaml` at this tag still embeds a stale `v0.8.19` image reference even though the release itself is `v1.35.2` — pinned explicitly to `v1.35.2` here instead (verified the tag exists on `registry.k8s.io` for amd64+arm64 via `docker manifest inspect`), not copied verbatim.
- Deployed **unscraped** — no `ServiceMonitor`, no Alloy scrape annotation — per this repo's `grafana-cardinality-guard` skill, which explicitly gates node-problem-detector on this. Checked the current active-series baseline anyway for the record: ~2523, well under the 10K Grafana Cloud budget.
- RBAC binds to the built-in `system:node-problem-detector` ClusterRole shipped by Kubernetes/k3s itself (confirmed present on kubenuc via `kubectl get clusterrole`) — not something this repo needs to define.
- Deliberately **not** using the upstream `node-problem-detector-healthchecker.yaml` variant (kubelet health via systemd/dbus with a writable `mountPropagation: Bidirectional` host mount) — narrower footprint as a first step, consistent with this plan's audit-first approach elsewhere (`driftDetection: warn`, non-preempting `PriorityClass`, etc.). Can be layered in later if useful.

## KubeLinter exception (first use of this pattern in the repo)
Privileged mode is required to read `/dev/kmsg` for kernel-level fault detection (OOM kills, deadlocks, filesystem remounts) — the standard, documented requirement for this tool across the ecosystem, not something specific to this deployment. Trips 3 included checks: `privileged-container`, `privilege-escalation-container`, `run-as-non-root`. Suppressed via `ignore-check.kube-linter.io/*` annotations with inline justification on the DaemonSet. `readOnlyRootFilesystem: true` is set (that check passes cleanly — NPD doesn't write to its own container filesystem).

## Test plan
- [x] `kube-linter lint` (local, v0.8.3, same version as CI) — clean, including a full run across every cluster's `apps/` dirs to confirm no regressions elsewhere
- [x] `kubectl kustomize clusters/kubenuc` builds without error
- [x] pre-commit passes
- [x] CI `cluster-test` e2e