### PR TITLE
fix(kubenuc): complete stuck velero upgrade to chart 12.1.0 (velero 1.18.1)

### DIFF
--- a/clusters/kubenuc/apps/velero/manifests/release.yml
+++ b/clusters/kubenuc/apps/velero/manifests/release.yml
@@ -30,11 +30,16 @@ spec:
   driftDetection:
     mode: warn
   values:
-    # Pinned to match the live CLI-installed version exactly - this PR adopts
-    # existing resources under GitOps, it does not also upgrade Velero.
+    # image.tag (and the AWS plugin initContainers image below) must always be
+    # bumped together with spec.chart.spec.version. Chart 12.x's upgrade-crds
+    # pre-install/pre-upgrade hook runs `velero install --crds-only --apply`,
+    # and --apply only exists in the velero CLI from v1.18.0 onward - if this
+    # image lags behind what the chart's hook expects, the hook Job fails
+    # immediately and the HelmRelease upgrade never completes (see the
+    # chart 10.1.3->12.1.0 stuck-upgrade incident this comment replaces).
     image:
       repository: velero/velero
-      tag: v1.16.0
+      tag: v1.18.1
     # The chart's default kubectl sidecar (used by the pre-install/pre-upgrade
     # upgrade-crds Job) derives its tag from the live cluster's Kubernetes
     # minor version, but docker.io/bitnami/kubectl no longer publishes
@@ -47,7 +52,7 @@ spec:
         tag: "1.33.4"
     initContainers:
       - name: velero-plugin-for-aws
-        image: velero/velero-plugin-for-aws:v1.12.0
+        image: velero/velero-plugin-for-aws:v1.14.2
         imagePullPolicy: IfNotPresent
         volumeMounts:
           - mountPath: /target

--- a/renovate.json
+++ b/renovate.json
@@ -354,6 +354,14 @@
       "matchDatasources": ["github-releases"],
       "matchPackageNames": ["kubernetes-sigs/kustomize"],
       "extractVersion": "^kustomize/(?<version>.+)$"
+    },
+    {
+      "description": "Velero: chart, server image, and AWS plugin image must move together (chart's upgrade-crds hook requires velero CLI >=1.18 for --apply; images are pinned independently of chart appVersion)",
+      "matchDatasources": ["helm", "docker"],
+      "matchPackageNames": ["velero", "velero/velero", "velero/velero-plugin-for-aws"],
+      "groupName": "Velero (chart + images, upgrade together)",
+      "reviewers": ["team:platform-engineering"],
+      "prPriority": 5
     }
   ],
   "helm-values": {
@@ -532,6 +540,18 @@
         "image:\\s+(?<depName>[^:]+):\\$\\{[^:-]+:?-(?<currentValue>[^}]+)\\}"
       ],
       "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "description": "Velero server image tag (values.image uses split repository/tag fields, not covered by the generic single-line 'image: repo:tag' manager)",
+      "managerFilePatterns": [
+        "/clusters/.+/apps/velero/manifests/release\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "repository:\\s+(?<depName>velero/velero)\\s*\\n\\s*tag:\\s+v?(?<currentValue>[0-9.]+)"
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "semver"
     }
   ],
   "hostRules": [


### PR DESCRIPTION
## Summary

Renovate PR #1623 bumped the Velero HelmRelease chart `10.1.3` → `12.1.0`, but the pinned `values.image.tag` (`v1.16.0`) and AWS plugin image (`v1.12.0`) were left behind from GitOps-adoption time. Chart `12.1.0`'s `upgrade-crds` pre-install/pre-upgrade hook Job runs `velero install --crds-only --apply`, and `--apply` only exists in the velero CLI from `v1.18.0` onward. With the image still pinned at `v1.16.0`, the hook Job failed on every attempt (~1 minute to fail each time), Flux exhausted its 6 retries, and the HelmRelease went `Stalled`/`RetriesExceeded` — while the live release stayed auto-rolled-back to the old chart/image (Helm revision 16, `deployed`).

This PR pushes the upgrade forward rather than reverting:
- `values.image.tag`: `v1.16.0` → `v1.18.1` (matches chart `12.1.0`'s own appVersion/default, and is the first server version with the `--apply` flag the hook needs)
- `values.initContainers[0].image` (velero-plugin-for-aws): `v1.12.0` → `v1.14.2`
- Replaced the outdated pin comment with one describing the new invariant (chart version and these two image tags must move together)
- Added a Renovate `customManagers` regex entry for `values.image`'s split `repository:`/`tag:` fields — the existing generic single-line `image: repo:tag` manager never matched this, which is the direct reason the image silently sat at `v1.16.0` while the chart moved two majors ahead
- Added a Renovate `packageRules` group tying the chart, server image, and plugin image together so they can only ever be proposed/merged as one PR going forward

**Caveat for reviewers:** the plugin bump to `v1.14.2` is *inferred* from the plugin's established one-to-one version cadence with Velero server releases (`v1.9↔1.13`, ..., `v1.13↔1.17`), not from an explicitly published compatibility-table entry for `v1.18.x` — the table only goes up through `v1.13.x`↔`v1.17.x`. Both `velero/velero:v1.18.1` and `velero/velero-plugin-for-aws:v1.14.2` were confirmed to exist on Docker Hub before opening this PR, but the pairing itself deserves a second look.

This also means skipping the `1.17` upgrade step (`1.16` → `1.18` directly). Velero's upgrade docs don't explicitly forbid this but do imply sequential upgrades are safer — accepted risk for this backup system, confirmed with the repo owner.

No other `values` changes — diffed chart `12.1.0`'s `values.yaml` against the current overrides and found no renamed/deprecated keys. `values.kubectl.image` (bitnamilegacy pin) is untouched; it's used by the chart's `cleanup-crds.yaml` pre-delete hook, unrelated to the `upgrade-crds` Job that broke.

## Test plan

This is implemented but **not yet live-verified** — verification requires Flux to reconcile the merged change on the `kubenuc` cluster:

- [ ] `flux get helmrelease velero -n velero` — `Stalled` clears, new `Ready: True`/`UpgradeSucceeded`
- [ ] `helm -n velero history velero` — new revision `chart=velero-12.1.0`, `appVersion=1.18.1`, `status=deployed`, no new `failed` revision
- [ ] `kubectl -n velero get pods` — `velero-*` deployment and `node-agent-*` daemonset pods restart cleanly and reach `Running`/`Ready`
- [ ] `kubectl -n velero logs deploy/velero --tail=50` — clean startup, no plugin-registration errors
- [ ] Existing `BackupStorageLocation`/`VolumeSnapshotLocation`s report `Available`/healthy; `schedule-fastnet-nextcloud` Schedule still present and unmodified
- [ ] Optional: trigger one manual on-demand backup to confirm the full backup path works end-to-end after the version jump

🤖 Generated with [Claude Code](https://claude.com/claude-code)