### PR TITLE
feat(kubenuc): opt jenkins into external-dns

### DIFF
--- a/clusters/kubenuc/apps/jenkins/manifests/release.yml
+++ b/clusters/kubenuc/apps/jenkins/manifests/release.yml
@@ -46,6 +46,14 @@ spec:
 
         annotations:
           cert-manager.io/cluster-issuer: letsencrypt
+          # Opt-in to external-dns (see the External DNS runbook). Adopts
+          # the existing live record - proxied:"true" matches its current
+          # state, confirmed via dig resolving to Cloudflare edge IPs
+          # before this change. Tunnel target comes from cluster-vars
+          # (never hardcode FQDNs/tunnel targets in git).
+          external-dns.alpha.kubernetes.io/managed-by: external-dns
+          external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
+          external-dns.alpha.kubernetes.io/target: ${CLOUDFLARE_TUNNEL_TARGET}
         ingressClassName: haproxy
 
         hostName: ${JENKINS_HOST}


### PR DESCRIPTION
## Summary
External DNS migration, Phase 1 (see the [External DNS runbook](https://fastnetserv.atlassian.net/wiki/spaces/IT/pages/774012929/External+DNS)) — opting in one verified host at a time. Third host, second on kubenuc: **jenkins**.

- jenkins already has a live, Cloudflare-proxied A record today (confirmed via `dig` before this change — resolves to real Cloudflare edge IPs). This adopts that existing record; nothing new is created.
- `cloudflare-proxied: "true"` matches the record's current live state.
- `target` sources from the existing `CLOUDFLARE_TUNNEL_TARGET` cluster-vars entry (already defined on kubenuc, used by portainer's opt-in in #1610).
- `policy: upsert-only` on the external-dns HelmRelease means this can only create/update this host's record, never delete it.

## Verification plan post-merge (before Phase 2 on this host)
1. `kubectl -n external-dns logs deploy/external-dns` — expect exactly one `CREATE`/`UPDATE` for jenkins and nothing else, no `_acme-challenge` touches.
2. Confirm a new `extdns-jenkins` TXT ownership record appears in Cloudflare.
3. `terraform plan` in `terraform/DNS/` — expect **zero changes** to jenkins' existing A record.
4. Only once that's clean does Phase 2 (releasing the record from Terraform state without destroying it) happen, as a separate PR per the runbook — not bundled here.

## Test plan
- [x] `kube-linter lint` — clean
- [x] `kubectl kustomize clusters/kubenuc` builds without error
- [x] pre-commit passes
- [x] CI `cluster-test` e2e
- [x] Live verification per the 4 steps above, post-merge