### PR TITLE
fix(kubenuc): exclude kubenuc-w1 from node-problem-detector DaemonSet

### DIFF
--- a/clusters/kubenuc/apps/node-problem-detector/manifests/daemonset.yml
+++ b/clusters/kubenuc/apps/node-problem-detector/manifests/daemonset.yml
@@ -32,6 +32,10 @@ spec:
                     operator: In
                     values:
                       - linux
+                  - key: kubernetes.io/hostname
+                    operator: NotIn
+                    values:
+                      - kubenuc-w1
       serviceAccountName: node-problem-detector
       containers:
         - name: node-problem-detector


### PR DESCRIPTION
## Summary
- `kubenuc-w1` is currently unavailable; its `node-problem-detector` pod is stuck (Pending/CrashLoop/unreachable), generating noise.
- Adds a `NotIn` nodeAffinity term on `kubernetes.io/hostname` to exclude just that node from scheduling, following the same pattern already used by `falco` and `grafana-alloy`.

## Test plan
- [x] YAML parses cleanly (yamllint not available locally; validated with `python3 -c "import yaml; ..."`)
- [ ] Confirm after merge that no `node-problem-detector` pod is scheduled on `kubenuc-w1` and pods on other nodes are undisturbed

## Follow-up
Once `kubenuc-w1` is back and available, this `NotIn` exclusion should be removed in a follow-up PR.