### PR TITLE
fix(kubenuc): resolve DNS resolution failure in nextcloud db backup

### DIFF
--- a/clusters/kubenuc/apps/nextcloud/manifests/backup.yml
+++ b/clusters/kubenuc/apps/nextcloud/manifests/backup.yml
@@ -10,6 +10,10 @@ spec:
     spec:
       template:
         spec:
+          dnsConfig:
+            options:
+              - name: ndots
+                value: "2"
           containers:
           - name: pgbackup
             image: ghcr.io/solectrus/postgres-s3-backup:17@sha256:3a5d281955fd6bcdbb97628979ab4df83243253e1f5ebe90b2db13b05d65eda5
@@ -48,10 +52,7 @@ spec:
             - name: S3_PREFIX
               value: "nextcloud-db-backup"
             - name: POSTGRES_HOST
-              valueFrom:
-                secretKeyRef:
-                  name: nextcloud-db-secret
-                  key: server
+              value: "postgresql-nuc-cluster.databases"
             - name: POSTGRES_DATABASE
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Summary
- nextcloud's `nextcloud-db-backup` CronJob was failing every run with `pg_dump: error: could not translate host name ... to address: Name has no usable address` — a known musl-libc DNS resolution bug (Alpine `postgres-s3-backup` image) triggered by the default `ndots:5` combined with an already-fully-qualified postgres hostname.
- Applies the same fix already proven on harbor's `harbor-db-backup` CronJob (merged previously): sets pod-level `dnsConfig.options.ndots: "2"` and switches `POSTGRES_HOST` from a 1Password-sourced FQDN to the literal short 2-label service name, so resolution completes via the search-domain path instead of hitting the musl bug.
- No 1Password changes — the existing DB secret is left untouched (still used by the live Nextcloud app itself).

## Test plan
- [x] `pre-commit` (yamllint / trailing whitespace / secret scan) passes on the changed file
- [x] Reproduced the original failure live by triggering the (pre-fix) CronJob manually
- [x] Verified the fix live: ran a one-off Job with the patched pod spec (not touching the tracked CronJob) — `pg_dump` succeeded and the backup uploaded to S3
- [x] Confirmed harbor's own backup CronJob still resolves DNS correctly with this same mechanism (its current failures are an unrelated Postgres permission issue, not DNS)