### PR TITLE
fix(k8s-vms-daniele,semaphore): fix runner crash-loop on service link env

### DIFF
--- a/clusters/k8s-vms-daniele/apps/semaphore/manifests/runner.yml
+++ b/clusters/k8s-vms-daniele/apps/semaphore/manifests/runner.yml
@@ -55,6 +55,14 @@ spec:
       labels:
         app.kubernetes.io/name: semaphore-runner
     spec:
+      # Without this, Kubernetes auto-injects legacy Docker-links env vars
+      # for every Service in this namespace - including SEMAPHORE_PORT=
+      # tcp://<clusterIP>:3000 from the server's own `semaphore` Service.
+      # The server Deployment survives because its chart explicitly sets
+      # SEMAPHORE_PORT=3000 to override it; this hand-written Deployment
+      # never did, so the runner CLI's config loader received the raw
+      # tcp://... value and rejected it as an invalid port at startup.
+      enableServiceLinks: false
       securityContext:
         # Base image defaults to uid 1001 / gid 0; fsGroup matches that gid
         # so the PVC's token file is group-writable by the container's user.


### PR DESCRIPTION
## Summary
- The `semaphore-runner` Deployment was panicking on startup (`value of field 'Port' is not valid`) because Kubernetes auto-injects a legacy `SEMAPHORE_PORT=tcp://<clusterIP>:3000` env var into every pod in the `semaphore` namespace, sourced from the server's own ClusterIP Service.
- The server Deployment (Helm chart-managed) survives this because it explicitly sets its own `SEMAPHORE_PORT` env var, which overrides the injected one. The hand-written `semaphore-runner` Deployment never did, so the runner CLI received the raw `tcp://...` value and rejected it as an invalid port.
- Fix: set `enableServiceLinks: false` on the runner pod spec, which stops Kubernetes from injecting Service-derived env vars into this Deployment. No change to the server chart or the Service name.

## Test plan
- [ ] `kubectl apply`/Flux reconcile picks up the updated Deployment and the runner pod restarts (Recreate strategy)
- [ ] `kubectl -n semaphore logs deploy/semaphore-runner` shows successful registration/start with no panic
- [ ] Runner shows as connected in the Semaphore UI and can pick up a task