### PR TITLE
chore: remove redundant wrapper kustomization.yaml files

### DIFF
--- a/clusters/CLAUDE.md
+++ b/clusters/CLAUDE.md
@@ -83,6 +83,8 @@ clusters/{cluster-name}/
 
 PR validation runs k3s + Flux CD with a 2-hour timeout. Robot Framework E2E tests via `tests/robot/robot-test-job.yaml`.
 
+**Known gap — neither workflow validates the real root `apps/kustomization.yaml`:** both `validate-kubenuc.yml` and `validate-k8s-vms.yml` derive their app list from `git diff` path-parsing and create one synthetic `flux create kustomization app-<name>` CR per changed app, never building/applying a Kustomization pointed at the whole `clusters/{cluster}/apps` directory. Both also deploy exclusively from the `-test` cluster directories (`kubenuc-test`, `k3s-prod-test`), which don't have a root `apps/kustomization.yaml` at all — only the prod directories (`kubenuc`, `k8s-vms-daniele`) do. A bug in the real file (typo'd path, missing app entry) has no CI code path that would ever catch it — only manual `kustomize build clusters/{cluster}/apps` review. TODO if either workflow is touched again: add a build-the-real-file check. See memory `project_kubenuc_e2e_bootstrap_gap.md` / `project_k8s_vms_e2e_ci_gap.md`.
+
 ---
 
 ## Renovate

--- a/clusters/k8s-vms-daniele/apps/1password/kustomization.yaml
+++ b/clusters/k8s-vms-daniele/apps/1password/kustomization.yaml
@@ -1,4 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-  - deploy.yml

--- a/clusters/k8s-vms-daniele/apps/cloudnative-pg-operator/kustomization.yaml
+++ b/clusters/k8s-vms-daniele/apps/cloudnative-pg-operator/kustomization.yaml
@@ -1,4 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-  - deploy.yaml

--- a/clusters/k8s-vms-daniele/apps/kustomization.yaml
+++ b/clusters/k8s-vms-daniele/apps/kustomization.yaml
@@ -1,13 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - 1password
+  - 1password/deploy.yml
   - awx/deploy.yaml
   - awx/backup/backup.yml
   - blackbox/deploy.yaml
   - cert-manager/deploy.yml
   - cloudflare/deploy.yml
-  - cloudnative-pg-operator
+  - cloudnative-pg-operator/deploy.yaml
   - external-dns/deploy.yaml
   - falco/deploy.yaml
   - flux-operator/deploy.yaml
@@ -17,6 +17,6 @@ resources:
   - node-exporter/deploy.yaml
   - reloader/deploy.yaml
   - semaphore/deploy.yaml
-  - semaphore-db
+  - semaphore-db/deploy.yaml
   - system-upgrade-controller/deploy.yaml
   - teleport-agent/deploy.yaml

--- a/clusters/k8s-vms-daniele/apps/semaphore-db/kustomization.yaml
+++ b/clusters/k8s-vms-daniele/apps/semaphore-db/kustomization.yaml
@@ -1,4 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-  - deploy.yaml

--- a/clusters/kubenuc/apps/1password/kustomization.yaml
+++ b/clusters/kubenuc/apps/1password/kustomization.yaml
@@ -1,4 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-  - deploy.yaml

--- a/clusters/kubenuc/apps/kustomization.yaml
+++ b/clusters/kubenuc/apps/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - 1password
+  - 1password/deploy.yaml
   - cert-manager/deploy.yaml
   - cloudflare/deploy.yml
   - coredns/deploy.yaml


### PR DESCRIPTION
## Summary
- Removes 4 app-level `kustomization.yaml` wrapper files that only contained `resources: [deploy.y*ml]` — a pure indirection with no behavior difference (`k8s-vms-daniele`: `1password`, `cloudnative-pg-operator`, `semaphore-db`; `kubenuc`: `1password`)
- Updates each cluster's root `apps/kustomization.yaml` to reference the `deploy.y*ml` file directly instead of the app's bare directory
- `fluxcd` wrapper files on both clusters are deliberately **not touched** — they have real `configMapGenerator` + curated multi-resource lists, no `deploy.yaml` exists in that directory
- Documents a known CI gap in `clusters/CLAUDE.md`: neither `validate-kubenuc.yml` nor `validate-k8s-vms.yml` ever builds/applies the real root `apps/kustomization.yaml` — flagged as a TODO, not fixed in this PR

## Test plan
- [x] `kustomize build clusters/k8s-vms-daniele/apps` output byte-identical before/after
- [x] `kustomize build clusters/kubenuc/apps` output byte-identical before/after
- [x] `pre-commit run` clean
- [x] CI validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)