### PR TITLE
feat(k8s-vms-daniele): opt semaphore into external-dns

### DIFF
--- a/clusters/k8s-vms-daniele/apps/semaphore/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/semaphore/manifests/release.yml
@@ -94,6 +94,16 @@ spec:
       className: traefik
       annotations:
         cert-manager.io/cluster-issuer: "letsencrypt"
+        # Opt-in to external-dns (see the External DNS runbook). No public
+        # DNS record for SEMAPHORE_HOST exists today (confirmed via dig
+        # against multiple resolvers) despite this Ingress running for
+        # weeks - creates a new record rather than adopting an existing
+        # one. proxied:"true" to match every other app host in this
+        # migration. Tunnel target comes from cluster-vars (never hardcode
+        # FQDNs/tunnel targets in git).
+        external-dns.alpha.kubernetes.io/managed-by: external-dns
+        external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
+        external-dns.alpha.kubernetes.io/target: ${CLOUDFLARE_TUNNEL_TARGET}
       hosts:
         - host: ${SEMAPHORE_HOST}
           paths:


### PR DESCRIPTION
## Summary
External DNS migration, Phase 1 (see the [External DNS runbook](https://fastnetserv.atlassian.net/wiki/spaces/IT/pages/774012929/External+DNS)) — opting in one verified host at a time. First (and, per the current audit, only) untouched dev-cluster host: **semaphore**.

- Unlike every other host in this migration, `SEMAPHORE_HOST` has **no public Cloudflare DNS record at all** today — confirmed via `dig` against both the local resolver and `8.8.8.8` directly, both empty. This is despite the Ingress running for 42 days. Its `semaphore-tls` Certificate has been stuck `READY: False` the entire time as a direct consequence.
- Confirmed with the user this is an oversight, not intentional (Semaphore isn't meant to be private) — this PR creates a new record rather than adopting an existing one, unlike the other hosts in this migration.
- `cloudflare-proxied: "true"` to match every other app host (no existing record to match against here).
- `target` sources from the existing `CLOUDFLARE_TUNNEL_TARGET` cluster-vars entry (already defined on this cluster, used by AWX's already-live opt-in).
- Both clusters' `ClusterIssuer` use DNS-01 (Cloudflare) challenges, not HTTP-01, so the stuck cert was never blocked on public DNS resolution existing — this PR may or may not also unstick it as a side effect; worth checking post-merge but isn't the primary goal here.

## Verification plan post-merge
1. `kubectl -n external-dns logs deploy/external-dns` — expect exactly one `CREATE` for `semaphore` and nothing else.
2. Confirm the new record + `extdns-semaphore` TXT ownership record appear in Cloudflare.
3. Check whether `semaphore-tls` Certificate transitions to `READY: True` (separate question from external-dns adoption itself, but worth confirming either way).
4. `terraform plan` in `terraform/DNS/` — expect zero changes (this host was never Terraform-managed in the first place, so there's no Phase 2 for it).

## Test plan
- [x] `kube-linter lint` — clean
- [x] `kubectl kustomize clusters/k8s-vms-daniele` builds without error
- [x] pre-commit passes
- [x] CI `cluster-test` e2e (`validate-k8s-vms.yml`)
- [x] Live verification per the 4 steps above, post-merge