### PR TITLE
fix(kubenuc): adopt pre-existing velero namespace into Flux

### DIFF
--- a/clusters/kubenuc/apps/kustomization.yaml
+++ b/clusters/kubenuc/apps/kustomization.yaml
@@ -37,4 +37,5 @@ resources:
   - sso/namespace.yml
   - system-upgrade-controller/deploy.yaml
   - velero/deploy.yaml
+  - velero/namespace.yml
   - zabbix/deploy.yaml

--- a/clusters/kubenuc/apps/velero/namespace.yml
+++ b/clusters/kubenuc/apps/velero/namespace.yml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: velero
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled


### PR DESCRIPTION
## Summary
Final PR in the namespace bootstrap-ordering rollout (after #1707/#1708/#1709 — merged and live-verified clean).

This one is fundamentally different from the other 13: velero's namespace was **never Flux-managed at all**. It's a genuine adoption of a pre-existing object with another owner, not a byte-identical move.

- Live inspection via kubernetes-mcp-server: `velero` namespace created 2022-06-07, carries `finalizers: [controller.cattle.io/namespace-auth]` and `lifecycle.cattle.io/create.namespace-auth: "true"` (Rancher-managed), **no** `kustomize.toolkit.fluxcd.io/name` label (confirms Flux has never owned it). It already carries `kustomize.toolkit.fluxcd.io/prune: disabled` as a **label** (not annotation) — set manually via kubectl at some point, not git-tracked — independent extra protection, confirmed live (`kubectl describe ns velero`) alongside the MCP read.
- `velero/manifests/` never had its own `namespace.yml` — confirmed nothing exists under `velero/` before this change, so this is a pure add, not a move. The PR2-style `kubenuc-test` cross-reference breakage structurally can't happen here.
- Adds `clusters/kubenuc/apps/velero/namespace.yml` with `kustomize.toolkit.fluxcd.io/prune: disabled` set explicitly (authored fresh), and lists it in `clusters/kubenuc/apps/kustomization.yaml`.
- **Deliberately omits** the `pod-security.kubernetes.io/*` labels the other 13 namespace files carry: live velero has none today, and its backup/node-agent pods are privileged/hostPath — adding `restricted` labels would trip warn/audit admission warnings as a silent rider on a PR that's nominally just about bootstrap ordering. Matches live state exactly; a future PR can add PSA hardening deliberately if wanted.

## Why no dry-run apply is needed
Field-by-field comparison against the live object: Rancher's owned fields (`field.cattle.io/projectId`, `cattle.io/status`, `lifecycle.cattle.io/create.namespace-auth`, the finalizer) and what this manifest declares (`name`, the prune-disabled annotation) share **no field path**. SSA conflicts require two managers claiming the same field — there is no such field here, so no conflict is possible regardless of a dry-run. This is a metadata-only patch to an existing object (not a create), so there's no immutable-field risk either. Deletion protection (`prune: disabled`) is already live today, independent of this PR. A dry-run apply would only re-confirm what this static analysis already establishes conclusively.

## Test plan
- [x] `kustomize build clusters/kubenuc/apps` succeeds, includes `velero` namespace alongside the other 8 already-moved
- [x] Confirmed no `namespace.yml` exists anywhere under `velero/` prior to this change (pure add)
- [x] `pre-commit run` clean
- [x] CI validation passes
- [ ] Post-merge: live-check via kubernetes-mcp-server — same checks as prior PRs, plus confirm the Rancher finalizer/annotations are untouched and no pod restarts in `velero` namespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)