### PR TITLE
fix(flux): migrate deprecated spec.summary to spec.eventMetadata.summary on Alerts

### DIFF
--- a/clusters/k3s-rabbit/apps/fluxcd/notifications.yaml
+++ b/clusters/k3s-rabbit/apps/fluxcd/notifications.yaml
@@ -16,7 +16,6 @@ metadata:
   name: fluxcd-notifications
   namespace: flux-system
 spec:
-  summary: "cluster status"
   providerRef:
     name: slack
   # kubenuc/k8s-vms-daniele's Alerts also set eventMetadata.region (milan /
@@ -24,6 +23,7 @@ spec:
   # cluster's physical region wasn't confirmed against any source in this
   # repo, and region isn't required by the schema.
   eventMetadata:
+    summary: "cluster status"
     env: "production"
     cluster: "k3s-rabbit"
   eventSeverity: error
@@ -59,10 +59,10 @@ metadata:
   name: github-commit-status
   namespace: flux-system
 spec:
-  summary: "cluster reconcile status"
   providerRef:
     name: github-status
   eventMetadata:
+    summary: "cluster reconcile status"
     env: "production"
     cluster: "k3s-rabbit"
   eventSeverity: info

--- a/clusters/k8s-vms-daniele/apps/fluxcd/notifications.yaml
+++ b/clusters/k8s-vms-daniele/apps/fluxcd/notifications.yaml
@@ -16,10 +16,10 @@ metadata:
   name: fluxcd-notifications
   namespace: flux-system
 spec:
-  summary: "cluster status"
   providerRef:
     name: slack
   eventMetadata:
+    summary: "cluster status"
     env: "production"
     cluster: "k8s-vms-daniele"
     region: "switzerland"
@@ -72,10 +72,10 @@ metadata:
   name: github-commit-status
   namespace: flux-system
 spec:
-  summary: "cluster reconcile status"
   providerRef:
     name: github-status
   eventMetadata:
+    summary: "cluster reconcile status"
     env: "production"
     cluster: "k8s-vms-daniele"
   eventSeverity: info

--- a/clusters/kubenuc/apps/fluxcd/notifications.yaml
+++ b/clusters/kubenuc/apps/fluxcd/notifications.yaml
@@ -16,10 +16,10 @@ metadata:
   name: fluxcd-notifications
   namespace: flux-system
 spec:
-  summary: "cluster status"
   providerRef:
     name: slack
   eventMetadata:
+    summary: "cluster status"
     env: "production"
     cluster: "kubenuc"
     region: "milan"
@@ -114,10 +114,10 @@ metadata:
   name: github-commit-status
   namespace: flux-system
 spec:
-  summary: "cluster reconcile status"
   providerRef:
     name: github-status
   eventMetadata:
+    summary: "cluster reconcile status"
     env: "production"
     cluster: "kubenuc"
   eventSeverity: info


### PR DESCRIPTION
## Summary
- `notification-controller` logs a deprecation warning on every matched event for hand-written Flux `Alert` resources still setting `.spec.summary` ("specifying an alert summary with '.spec.summary' is deprecated, use '.spec.eventMetadata.summary' instead")
- Migrates `summary` into `spec.eventMetadata.summary` for all 6 affected Alerts (2 per cluster: `fluxcd-notifications` + `github-commit-status`) across `kubenuc`, `k8s-vms-daniele`, and `k3s-rabbit`
- `nextcloud-maintenance` (kubenuc) has no `summary` field at all and is left untouched; `oc-ampere`/`kubenuc-test`/`k3s-prod-test` have no notification resources

## Test plan
- [x] `pre-commit run check-yaml` passes on all 3 changed files
- [x] Independently reviewed by Codex and a Fable-model agent: no other `eventMetadata` keys disturbed/reordered, k3s-rabbit's explanatory comment above `eventMetadata` preserved exactly, no incidental whitespace/line-ending drift
- [x] CI flate + kubeconform schema-validation gate on this PR
- [ ] Post-merge: confirm deprecation warning no longer appears in `notification-controller` logs on kubenuc/k8s-vms-daniele/k3s-rabbit, and GitHub commit statuses still post correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)