### PR TITLE
fix(awx-charts): Fix AWX helm chart

### DIFF
--- a/clusters/k8s-vms-daniele/charts/awx.yml
+++ b/clusters/k8s-vms-daniele/charts/awx.yml
@@ -6,5 +6,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h
-  url: https://ansible-community.github.io/awx-operator-helm/
+  #url: https://ansible-community.github.io/awx-operator-helm/
+  url: oci://harbor.ddlns.net/library
   timeout: 3m
+  type: "oci"


### PR DESCRIPTION
AWX Helm chart is no longer available we temporary self-host it in Harbor until we do migrate to semaphore.