### PR TITLE
fix(kubenuc-test): add missing driftDetection to 1password HelmRelease

### DIFF
--- a/clusters/kubenuc-test/apps/1password/manifests/release.yml
+++ b/clusters/kubenuc-test/apps/1password/manifests/release.yml
@@ -25,6 +25,12 @@ spec:
     remediation:
       retries: 10
     timeout: 10m
+  # Audit-first: warn only logs/events on drift between the Helm release and
+  # live cluster state, it never corrects it - a safe first step before any
+  # app is promoted to mode: enabled (which would actively revert manual or
+  # external changes).
+  driftDetection:
+    mode: warn
   values:
     connect:
       create: false


### PR DESCRIPTION
## Summary
- `clusters/kubenuc-test/apps/1password/manifests/release.yml`'s HelmRelease had `remediation:` but was missing `driftDetection:` — the single gap out of 40 HelmReleases repo-wide (39 already have both).
- Adds the identical audit-first `driftDetection: mode: warn` block used across all 39 other occurrences, in the same position (after `upgrade`, before `values`).
- `mode: warn` only logs/events on drift, it never corrects it — a safe first step before any app is promoted to `mode: enabled`, which is not used anywhere in this repo today.

## Test plan
- [x] `pre-commit run check-yaml` passes on the modified file
- [ ] `validate-kubenuc.yml`'s E2E run deploys `clusters/kubenuc-test/apps/1password/manifests` live against a real k3s+Flux cluster — the strongest verification available, confirm it goes green on this PR