### PR TITLE
chore(sops,terraform,cloudflare): update tunnel hostnames in secrets.sops.yaml

### DIFF
--- a/terraform/cloudflare-tunnel/secrets.sops.yaml
+++ b/terraform/cloudflare-tunnel/secrets.sops.yaml
@@ -1,34 +1,34 @@
-account_id: ENC[AES256_GCM,data:32VBwZfWOJkWP7sBk25F4+47p7o3pPLQsOSbim76ZZo=,iv:TIK6dxRVrN9673uXd1pMxnzu275VPdeKyMonjflN5vI=,tag:SI8ClRS/OvPk9kcCgznMcQ==,type:str]
+account_id: ENC[AES256_GCM,data:8t5gNCRj+qSWYpXFpqSvYmmBaNJ1BgoLFtaGGTyyiKA=,iv:rnAlnvVVdafPBU+dyTs2cUHy8uh5E0Nq1oJTNt1VgFQ=,tag:AJfXOqF2UENWs5H5QpTfmQ==,type:str]
 kubenuc:
-    tunnel_id: ENC[AES256_GCM,data:jExdVXgXFk6keRdNRifJpGSAo16vw6BgG44Y+QCRvQ6KP1SC,iv:EKtpqlR79Rt3rOkYNZ2+zuuiRe90epwt41nEhEJhxQg=,tag:8wCj5a0ZD/ZWBVYiZ5t/WQ==,type:str]
-    kubenuc_host: ENC[AES256_GCM,data:ChHeWfFrI0Et0i94lDF2QW8=,iv:Y4NsM3rWwQpOEASR4d25z9ZPi9AAglyDR7mXWwhYSh8=,tag:CXgffisCG2ljfbnCADyvGQ==,type:str]
-    nextcloud_host: ENC[AES256_GCM,data:+tdf61pxrgWcjUOVMxiI,iv:mJTkfzFi4veQDb/4BIXSgraMO+AeESLypfD4eVHMqP4=,tag:83v1ICmzC/1dBrPzbvFiOQ==,type:str]
-    harbor_host: ENC[AES256_GCM,data:gSPUEmTuxFHcuO2tzr9QOw==,iv:qp6lu+bpqviXSKvm2kqSkwHdM/hj2fPWLzFooLV2dKg=,tag:44RbXdXrQQ2MHoFcRscVBw==,type:str]
-    portainer_host: ENC[AES256_GCM,data:pkW7ZmZDcnX+/UvadH3ix650Nw==,iv:wob5VtoZVlq4ZRK2059tjMkKxUgnwRYOvzbbUfuWgdk=,tag:3G7CWHj5iAL7yOKrJzE0Sw==,type:str]
-    photos_host: ENC[AES256_GCM,data:XXD0yF+kVFgl/Wst1MOReA==,iv:U2I3CUlmTJ9htuxcnvbXp1rSye2eF+3WXuW7Y6K9CqU=,tag:BTa/Q19VaSUJoaTX+Jusyg==,type:str]
-    jenkins_host: ENC[AES256_GCM,data:D7/CJNkI4Xjp8RP2FCxFOY4=,iv:+FSzc9hcj/z4MwEQz5zbkKW3ww5PnNbnzURlc6/K34A=,tag:7YQkNqkYX3tBPrQvRAGnHg==,type:str]
-    sso_authentik_host: ENC[AES256_GCM,data:jTzf0KaOR7XeaUaxeg==,iv:D8rGgO5D6ixvtXSHmwj99pAGONTIsH9itPcRAT212kA=,tag:mKLMMuAFpOTK4jPDeYmmog==,type:str]
-    sso_host: ENC[AES256_GCM,data:GuWUNyfOgnB6JWZVffo7cS57,iv:hP4UcaoBBc2iNgweG5IVg8VVVRzv24n93HupeVHXktE=,tag:Y4SHhQtRbXT3qJKbP0vo0A==,type:str]
-    s3_api_host: ENC[AES256_GCM,data:wo8g8FUMrGuKc3g3npBGPg==,iv:swHytdqLdwj/Ubm63Xw5cz8dd0P70oNUke7jVPEMaiU=,tag:7GtCqt6yF3x4HEVp5LQn0w==,type:str]
-    s3_host: ENC[AES256_GCM,data:usm30XCOXIyHLzxI,iv:lY/NIGvs40ffT1xMX+hNvwJJzlOlp2PpkT153hfHX14=,tag:0AtdH/g7Qn1g5rrJzpHL8Q==,type:str]
-    artifactory_host: ENC[AES256_GCM,data:/nVO0PRw448GfkglbYqnzAFk9D4t,iv:Mxhop4w9cowhcm/i9KRLAeh9a6EFB1XynrdUK3sUyvk=,tag:xWrcHWIdq8yD/05GKu1uoA==,type:str]
-    flux_webhook_host: ENC[AES256_GCM,data:TBU+mgynAxAPoeWtG2jH629lnAML2sB886AKTS4x,iv:QpxUl2LQvxof7Uzsn/69252cdExk+O3qEBnip4mR6O0=,tag:F+qNxILST6s10BEpi3nsTA==,type:str]
+    tunnel_id: ENC[AES256_GCM,data:vGI4sN8v1X0UVP+wlYGmQ8bhfcFpdVRD80gHiLyVGcDIvHiX,iv:F7jMnV1hlE6m1kx8wWYDBE1zHKUj6iAJAxz/8ugRdek=,tag:xKnER2sGBrhE52tPyMiLZA==,type:str]
+    kubenuc_host: ENC[AES256_GCM,data:fmH2H89cuZqSywbdexYv5pU=,iv:HlR6QeMWoUDyHgevj6JoT9lVBnPQ4FhfGmF81KvLm2Q=,tag:Ov1pAB6wBnOmWZ3YIBWpCA==,type:str]
+    nextcloud_host: ENC[AES256_GCM,data:EYCkkh8nd0xUMXXNPBP3,iv:NCyxuOySmjVgvASIWJMafCbc8gMXF81Jgfgekc8v7fw=,tag:Fk5wTzmd55nrO0cCexOn0g==,type:str]
+    harbor_host: ENC[AES256_GCM,data:1r545jaWI5qulqDZE7PbNA==,iv:/6BNK5Z7zyQ+fGPIApm/TdyshPNhY52C8PLiq1gQhnU=,tag:BRMY6ICWrL097zLRmtcnvA==,type:str]
+    portainer_host: ENC[AES256_GCM,data:rGBrzEm+qd7IGHFAk8nFdW3peg==,iv:NOqShJHqIrYGVZRd8Ipb5lBrBkfHD4OgtEvCyWKsYL8=,tag:Oo14BFopmY4vyuM0+TgYRQ==,type:str]
+    photos_host: ENC[AES256_GCM,data:G2D5A7i6RmYfKu4wopBtqQ==,iv:IK+INejtyEFV3Qv/2Hco+sO3WZtTHDxUHBjq/bXsR/s=,tag:TnxKRyituUSBqa/x6M6TDQ==,type:str]
+    jenkins_host: ENC[AES256_GCM,data:bUqdkNy5DBdkpwB78js9BBU=,iv:9XLV0x4Z2xLR2iJlFDYsWh/0yNBU34FuPPtN+3bRoTw=,tag:sVYKJsnjySf9EBnDyhO6Rg==,type:str]
+    sso_authentik_host: ENC[AES256_GCM,data:868lLQpubbvksJ81Mw==,iv:0YRQjTDkVTNHic2fqgAL+/ztP1aayvWF2YE3nk3TVpA=,tag:kVD9u7QcDG/MvXk8cX/XcQ==,type:str]
+    sso_host: ENC[AES256_GCM,data:bP1mjwIt+H5Ltu94wiaG7baM,iv:iRGF6aS2I9d2/3P2N92EmkEYxdYOEX3xLMbuKbx/Cu0=,tag:8ejPc2uip8c+fd23/dTVCw==,type:str]
+    s3_api_host: ENC[AES256_GCM,data:HiNmru+Cw9MDgL5EOt7/zA==,iv:2NejfSouK29Reh9oFTcwAR9q1eP2OclW9C2S0BBR2BY=,tag:h79d9n6Xmm0xb3KoBxAGCg==,type:str]
+    s3_host: ENC[AES256_GCM,data:J8PvPUT97UcTZNu2,iv:yrew4Ot++wRL35R0yM/VAjhKHUMp6/9Prm+p+s9k8mo=,tag:HLTGDF9mN8xTg1Kt0fdbTQ==,type:str]
+    artifactory_host: ENC[AES256_GCM,data:q2wVJKig+EH7nK0i5aYomggR95Yu,iv:73fWCIn/PUpgPQ0/xUSy8ED/zDeh0beom2fysx+5kno=,tag:R7zXwG3Qm+Inx9Id89VWLw==,type:str]
+    flux_webhook_host: ENC[AES256_GCM,data:BMOZrfMVF2D+EO5TdJpjlb3XPk1pc4LMZlsnw6Bl,iv:5pb1UVpGRyPa+pFVZ9D25jbzSR6H4fjVgGbcfaV5bro=,tag:afGJWuyzgEDOfnwsInZdPA==,type:str]
 prod_k3s:
-    tunnel_id: ENC[AES256_GCM,data:fHVf05eoVsoPQcJcX1dpvNCsLwo9kuFo+GjlaHhEzZ+LRGY+,iv:c72sfFS25zaMS3CJAOUhZrTWxybrf0QBePhoFfqSHhU=,tag:xjTAyjemP2TKmjTWgfs0Dw==,type:str]
-    semaphore_host: ENC[AES256_GCM,data:Kh2OfXMNpAZ+vIdoyyy0BVTYNsBPmcLpEA==,iv:YTNbwODxoj9J3htPD2rBkSpy18ccLWD3uoKiehVYTNc=,tag:MYekxtxBBpuN+kKwEWSNgQ==,type:str]
-    awx_host: ENC[AES256_GCM,data:MZRUtvhEkxbdd55x6p0vThUlgvseH6M=,iv:PGNy4aCWr+iO66XtsfqeoARJ5iuQuJVfUbowcE8ytyE=,tag:UmWStkMJChp12C/mbbGS4g==,type:str]
+    tunnel_id: ENC[AES256_GCM,data:rpUQKwIwROsYNQtkoQBOeICmqebwSk0+/EDrsAurQvS/rOVr,iv:BxnN+95ms9ZLHD7GzzjEPUuNiqnrYB9eRHZKTctOsJ0=,tag:3LWVVWe1QWfzJaret2VLjw==,type:str]
+    semaphore_host: ENC[AES256_GCM,data:3wacxzrz/VY9I6PbDJX4Y6TRRTQyjYzqOg==,iv:ooKsgLw/RvH01UVuPE0ROgJLJjeTBqCa2F6hQyG81No=,tag:+rvyronfRCorFS5Hve3bqQ==,type:str]
+    awx_host: ENC[AES256_GCM,data:nqwRTwBRYDqtNYH4uf22hwV1XkR4KyY=,iv:lkjJu3cYt2d8QyxYfd/8dBqjyNbNiEwtKxWNSJe3a8o=,tag:WJOwLZq00bcreU+2LmukMg==,type:str]
 sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBVTBySEkra1hjY293UTdU
-            K1liaTk0WGRjR0l6NEg3aVc2NmwvUlAySWpVCi9hcjQ5bkh4c0NDYUtZT3NxVXN0
-            VmF5aUtHQkRqU05IWVQ3NW9WckdQaXcKLS0tIDZRTnNMWjlaSG5GWS9Zc01YN0tE
-            YnZEY3l5RlE0TzQrR1VFQjFkbURXTE0KPwHtY/WMk732Gu8N1HhwHnemHEbz34DX
-            ZM722+FNv8swOdlTz804x6otBrtACcboBQf/S/B+jnaFl/xV5ew5Tg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQWG1oNi80K0JVSnlDUEli
+            WldKaThraEoySEllZ0ZkZTJnR3VQUFZKTHhJClFUSFZMRVI3UVd1MEpHRDc3NUtB
+            RUZzTzZJWVJKOWpyRGhlMUNmT3ZHMVUKLS0tIHg3eFNYQitQa0RWZjNHem1SaUZH
+            aVNxTjZXaWQ4S2ZHYlA1WitiNUFzTTAKL8IiLbNCK1lgq5IsREEoapjczatw2ZNq
+            Z7FvuoQ+eF8Z7F3Wqzs0lAH8mbKvLiOcpEvm4UoAV6XT7PIK5F1AjQ==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1tce0mlehlddhnlsun7l2kd5mymuf5czk3dk8gs62u7vsxn76hfsq0ajkqv
-    lastmodified: "2026-07-12T11:57:24Z"
-    mac: ENC[AES256_GCM,data:3mascdRaytkXL1FNQj0mHB9o7CLyrXifNgw8AHQ62rVNwDBhmgCe2KgPvFoGGr/xNktvnlQiL/VtFfGKhQO186GVXb45GQ/CHYBThN1Ml9Dg8os6rGBtV9vdTF6BQPvtNzv1HG0KgCZF/rihYFkRn1AYw6cXnSC8UK3bd6wtyJE=,iv:GJMeS75aXqoPUi+aAzWRnlP+J6QUio4K8rpiwY8+ryQ=,tag:1RYfEqeVBmZoqYq5Zx3Ahg==,type:str]
+    lastmodified: "2026-07-12T12:33:15Z"
+    mac: ENC[AES256_GCM,data:xpKWuxanbbsi+EpKs3jPS2agb6BEZ4KoWD9tyG6oOQNEayKNg/pZbMpiGn2F6avhyoUHKX6AKMXiGoC75ssYytnD7dm/RL9Ag4VtS0vsyycvbBVpfMbFB56QAFX4fmQ51X+7gsDlvdL6CWvmUHCMadO8qe8aS28j6k8Zyk1VwEw=,iv:WcZdAtpVCIf0OqBcvdE8fc5cGA69lQEpzKGiPwH4ceA=,tag:rWU9m29MPTr1+nCnI6+ZBw==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.2


### PR DESCRIPTION
## Summary
- Updates hostname values in `terraform/cloudflare-tunnel/secrets.sops.yaml` following #1635.

## Test plan
- [x] `terraform plan` in `terraform/cloudflare-tunnel/` shows the expected diff for the updated hostnames

🤖 Generated with [Claude Code](https://claude.com/claude-code)