### PR TITLE
feat(k8s-vms): add cloudnative-pg operator and dedicated semaphore postgres

### DIFF
--- a/clusters/k8s-vms-daniele/apps/cloudnative-pg-operator/deploy.yaml
+++ b/clusters/k8s-vms-daniele/apps/cloudnative-pg-operator/deploy.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cloudnative-pg-operator
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: cluster-vars
+    - name: charts
+  interval: 15m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./clusters/k8s-vms-daniele/apps/cloudnative-pg-operator/manifests
+  prune: true
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: cloudnative-pg
+      namespace: cnpg-system

--- a/clusters/k8s-vms-daniele/apps/cloudnative-pg-operator/manifests/namespace.yml
+++ b/clusters/k8s-vms-daniele/apps/cloudnative-pg-operator/manifests/namespace.yml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cnpg-system
+  labels:
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: v1.32
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: v1.32
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/clusters/k8s-vms-daniele/apps/cloudnative-pg-operator/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/cloudnative-pg-operator/manifests/release.yml
@@ -1,0 +1,48 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cloudnative-pg
+  namespace: cnpg-system
+spec:
+  interval: 15m
+  maxHistory: 20
+  chart:
+    spec:
+      # Chart 0.29.0 tracks operator appVersion 1.30.0 (verified against the
+      # chart repo's index.yaml at implementation time) - first CNPG use in
+      # this repo, existing convention elsewhere (kubenuc) is the unrelated
+      # Zalando postgres-operator CRDs.
+      chart: cloudnative-pg
+      version: "0.29.0"
+      sourceRef:
+        kind: HelmRepository
+        name: cloudnative-pg
+        namespace: flux-system
+      interval: 15m
+  install:
+    createNamespace: true
+    crds: CreateReplace
+    remediation:
+      retries: 6
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 6
+  # Audit-first: warn only logs/events on drift between the Helm release and
+  # live cluster state, it never corrects it - a safe first step before any
+  # app is promoted to mode: enabled (which would actively revert manual or
+  # external changes).
+  driftDetection:
+    mode: warn
+  values:
+    # podMonitorEnabled left at the chart default (false) - Prometheus
+    # Operator CRDs are not confirmed present on k8s-vms-daniele, and
+    # enabling it would create a dangling PodMonitor CR.
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        cpu: 200m
+        memory: 256Mi

--- a/clusters/k8s-vms-daniele/apps/semaphore-db/deploy.yaml
+++ b/clusters/k8s-vms-daniele/apps/semaphore-db/deploy.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: semaphore-db
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: cloudnative-pg-operator
+  interval: 15m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./clusters/k8s-vms-daniele/apps/semaphore-db/manifests
+  prune: true
+  healthChecks:
+    - apiVersion: postgresql.cnpg.io/v1
+      kind: Cluster
+      name: semaphore-db
+      namespace: semaphore

--- a/clusters/k8s-vms-daniele/apps/semaphore-db/manifests/cluster.yml
+++ b/clusters/k8s-vms-daniele/apps/semaphore-db/manifests/cluster.yml
@@ -1,0 +1,40 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: semaphore-db
+  namespace: semaphore
+spec:
+  instances: 1
+  # No imageName set - uses the operator's default recommended PostgreSQL
+  # image/version rather than guessing a pin here.
+  storage:
+    size: 5Gi
+    storageClass: local-path
+  # Single instance, no standby to fail over to - a minAvailable:1 PDB would
+  # permanently block node drains (same reasoning as this repo's kubenuc
+  # single-replica-app convention, see clusters/kubenuc/CLAUDE.md).
+  enablePDB: false
+  monitoring:
+    # Left disabled - Prometheus Operator CRDs are not confirmed present on
+    # k8s-vms-daniele, and enabling it would create a dangling PodMonitor CR.
+    enablePodMonitor: false
+  bootstrap:
+    initdb:
+      database: semaphore
+      owner: semaphore
+      # No secret set - CNPG auto-generates a properly-typed
+      # (kubernetes.io/basic-auth) "semaphore-db-app" Secret with
+      # username/password. 1Password's OnePasswordItem CRD has no way to
+      # set a target Secret's type, so a 1Password-sourced secret here
+      # would not satisfy CNPG's requirement.
+  resources:
+    # Guaranteed QoS (CNPG's own recommendation for Postgres pods) -
+    # requests == limits. Sized modestly for Semaphore's light job-history
+    # workload.
+    requests:
+      cpu: 200m
+      memory: 512Mi
+    limits:
+      cpu: 200m
+      memory: 512Mi

--- a/clusters/k8s-vms-daniele/apps/semaphore/deploy.yaml
+++ b/clusters/k8s-vms-daniele/apps/semaphore/deploy.yaml
@@ -23,6 +23,7 @@ spec:
   dependsOn:
     - name: cluster-vars
     - name: semaphore-secrets
+    - name: semaphore-db
   interval: 15m
   sourceRef:
     kind: GitRepository

--- a/clusters/k8s-vms-daniele/apps/semaphore/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/semaphore/manifests/release.yml
@@ -34,11 +34,14 @@ spec:
   #   admin-username  - Initial admin username
   #   admin-password  - Initial admin password
   #   admin-email     - Admin email address
-  #   db-host         - PostgreSQL host (e.g. postgresql-db.postgresql-db.svc.cluster.local)
-  #   db-name         - PostgreSQL database name
-  #   db-user         - PostgreSQL username
-  #   db-password     - PostgreSQL password
   #   access-key      - Random 32-char string used as encryption key
+  #
+  # db-host/db-name/db-user/db-password used to live in this secret too, but
+  # are now unused/stale - Semaphore has its own dedicated CNPG Postgres
+  # (see ../semaphore-db). database.host/database.name are literal values
+  # below (not sensitive - the CNPG service name and db name are known once
+  # the Cluster is named); db-user/db-password now come from the
+  # CNPG-generated semaphore-db-app secret instead.
   valuesFrom:
     - kind: Secret
       name: semaphore-credentials
@@ -53,20 +56,12 @@ spec:
       valuesKey: admin-email
       targetPath: auth.admin.email
     - kind: Secret
-      name: semaphore-credentials
-      valuesKey: db-host
-      targetPath: database.host
-    - kind: Secret
-      name: semaphore-credentials
-      valuesKey: db-name
-      targetPath: database.name
-    - kind: Secret
-      name: semaphore-credentials
-      valuesKey: db-user
+      name: semaphore-db-app
+      valuesKey: username
       targetPath: database.username
     - kind: Secret
-      name: semaphore-credentials
-      valuesKey: db-password
+      name: semaphore-db-app
+      valuesKey: password
       targetPath: database.password
     - kind: Secret
       name: semaphore-credentials
@@ -88,6 +83,11 @@ spec:
 
     database:
       type: postgres
+      # Not sensitive - CNPG's generated -rw service name and the bootstrap
+      # database name, both known once the Cluster is named. See
+      # ../semaphore-db/manifests/cluster.yml.
+      host: semaphore-db-rw.semaphore.svc.cluster.local
+      name: semaphore
 
     ingress:
       enabled: true

--- a/clusters/k8s-vms-daniele/charts/cloudnative-pg.yml
+++ b/clusters/k8s-vms-daniele/charts/cloudnative-pg.yml
@@ -1,0 +1,10 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: cloudnative-pg
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://cloudnative-pg.github.io/charts
+  timeout: 3m

--- a/clusters/k8s-vms-daniele/charts/kustomization.yaml
+++ b/clusters/k8s-vms-daniele/charts/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: flux-system
 resources:
   - 1password.yml
+  - cloudnative-pg.yml
   - external-dns.yml
   - falcosecurity.yml
   - grafana.yml


### PR DESCRIPTION
## Summary
- **Root cause (confirmed live):** Semaphore crashloops with `panic: pq: password authentication failed for user "semaphore" (28P01)`. Its `db-host` points at AWX's own leftover bundled Postgres — no `semaphore` role/database was ever created there.
- **Decision:** don't reuse AWX's postgres; deploy a dedicated single-instance CloudNativePG cluster (operator v1.30, chart `0.29.0` — verified against the chart repo's `index.yaml` — `instances: 1`, no HA). First CNPG use in this repo; existing convention elsewhere (kubenuc) is Zalando's operator, unrelated CRDs.
- `clusters/k8s-vms-daniele/charts/cloudnative-pg.yml` — new `HelmRepository`, added to the charts kustomization's explicit `resources:` list.
- `clusters/k8s-vms-daniele/apps/cloudnative-pg-operator/` — new app: operator `HelmRelease` in `cnpg-system`.
- `clusters/k8s-vms-daniele/apps/semaphore-db/` — new app: `Cluster` (`semaphore` namespace, `instances: 1`, `storageClass: local-path`, **5Gi** PVC, `enablePDB: false` — consistent with this repo's single-replica-app PDB convention, `monitoring.enablePodMonitor: false` since Prometheus Operator CRDs aren't confirmed present here).
- **`bootstrap.initdb.secret` intentionally omitted.** CNPG requires a `kubernetes.io/basic-auth`-typed secret; the 1Password Operator's `OnePasswordItem` CRD has no way to set a target Secret's `type` (verified against its live CRD schema on kubenuc — `spec` only exposes `itemPath`). CNPG auto-generates its own correctly-typed `semaphore-db-app` secret instead.
- `clusters/k8s-vms-daniele/apps/semaphore/manifests/release.yml` — `database.host`/`database.name` are now literal `values:` (not sensitive — the CNPG `-rw` service name and db name are known once the Cluster is named); `db-user`/`db-password` `valuesFrom` now point at the CNPG-generated `semaphore-db-app` secret (`username`/`password` keys) instead of `semaphore-credentials`. The 1Password item `semaphore_k8s-vms-daniele` keeps only `admin-username`/`admin-password`/`admin-email`/`access-key` as still relevant — its `db-host`/`db-name`/`db-user`/`db-password` fields are now stale/unused (noted, not removed from 1Password in this PR).
- `clusters/k8s-vms-daniele/apps/semaphore/deploy.yaml` — added `semaphore-db` to the `semaphore` Kustomization's `dependsOn`.
- **Out of scope:** `awx-postgres-15` / the `awx` namespace is untouched — a possible future cleanup, not addressed here.

## Known gaps (pre-existing, not introduced by this PR)
- **Namespace bootstrap ordering:** `semaphore-db`'s `Cluster` applies into `namespace: semaphore`, which is only created by `semaphore/manifests/namespace.yml` (applied by the `semaphore` Kustomization, which now `dependsOn: [..., semaphore-db]`). On a truly fresh cluster bootstrap this is a deadlock — `semaphore-db` can never go Ready without the namespace, so `semaphore` never runs to create it. **This is not new**: `semaphore-secrets` (targets `namespace: semaphore`, no dependency that creates it) and `awx-secrets` (same pattern for `namespace: awx`) already have this exact same gap today. Doesn't affect the live incident fix (the `semaphore` namespace already exists on the live cluster), but worth a dedicated follow-up PR to fix namespace-creation ordering repo-wide rather than patched ad hoc here.
- **CI blind spot:** `validate-k8s-vms.yml` detects changed app directories under `clusters/k8s-vms-daniele/apps/` but actually deploys/tests from the mirrored `clusters/k3s-prod-test/apps/` tree, which only carries a small infra baseline (`1password`, `blackbox`, `fluxcd`, `node-exporter`, `teleport-agent`). Neither `cloudnative-pg-operator` nor `semaphore-db` (nor `semaphore` itself) exist under `k3s-prod-test/apps/`, so this PR's new Kustomizations will be silently skipped by that CI rather than actually exercised.

## Test plan
- [ ] CNPG operator pod Ready in `cnpg-system`
- [ ] `Cluster` `semaphore-db` reaches `Ready`; `semaphore-db-app` secret exists with `kubernetes.io/basic-auth` type
- [ ] After Flux reconciles the updated Semaphore HelmRelease, the Semaphore pod goes Running and the `28P01` panic disappears from its logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)