### PR TITLE
fix(kubenuc): pin velero-plugin-for-aws to v1.14.0 to avoid B2 tagging bug

### DIFF
--- a/clusters/kubenuc/apps/velero/manifests/release.yml
+++ b/clusters/kubenuc/apps/velero/manifests/release.yml
@@ -52,7 +52,14 @@ spec:
         tag: "1.33.4"
     initContainers:
       - name: velero-plugin-for-aws
-        image: velero/velero-plugin-for-aws:v1.14.2
+        # v1.14.1+ unconditionally sends an empty x-amz-tagging header on every
+        # PutObject (aws-sdk-go-v2 bump), which Backblaze B2 rejects with HTTP 400
+        # "Unsupported header" - breaks the final velero-backup.json/log upload on
+        # every backup. Fixed upstream (PR #299, commit 8dbd6b84) but not in any
+        # released tag yet. v1.14.0 predates the SDK bump and is still in the
+        # documented-compatible range for server v1.18.x - pin here until a
+        # v1.14.3+/v1.15.0+ release ships the fix, then bump forward.
+        image: velero/velero-plugin-for-aws:v1.14.0
         imagePullPolicy: IfNotPresent
         volumeMounts:
           - mountPath: /target

--- a/renovate.json
+++ b/renovate.json
@@ -362,6 +362,12 @@
       "groupName": "Velero (chart + images, upgrade together)",
       "reviewers": ["team:platform-engineering"],
       "prPriority": 5
+    },
+    {
+      "description": "Pin velero-plugin-for-aws below the empty x-amz-tagging PutObject bug (breaks Backblaze B2) until a release ships the fix (upstream PR #299 / commit 8dbd6b84, unreleased as of v1.14.2)",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["velero/velero-plugin-for-aws"],
+      "allowedVersions": "1.14.0"
     }
   ],
   "helm-values": {


### PR DESCRIPTION
## Summary

- `schedule-fastnet-nextcloud` (kubenuc/velero) has failed every run since the plugin was bumped to v1.14.x: 26/26 items backed up, kopia Pod Volume Backup completed, but `Phase: Failed` — the final `velero-backup.json` metadata upload never lands (`velero backup logs` returns "file not found").
- Confirmed live via `status.failureReason` on a failed Backup object: `api error InvalidArgument: Unsupported header 'x-amz-tagging' received for this API call.`
- `velero-plugin-for-aws` v1.14.1/v1.14.2 unconditionally sets an empty `Tagging` header on every S3 `PutObject` after an `aws-sdk-go-v2` bump; Backblaze B2's S3-compatible API rejects any request carrying `x-amz-tagging`. Fixed upstream (PR #299 / commit `8dbd6b84`), but not in any released tag yet.
- `v1.14.0` predates the SDK bump (same `aws-sdk-go-v2`/`service/s3` generation as known-good `v1.13.2`), still supports this BSL's `checksumAlgorithm` config, and stays in the documented-compatible range for server `v1.18.x` (unlike stepping down to `v1.13.x`, matrix-paired with server `v1.17.x`).
- Added a `renovate.json` `allowedVersions` rule scoped to just `velero/velero-plugin-for-aws` so Renovate stops proposing a revert back to the broken `v1.14.2`, without affecting the existing chart+server+plugin grouping rule.

**Note:** every backup taken since the v1.14.x upgrade has failed this way — kopia data landed in the bucket but with no `velero-backup.json` index, so none of them are restorable. The first backup after this merges is the first usable one for this window.

## Test plan
- [x] `renovate-config-validator` passes on `renovate.json`
- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] After merge: Flux reconciles `velero` Kustomization on kubenuc; confirm pulled init container image is `v1.14.0`
- [ ] After merge: trigger `velero backup create --from-schedule schedule-fastnet-nextcloud manual-test-<date>` and confirm `Phase: Completed` + non-empty `velero backup logs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)