### PR TITLE
feat(terraform): add cloudflare tunnel ingress rules for distr and gitea

### DIFF
--- a/terraform/cloudflare-tunnel/main.tf
+++ b/terraform/cloudflare-tunnel/main.tf
@@ -87,6 +87,27 @@ module "kubenuc" {
         origin_server_name = local.cf.kubenuc.flux_webhook_host
       }
     },
+    {
+      hostname = local.cf.kubenuc.distr_host
+      service  = "http://haproxy-ingress-kubernetes-ingress.haproxy-ingress.svc.cluster.local"
+      origin_request = {
+        origin_server_name = local.cf.kubenuc.distr_host
+      }
+    },
+    {
+      hostname = local.cf.kubenuc.distr_registry_host
+      service  = "http://haproxy-ingress-kubernetes-ingress.haproxy-ingress.svc.cluster.local"
+      origin_request = {
+        origin_server_name = local.cf.kubenuc.distr_registry_host
+      }
+    },
+    {
+      hostname = local.cf.kubenuc.gitea_host
+      service  = "http://haproxy-ingress-kubernetes-ingress.haproxy-ingress.svc.cluster.local"
+      origin_request = {
+        origin_server_name = local.cf.kubenuc.gitea_host
+      }
+    },
     { service = "http_status:404" }, # catch-all, must stay last
   ]
 }

--- a/terraform/cloudflare-tunnel/secrets.sops.yaml
+++ b/terraform/cloudflare-tunnel/secrets.sops.yaml
@@ -13,6 +13,9 @@ kubenuc:
     s3_host: ENC[AES256_GCM,data:S4FCNGTHPNBBVdYT,iv:NDNInjKL/OYHTdy2gfj+/+YhrFIkf9uyvl9YWL/wLEs=,tag:t3SqR1bm1iLFTcPV5Os82Q==,type:str]
     artifactory_host: ENC[AES256_GCM,data:M5c25KF4TejlM0jguKeB4ll0JyI8,iv:jeoY1cAV6pQAzK2fPDoXzzF1hM5nVVAPCzC14nE0ots=,tag:C9/tGiBhPdeGjdDvwr6jMw==,type:str]
     flux_webhook_host: ENC[AES256_GCM,data:xINMbbUEZxFznMJ/9TQo7gfNNEHw1oYgJKCrF0pe,iv:CrISP6Zq7Nhp6Dk0eJu9tLZSZ6vfneNUF9RuR2P4vZ4=,tag:bCiFBFQWLVjYmWE3Kn0hzQ==,type:str]
+    distr_host: ENC[AES256_GCM,data:VllyRN2WV/NS5ZJvSRKy,iv:csSegYRayDEPIquK85yeNqN8Ryr1rUfhKm+g4Y1y8uU=,tag:pZ+vCqCKwW284eUXyytuKw==,type:str]
+    distr_registry_host: ENC[AES256_GCM,data:TMSFMbg7DaAYJEzdkH9GR1T8jA==,iv:ot96bsvmnV/FKRfyWs2B7F9JC9759WV9dphs0RBso2o=,tag:A+KvqkQ/tvbiM6WfB0FIOQ==,type:str]
+    gitea_host: ENC[AES256_GCM,data:ddQJQ4Oh3zZHORdBoSjf,iv:yOXSqh5m8Rdm90KedFsqrUhw8RlcvbvDunUvYsP0QAI=,tag:9IOn/s/L/18toLydRxwe5g==,type:str]
 prod_k3s:
     tunnel_id: ENC[AES256_GCM,data:9PdwOEyIHyKH9VQzEZM42akk9KZJPUK793Fss5JzCManmisw,iv:VzrvxKtHRNpwm481cf/PTv9N9mpDPdS5DJo17s/J2Ps=,tag:y4qVo+sDrSSrcJXVF8+LVw==,type:str]
     semaphore_host: ENC[AES256_GCM,data:kbixWap9bEQVIzfTAFcNJcmWwt6jEHu5yA==,iv:6hZF5o0G4U70xImJKlzCUQ10TVrtB/Odkx2GO67Mra4=,tag:BmJAtIPm0cjEz3Se55kcDA==,type:str]
@@ -29,7 +32,7 @@ sops:
             9bKYVyCv9AR8tI5p2Mp+kv95X7q5NEo6VkArG+I12YtDkUQqoXQLUA==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1tce0mlehlddhnlsun7l2kd5mymuf5czk3dk8gs62u7vsxn76hfsq0ajkqv
-    lastmodified: "2026-07-19T09:33:26Z"
-    mac: ENC[AES256_GCM,data:sONMcToZfqOKIhy++DMcmQ3bwRvHtE+p93DPZj+HWyqOmOUH32aJF6b8p6LPYnIUT4m5xUK1HNZTaNf3d5iXWy6akXwP33mYcywAgnFBj7TND56FyH2nbTqVO3041xbqioq4aLCs8iZY4Gd1lx0FiBFc+G8i62HoligRYSNrfR0=,iv:jkjFPPXo4txkPlllRIijPqSLmIrE1samaL9pjAFzaFw=,tag:OAlgoo/O6IwjGuWACYcFzA==,type:str]
+    lastmodified: "2026-07-23T08:49:07Z"
+    mac: ENC[AES256_GCM,data:R+ol+nGgi/dhPfbqp9fOlOM2lYZjSnFQWw7b9HIR4EpeKTiqvWIeHiKQfMTQlNplnq0thqkFb5BJOgRpc+Uc+8rA3PqxVeyLt71GL2aTypUEAVmAzPyB8fOjWBVr+FMX5Arc6QRQCrb5EdFuroi2XBi7P4a2bgYxNmjvKM5K82E=,iv:WIOx84lZfGrbqHKp2Y76IezqLJj+eixvK7nekgwfD5M=,tag:SiFOirgpqAOIrhy1Nz7PMA==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.2


### PR DESCRIPTION
## Summary
- Adds three new kubenuc Cloudflare Tunnel ingress hostnames ahead of the upcoming Distr and Gitea app PRs: Distr's web UI, Distr's OCI registry endpoint, and Gitea.
- Mirrors the existing per-hostname ingress block pattern (e.g. Harbor's) exactly — same origin service, same `origin_server_name` convention.
- Lands first in a three-PR sequence (terraform → gitea → distr) so external-dns has real tunnel routes to publish against once each app's Ingress reconciles, instead of hitting the tunnel's 404 catch-all.

## Test plan
- [x] `terraform fmt -check` — clean, no diff
- [x] `terraform validate` — success
- [x] `terraform plan` (CI, self-hosted runner)
- [ ] Confirm the three new hostnames route correctly once the corresponding app PRs merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)