### PR TITLE
fix(harbor): grant harbor role SELECT on all tables/sequences for pg_dump backup

### DIFF
--- a/clusters/kubenuc/apps/harbor/manifests/release.yml
+++ b/clusters/kubenuc/apps/harbor/manifests/release.yml
@@ -69,7 +69,10 @@ spec:
               -c \"CREATE USER harbor WITH ENCRYPTED PASSWORD '$${HARBOR_DB_PASSWORD}';\"
               -c 'GRANT ALL PRIVILEGES ON DATABASE registry TO harbor;'
               -c '\\c registry postgres'
-              -c 'GRANT ALL ON SCHEMA public TO harbor;'"]
+              -c 'GRANT ALL ON SCHEMA public TO harbor;'
+              -c 'GRANT SELECT ON ALL TABLES IN SCHEMA public TO harbor;'
+              -c 'GRANT SELECT ON ALL SEQUENCES IN SCHEMA public TO harbor;'
+              -c 'ALTER DEFAULT PRIVILEGES FOR ROLE harbor IN SCHEMA public GRANT SELECT ON TABLES TO harbor;'"]
           env:
             - name: PGHOST
               value: postgresql-nuc-cluster.databases.svc.cluster.local


### PR DESCRIPTION
## Summary
- The weekly `harbor-db-backup` CronJob's `pg_dump` was failing with `permission denied for table sbom_report` — `GRANT ALL ON SCHEMA public TO harbor` only covers schema-level USAGE/CREATE, not existing tables owned by a different role
- Extends `init-db`'s bootstrap SQL to also grant SELECT on all current and future tables (via `ALTER DEFAULT PRIVILEGES`), plus sequences, which `pg_dump` also reads
- Self-heals on the next `harbor-core` pod restart — no manual live-DB intervention needed

## Test plan
- [ ] Confirm `harbor-db-backup` CronJob run completes without permission errors after this merges and a `harbor-core` pod restart re-applies the grants