### PR TITLE
docs(cloudflare): document real Cloudflare Tunnel routing process

### DIFF
--- a/clusters/k8s-vms-daniele/apps/cloudflare/manifests/cloudflared.yml
+++ b/clusters/k8s-vms-daniele/apps/cloudflare/manifests/cloudflared.yml
@@ -95,6 +95,22 @@ data:
     # autoupdate doesn't make sense in Kubernetes. However, outside of Kubernetes, we strongly
     # recommend using autoupdate.
     no-autoupdate: true
+    # This ingress list only tells cloudflared where to forward traffic once it is
+    # already inside the tunnel - it does NOT by itself make a hostname reachable.
+    # Two more things are required for a new hostname to actually route:
+    #   1. A DNS record pointing the hostname at <tunnel-uuid>.cfargotunnel.com.
+    #      Apps that opt in get this automatically via external-dns, using the
+    #      external-dns.alpha.kubernetes.io/managed-by=external-dns and
+    #      ...target: ${CLOUDFLARE_TUNNEL_TARGET} annotations on their Ingress
+    #      (see apps/awx/manifests/release.yml for the working pattern).
+    #   2. A manual "Public Hostname" registration for this tunnel in the
+    #      Cloudflare Zero Trust dashboard (Networks -> Tunnels -> kubenuc ->
+    #      Public Hostname). This has been required even with both of the above
+    #      already in place (confirmed empirically with Semaphore, which sat
+    #      unreachable for months despite being in this list). Until/unless this
+    #      is codified as Terraform (e.g. a
+    #      cloudflare_zero_trust_tunnel_cloudflared_config resource - none exists
+    #      in this repo today), it must be done by hand for every new hostname.
     # Keep this list explicit so new DNS records do not become reachable through
     # the tunnel unless they are intentionally added here.
     ingress:

--- a/clusters/k8s-vms-daniele/apps/semaphore/secrets/semaphore-secret.yml
+++ b/clusters/k8s-vms-daniele/apps/semaphore/secrets/semaphore-secret.yml
@@ -8,9 +8,10 @@ spec:
   #   admin-username  - Initial admin username
   #   admin-password  - Initial admin password
   #   admin-email     - Admin email address
-  #   db-host         - PostgreSQL host
-  #   db-name         - PostgreSQL database name
-  #   db-user         - PostgreSQL username
-  #   db-password     - PostgreSQL password
   #   access-key      - Random 32-char encryption key (generate with: openssl rand -hex 16)
+  #
+  # db-host/db-name/db-user/db-password are no longer needed here - Semaphore
+  # has its own dedicated CNPG Postgres (see ../semaphore-db); db-user/db-password
+  # now come from the CNPG-generated semaphore-db-app secret instead (see
+  # ../manifests/release.yml).
   itemPath: "vaults/k8s_secrets/items/semaphore_k8s-vms-daniele"


### PR DESCRIPTION
## Summary
- Restore and extend the `cloudflared.yml` ConfigMap comment to document all three steps actually required to route a new hostname through the tunnel: the local `ingress:` list, DNS via `external-dns` opt-in annotations, and a manual "Public Hostname" registration in the Cloudflare Zero Trust dashboard.
- Update the Semaphore `OnePasswordItem` secret comment to drop the stale `db-host`/`db-name`/`db-user`/`db-password` fields, matching the note already present in `release.yml` since Semaphore moved to its own dedicated CNPG Postgres.
- Corrected the linked Confluence "Cloudflare Tunnel" runbook page to remove the inaccurate claim that tunnel routing is managed via `terraform/DNS/` (that root only manages zone-level DNS records) and document the real process.

## Test plan
- [x] `pre-commit run --files` on both changed YAML files (trailing whitespace, EOF, yaml syntax, secret scan) — all passed
- [x] Manually re-read the restored `cloudflared.yml` comment against what actually happened onboarding Semaphore
- [x] Cross-checked the `external-dns` annotation example against AWX's live Ingress in `apps/awx/manifests/release.yml`

Comment-only changes; no functional/runtime behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)