### PR TITLE
docs(skills): proactive documentation trigger + kubernetes-mcp-server troubleshooting step

### DIFF
--- a/.claude/skills/app-troubleshooting/SKILL.md
+++ b/.claude/skills/app-troubleshooting/SKILL.md
@@ -18,7 +18,7 @@ Use this skill whenever an application in `kubenuc` or `k8s-vms-daniele` is repo
 
 - **kubenuc**: query **Graylog MCP first** (local, free, Grafana Alloy ships OTLP logs there at info level and above). Fall back to `mcp__grafana__query_loki_logs` only for logs that Graylog's info-level filter drops, or when you need a specific LogQL pattern.
 - **k8s-vms-daniele**: **Loki only** — this cluster has no Graylog feed, so `mcp__grafana__query_loki_logs` is the sole source.
-- **Pod never started / nothing in any log pipeline**: fall back to the kubernetes-agent for direct cluster access — `kubectl describe pod`, `kubectl get events --sort-by=.lastTimestamp`, `kubectl logs --previous`.
+- **Pod never started / nothing in any log pipeline**: reach for direct cluster access. Prefer the user-level `kubernetes-mcp-server` (read-only, one context per cluster — select the right one via its `configuration_contexts_list`/`configuration_view` tools) for quick lookups: `pods_get`, `resources_get`, `events_list`, `pods_log`. Reserve the `kubernetes-agent` subagent for anything needing `kubectl describe`/`get events --sort-by`/`logs --previous` combined with write-adjacent `kubectl`/`helm`/`flux`/`kustomize` operations, or Docker-isolated `exec`.
 
 ### 3. Metrics (both clusters)
 

--- a/.claude/skills/documentation/SKILL.md
+++ b/.claude/skills/documentation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: documentation
-description: Route documentation/notes to the right destination (Confluence, README/CLAUDE.md, Obsidian, or NetBox) based on content type, and confirm the exact destination with the user before writing anything.
+description: Route documentation/notes to the right destination (Confluence, README/CLAUDE.md, Obsidian, or NetBox) based on content type, and confirm the exact destination with the user before writing anything. Also invoke proactively — before opening a PR — when the change is a new operational gotcha, an incident, a security-hardening trade-off, a version-pin rationale, a new app/cluster, or a structural Terraform/infra change, to decide whether README.md, a CLAUDE.md, or Confluence needs updating.
 ---
 
 # Documentation Routing Skill
@@ -15,6 +15,19 @@ Use this skill whenever asked to write down, document, save, or note something �
 | Repo usage, conventions, how-to guides | README.md / directory-level READMEs / CLAUDE.md | Direct file edit + PR, following this repo's normal git workflow (feature branch, semantic commit, never push to `main`). |
 | Personal notes, ideas, journal entries | Obsidian | `obsidian_append_content` or an appropriate periodic note. |
 | Infra inventory (hosts, IPs, VM/device records) | NetBox | Verify current state via the NetBox MCP tools first (**read-only** in this workflow) — writes never go through the MCP directly. Instead, author/update `terraform/netbox/*.tf` and open a PR, so NetBox state stays under GitOps/Terraform control like everything else in this repo. |
+
+## When to proactively invoke
+
+Don't wait to be asked. Before opening a PR, check whether the change falls into one of these categories, and if so, run through this skill's routing table rather than merging silently:
+
+- A new operational gotcha (a chart quirk, a workaround, a non-obvious ordering requirement)
+- An incident or its postmortem
+- A security-hardening trade-off (why a control was loosened/tightened, what was accepted as risk)
+- A version-pin rationale (why a dependency is pinned below latest, or pinned to a specific SHA)
+- A new app or cluster
+- A structural Terraform/infra change (new module, new environment, moved state backend, changed CI topology)
+
+This list is intentionally narrow — it mirrors the categories already migrated out of YAML comments in PR #1638. Routine dependency bumps, one-line fixes, and other day-to-day changes don't need this check; treating "after any change" as the trigger would reintroduce the noise problem a hook would have caused.
 
 ## Mixed content
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,7 @@ Types: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `ci`
 8. **Sync intervals** — do not reduce sync intervals below `5m` without a documented reason
 9. **Self-hosted runners** — Terraform workflows run on self-hosted runners; ensure runner availability before expecting CI to pass
 10. **Submodule awareness** — `ansible/ansible-os-updates` is a git submodule; use `git submodule update --init` after cloning
+11. **Document before opening the PR** — before opening a PR for a structural infra change, a new app/cluster, an incident fix, a security-hardening trade-off, or a version-pin rationale, decide whether README.md, a CLAUDE.md, or Confluence needs updating — route the decision through the `documentation` skill
 
 ---
 


### PR DESCRIPTION
## Summary
- `documentation` skill: rewrite frontmatter `description` to name specific proactive trigger categories (operational gotcha, incident, security-hardening trade-off, version-pin rationale, new app/cluster, structural Terraform/infra change) — the description is what's visible every session and drives invocation, since a skill's body only loads after it's already been invoked. Add a supplementary "When to proactively invoke" section in the body.
- Root `CLAUDE.md`: add rule 11 under "Key Rules for AI Assistants" — an imperative checkpoint to route the documentation decision through the `documentation` skill before opening a PR for the same category of changes.
- `app-troubleshooting` skill: document the user-level `kubernetes-mcp-server` (read-only, one context per cluster) as the preferred lightweight tool for quick `pods_get`/`resources_get`/`events_list`/`pods_log` lookups, reserving the full `kubernetes-agent` subagent for write-adjacent kubectl/helm/flux/kustomize operations or Docker-isolated exec.

Convention-only change — no new hook or automation infrastructure, matching this repo's existing all-convention approach (no `PostToolUse`/`Stop` hooks anywhere).

## Test plan
- [x] `pre-commit run --files CLAUDE.md .claude/skills/documentation/SKILL.md .claude/skills/app-troubleshooting/SKILL.md` passes
- [x] `git diff` scoped to intended lines only, no unrelated drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)