### PR TITLE
ci(cloudflare): exclude cloudflare from e2e ALL_APPS unconditionally

### DIFF
--- a/.github/workflows/validate-k8s-vms.yml
+++ b/.github/workflows/validate-k8s-vms.yml
@@ -25,8 +25,10 @@ jobs:
       - name: Detect changed apps
         id: detect
         run: |
-          # Infra baseline for k3s-prod-test — always deployed
-          INFRA_APPS="cloudflare"
+          # Infra baseline for k3s-prod-test — always deployed.
+          # cloudflare is deliberately NOT here — see the ALL_APPS exclusion
+          # below for why.
+          INFRA_APPS=""
 
           # Detect changed app directories in k8s-vms-daniele
           CHANGED=$(git diff --name-only origin/main...HEAD \
@@ -36,7 +38,12 @@ jobs:
             | sort -u \
             | tr '\n' ' ')
 
-          ALL_APPS=$(echo "$INFRA_APPS $CHANGED" | tr ' ' '\n' | sort -u | tr '\n' ' ' | xargs)
+          # cloudflare is excluded even if CHANGED would re-add it: its
+          # OnePasswordItem syncs a real production tunnel token via CI's
+          # real OP_TOKEN, so deploying it in an ephemeral e2e cluster would
+          # register throwaway PR pods as live connectors on the production
+          # tunnel. Never deploy it here regardless of what changed.
+          ALL_APPS=$(echo "$INFRA_APPS $CHANGED" | tr ' ' '\n' | sort -u | grep -v '^cloudflare$' | tr '\n' ' ' | xargs)
           echo "Deploying apps: $ALL_APPS"
           echo "deploy_apps=$ALL_APPS" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/validate-kubenuc.yml
+++ b/.github/workflows/validate-kubenuc.yml
@@ -25,8 +25,10 @@ jobs:
       - name: Detect changed apps
         id: detect
         run: |
-          # Infra baseline — always deployed regardless of what changed
-          INFRA_APPS="openebs haproxy-ingress cloudflare coredns postgresql s3"
+          # Infra baseline — always deployed regardless of what changed.
+          # cloudflare is deliberately NOT here — see the ALL_APPS exclusion
+          # below for why.
+          INFRA_APPS="openebs haproxy-ingress coredns postgresql s3"
 
           # Detect changed app directories in kubenuc and kubenuc-test
           CHANGED=$(git diff --name-only origin/main...HEAD \
@@ -36,7 +38,12 @@ jobs:
             | sort -u \
             | tr '\n' ' ')
 
-          ALL_APPS=$(echo "$INFRA_APPS $CHANGED" | tr ' ' '\n' | sort -u | tr '\n' ' ' | xargs)
+          # cloudflare is excluded even if CHANGED would re-add it: its
+          # OnePasswordItem syncs a real production tunnel token via CI's
+          # real OP_TOKEN, so deploying it in an ephemeral e2e cluster would
+          # register throwaway PR pods as live connectors on the production
+          # tunnel. Never deploy it here regardless of what changed.
+          ALL_APPS=$(echo "$INFRA_APPS $CHANGED" | tr ' ' '\n' | sort -u | grep -v '^cloudflare$' | tr '\n' ' ' | xargs)
           echo "Deploying apps: $ALL_APPS"
           echo "deploy_apps=$ALL_APPS" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary
- `cloudflare`'s e2e baseline deploy is currently harmless (no credentials Secret exists in CI), but a follow-up PR wires a real `OnePasswordItem` for the tunnel token
- Once that lands, CI's real `OP_TOKEN` would sync the real production tunnel token into ephemeral e2e clusters on every PR run, registering throwaway pods as live connectors on the production tunnel
- Removing `cloudflare` from `INFRA_APPS` alone isn't enough: `ALL_APPS` is a union with `CHANGED` (auto-detected from the PR diff), so a PR touching `apps/cloudflare/**` would re-add it regardless of the baseline edit — including the very PR that introduces the real secret
- Filters `cloudflare` out of `ALL_APPS` after the union in both `validate-kubenuc.yml` and `validate-k8s-vms.yml`, so the exclusion holds unconditionally

## Sequencing
Part of a larger Cloudflare Tunnel migration (see follow-up PRs). **This one must merge first** — it's a prerequisite for safely introducing the real tunnel-token secret in a later PR.

## Test plan
- [x] CI passes on this PR (workflow YAML only, no cluster changes)
- [x] Confirm `cloudflare` no longer appears in `deploy_apps` output on a PR that touches `clusters/*/apps/cloudflare/**`

🤖 Generated with [Claude Code](https://claude.com/claude-code)