### PR TITLE
fix(k8s-vms-daniele,semaphore): fix runner registering inactive by default

### DIFF
--- a/docker/semaphore-runner/runner-entrypoint.sh
+++ b/docker/semaphore-runner/runner-entrypoint.sh
@@ -14,8 +14,15 @@ TOKEN_FILE=/data/runner_token.txt
 
 if [ ! -s "$TOKEN_FILE" ]; then
   echo "No persisted runner token at ${TOKEN_FILE}; registering with server" >&2
+  # --enabled=true is required, not just documentation: the "enabled" cobra
+  # flag defaults to true but is only applied when explicitly passed
+  # (registerRunner's applyRunnerRegisterFlags checks Changed("enabled")),
+  # so without this flag the server persists Active=false (Go's bool
+  # zero-value) and the runner polls successfully but never receives real
+  # tasks until an admin flips it on via the API/UI - confirmed against a
+  # live registration.
   printf '%s' "$SEMAPHORE_RUNNER_REGISTRATION_TOKEN" |
-    semaphore runner register --config "$CONFIG_FILE" --stdin-registration-token
+    semaphore runner register --config "$CONFIG_FILE" --stdin-registration-token --enabled=true
 fi
 
 exec semaphore runner start --config "$CONFIG_FILE"


### PR DESCRIPTION
## Summary
- Found while cleaning up after #1670: the runner registered successfully (no more "invalid public key" errors, "Runner connected" in logs) but the server had it stored as `active: false`. Confirmed via the admin API - the runner polls fine but a disabled runner never actually receives real tasks.
- Root cause: `registerRunner`'s `applyRunnerRegisterFlags` (in `semaphoreui/semaphore` v2.18.3) only assigns `util.Config.Runner.Enabled` when the `--enabled` cobra flag is explicitly passed (it checks `Changed("enabled")`) - even though the flag's own default is `true`. `runner-entrypoint.sh` calls `runner register` without that flag, so the value stays at Go's bool zero-value (`false`), and the server persists the new runner as inactive.
- Fix: pass `--enabled=true` explicitly on the `runner register` call in `docker/semaphore-runner/runner-entrypoint.sh`.

## Note
This only takes effect on the *next* fresh registration - i.e. it needs a rebuilt/repushed `docker/semaphore-runner` image (manual step, no CI automation for this image per `clusters/k8s-vms-daniele/CLAUDE.md`), and this Deployment only re-registers when its persisted token is missing. The runner that's live right now was already manually flipped to `active: true` via the admin API as a one-off, so this fix's practical effect is on any *future* re-registration (e.g. after a token wipe), not the currently-running identity.

## Test plan
- [x] Rebuild and push `docker/semaphore-runner:v2.18.3` with this entrypoint change
- [x] Force a fresh registration (clear the persisted token, restart the pod) and confirm the new runner comes up `active: true` without a manual API call