### PR TITLE
refactor(claude): scope skill routing and fix stale docs

### DIFF
--- a/.claude/agents/ansible-agent.md
+++ b/.claude/agents/ansible-agent.md
@@ -1,13 +1,13 @@
 ---
 name: ansible-agent
-description: Ansible specialist agent. Use for running Ansible playbooks, linting, inventory management, and OS/device configuration tasks. Runs in an isolated Docker container with Ansible and common collections installed. Replaces AWX for ad-hoc automation tasks.
+description: Ansible specialist agent. Use for running Ansible playbooks, linting, Molecule testing, inventory management, and OS/device configuration tasks — replaces AWX for ad-hoc automation.
 tools: Bash, Read, Grep, Glob
 model: haiku
 ---
 
 # Ansible Agent
 
-This agent specializes in Ansible automation for the infra-cd repository, replacing AWX for ad-hoc tasks.
+This agent specializes in Ansible automation for the infra-cd repository, replacing AWX for ad-hoc tasks. It runs in an isolated Docker container with Ansible and common collections installed.
 
 ## Available tools in the container
 

--- a/.claude/agents/kubernetes-agent.md
+++ b/.claude/agents/kubernetes-agent.md
@@ -1,13 +1,13 @@
 ---
 name: kubernetes-agent
-description: Kubernetes/Helm/FluxCD specialist agent. Use for kubectl operations, helm template rendering, flux manifest validation, kustomize builds, and GitOps troubleshooting. Runs in an isolated Docker container with kubectl, helm, flux, and kustomize installed.
+description: Kubernetes/Helm/FluxCD specialist agent. Use for kubectl operations, helm template rendering, flux manifest validation, kustomize builds, and GitOps troubleshooting across clusters/.
 tools: Bash, Read, Grep, Glob, mcp__grafana__query_loki_logs, mcp__grafana__query_prometheus, mcp__grafana__search_dashboards, mcp__graylog
 model: sonnet
 ---
 
 # Kubernetes / Helm / FluxCD Agent
 
-This agent specializes in Kubernetes, Helm, and FluxCD operations for the infra-cd repository.
+This agent specializes in Kubernetes, Helm, and FluxCD operations for the infra-cd repository. It runs in an isolated Docker container with kubectl, helm, flux, and kustomize installed.
 
 ## Available tools in the container
 

--- a/.claude/agents/terraform-agent.md
+++ b/.claude/agents/terraform-agent.md
@@ -1,13 +1,13 @@
 ---
 name: terraform-agent
-description: Terraform specialist agent. Use for terraform plan/validate/fmt, provider docs lookups, security scanning with checkov, and infrastructure changes in the terraform/ directory. Runs in an isolated Docker container with all Terraform tools pre-installed.
+description: Terraform specialist agent. Use for terraform plan/validate/fmt, provider docs lookups, checkov security scanning, and any read/verify step on infrastructure changes under terraform/.
 tools: Bash, Read, Grep, Glob, mcp__netbox__netbox_get_objects, mcp__netbox__netbox_search_objects, mcp__grafana__get_dashboard_by_uid
 model: sonnet
 ---
 
 # Terraform Agent
 
-This agent specializes in Terraform operations for the infra-cd repository.
+This agent specializes in Terraform operations for the infra-cd repository. It runs in an isolated Docker container with all Terraform tools pre-installed.
 
 ## Available tools in the container
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,5 +6,29 @@
     "grafana-app-sdk@grafana-skills": false,
     "grafana-k6@grafana-skills": false,
     "ccc-skills@ccc": false
+  },
+  "skillOverrides": {
+    "terraform-specialist": "user-invocable-only",
+    "terraform-infrastructure": "user-invocable-only",
+    "terraform-module-library": "user-invocable-only",
+    "cloud-architect": "user-invocable-only",
+    "hybrid-cloud-architect": "user-invocable-only",
+    "cloud-devops": "user-invocable-only",
+    "gitops-workflow": "user-invocable-only",
+    "kubernetes-architect": "user-invocable-only",
+    "kubernetes-deployment": "user-invocable-only",
+    "k8s-manifest-generator": "user-invocable-only",
+    "helm-chart-scaffolding": "user-invocable-only",
+    "github-actions-templates": "user-invocable-only",
+    "github-workflow-automation": "user-invocable-only",
+    "cicd-automation-workflow-automate": "user-invocable-only",
+    "deployment-pipeline-design": "user-invocable-only",
+    "deployment-engineer": "user-invocable-only",
+    "debugging-strategies": "user-invocable-only",
+    "systematic-debugging": "user-invocable-only",
+    "linux-troubleshooting": "user-invocable-only",
+    "incident-response-incident-response": "user-invocable-only",
+    "incident-response-smart-fix": "user-invocable-only",
+    "observability-engineer": "user-invocable-only"
   }
 }

--- a/.claude/skills/ansible-operations/SKILL.md
+++ b/.claude/skills/ansible-operations/SKILL.md
@@ -2,6 +2,7 @@
 name: ansible-operations
 description: Ansible playbook/role conventions, Molecule testing patterns, and ansible-agent invocation for the infra-cd repository.
 when_to_invoke: Any edit under ansible/ — new playbook, new role, task modifications, template changes, or adding a new playbook directory.
+paths: ansible/**
 ---
 
 # Ansible Operations
@@ -152,6 +153,8 @@ Verify **file existence + permissions**, **package installation**, and **service
 ---
 
 ## Running Molecule via ansible-agent
+
+Prefer dispatching to `ansible-agent` via the Agent tool (`subagent_type: ansible-agent`) over running these commands directly with Bash — it's the real Task-tool path the agent is defined for, not a manual fallback.
 
 The `ansible-agent` container has `molecule`, `molecule-plugins[docker]`, and Docker CLI pre-installed. The host Docker socket is mounted, so Molecule manages test containers from inside the agent.
 

--- a/.claude/skills/ci-workflows/SKILL.md
+++ b/.claude/skills/ci-workflows/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ci-workflows
 description: GitHub Actions workflow patterns for infra-cd — Terraform CI (fmt/init/validate/plan/apply), cluster validation (k3s + FluxCD + Robot Framework), Flux cron updates, and runner selection.
+paths: .github/workflows/**
 ---
 
 # CI Workflows Skill
@@ -89,12 +90,7 @@ Key components:
 
 ## FluxCD cron update workflow
 
-Reference: `.github/workflows/flux-cron.yml`
-
-- Runs Mondays at 3 AM
-- Also manually triggerable
-- Updates FluxCD components in `clusters/*/flux-system/`
-- Opens a PR with the update
+**Removed.** `flux-cron.yml` (weekly FluxCD component bump, Mondays 3 AM) was deleted in PR #1339 and does not exist in this repo. If a comparable cron-based Flux version bump is wanted again, either add Flux to Renovate's managed scope or re-create a dedicated workflow — don't assume this file exists.
 
 ## Required GitHub Actions secrets
 

--- a/.claude/skills/ci-workflows/SKILL.md
+++ b/.claude/skills/ci-workflows/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ci-workflows
-description: GitHub Actions workflow patterns for infra-cd — Terraform CI (fmt/init/validate/plan/apply), cluster validation (k3s + FluxCD + Robot Framework), Flux cron updates, and runner selection.
-paths: .github/workflows/**
+description: GitHub Actions workflow patterns for infra-cd — Terraform CI (fmt/init/validate/plan/apply), cluster validation (k3s + FluxCD + Robot Framework), and runner selection.
+paths: .github/workflows/**, terraform/**
 ---
 
 # CI Workflows Skill

--- a/.claude/skills/cluster-operations/SKILL.md
+++ b/.claude/skills/cluster-operations/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: cluster-operations
 description: Cluster lifecycle operations — setting up new clusters, kubenuc-test overlay pattern, kustomize patch conventions, and FluxCD bootstrap structure for infra-cd clusters.
+paths: clusters/**
 ---
 
 # Cluster Operations Skill
@@ -123,7 +124,7 @@ For apps without storage or database needs, omit the preceding steps.
 
 ## Agent delegation
 
-Use kubernetes-agent to validate Kustomization builds:
+Use kubernetes-agent to validate Kustomization builds. Prefer dispatching via the Agent tool (`subagent_type: kubernetes-agent`) over running these commands directly with Bash — it's the real Task-tool path the agent is defined for, not a manual fallback:
 
 ```bash
 cd docker/agents && docker compose up -d kubernetes-agent

--- a/.claude/skills/flux-operations/SKILL.md
+++ b/.claude/skills/flux-operations/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: flux-operations
 description: FluxCD/GitOps operations for infra-cd — add/update apps, HelmRepositories, SOPS variable substitution, and dependency chains. Delegates YAML generation to kubernetes-agent with Ollama.
+paths: clusters/**
 ---
 
 # FluxCD / GitOps Operations Skill
@@ -88,21 +89,7 @@ Always declare `dependsOn` in Kustomization, not in HelmRelease.
 
 ### kubenuc-test overlay pattern
 
-`kubenuc-test` reuses `kubenuc` manifests via path reference and applies JSON patches:
-
-```yaml
-# clusters/kubenuc-test/apps/{app}/deploy.yaml
-spec:
-  path: ./clusters/kubenuc/apps/{app}/manifests  # reuse production manifests
-  patches:
-    - patch: |-
-        - op: replace
-          path: /spec/values/replicas
-          value: 1
-      target:
-        kind: HelmRelease
-        name: {app-name}
-```
+`kubenuc-test` reuses `kubenuc` manifests via path reference and applies JSON patches (replica count, storage size). See the `cluster-operations` skill's "kubenuc-test overlay pattern" section for the full patch template — don't duplicate it here, and don't trust a copy of this section anywhere else that doesn't match it.
 
 ### Storage class
 
@@ -122,7 +109,7 @@ Common variables: `${S3_API_HOST}`, `${S3_WEB_HOST}`, `${CLUSTER_DOMAIN}`.
 
 ## Agent delegation
 
-For YAML generation and kustomize validation, use the kubernetes-agent with Ollama:
+For YAML generation and kustomize validation, use the kubernetes-agent with Ollama. Prefer dispatching via the Agent tool (`subagent_type: kubernetes-agent`) over running these commands directly with Bash — it's the real Task-tool path the agent is defined for, not a manual fallback:
 
 ```bash
 cd docker/agents && docker compose up -d kubernetes-agent

--- a/.claude/skills/git-pushing/SKILL.md
+++ b/.claude/skills/git-pushing/SKILL.md
@@ -4,6 +4,7 @@ description: "Stage all changes, create a conventional commit, and push to the r
 risk: critical
 source: community
 date_added: "2026-02-27"
+disable-model-invocation: true
 ---
 
 # Git Push Workflow

--- a/.claude/skills/grafana-cardinality-guard/SKILL.md
+++ b/.claude/skills/grafana-cardinality-guard/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: grafana-cardinality-guard
 description: Before adding any new Prometheus scrape target or exporter, check the active-series budget in Grafana Cloud and propose write_relabel drops if needed. Triggers on "add a scrape config", "add an exporter", "enable metrics for X", "add a ServiceMonitor". Gates any change that could grow active series count.
-paths: clusters/**, terraform/grafana/**
 ---
 
 # Grafana Cardinality Guard Skill

--- a/.claude/skills/grafana-cardinality-guard/SKILL.md
+++ b/.claude/skills/grafana-cardinality-guard/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: grafana-cardinality-guard
 description: Before adding any new Prometheus scrape target or exporter, check the active-series budget in Grafana Cloud and propose write_relabel drops if needed. Triggers on "add a scrape config", "add an exporter", "enable metrics for X", "add a ServiceMonitor". Gates any change that could grow active series count.
+paths: clusters/**, terraform/grafana/**
 ---
 
 # Grafana Cardinality Guard Skill

--- a/.claude/skills/op-terraform/SKILL.md
+++ b/.claude/skills/op-terraform/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: op-terraform
 description: 1Password Terraform provider (v3) — provider config, data sources, field access patterns, resource management. Use when reading or writing 1Password items from Terraform (data.tf, provider.tf, modules).
+paths: terraform/**
 ---
 
 # 1Password Terraform Provider Skill

--- a/.claude/skills/secrets-management/SKILL.md
+++ b/.claude/skills/secrets-management/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: secrets-management
 description: Secrets management patterns for infra-cd — 1Password Operator (OnePasswordItem/ExternalSecret), SOPS age encryption for FluxCD variable substitution and bootstrap secrets, and Terraform 1Password provider.
+paths: clusters/**, terraform/**
 ---
 
 # Secrets Management Skill

--- a/.claude/skills/terraform-operations/SKILL.md
+++ b/.claude/skills/terraform-operations/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: terraform-operations
 description: Terraform operations for infra-cd — create new environments, write modules, set up CI workflows, update renovate config. Delegates HCL generation and validation to terraform-agent with Ollama.
+paths: terraform/**
 ---
 
 # Terraform Operations Skill
@@ -139,6 +140,8 @@ docker compose exec terraform-agent sh -c "cd /workspace/terraform/{env} && terr
 ```
 
 ## Agent delegation
+
+Prefer dispatching to `terraform-agent` via the Agent tool (`subagent_type: terraform-agent`) over running these commands directly with Bash — it's the real Task-tool path the agent is defined for, not a manual fallback. The commands below are what that agent runs internally; reach for them yourself only if the Agent tool is unavailable.
 
 ```bash
 cd docker/agents && docker compose up -d terraform-agent

--- a/.github/workflows/skill-staleness-check.yml
+++ b/.github/workflows/skill-staleness-check.yml
@@ -1,0 +1,75 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Skill/Doc Staleness Check
+
+on:
+  pull_request:
+    paths:
+      - .claude/agents/**
+      - .claude/skills/ansible-operations/**
+      - .claude/skills/terraform-operations/**
+      - .claude/skills/flux-operations/**
+      - .claude/skills/cluster-operations/**
+      - .claude/skills/documentation/**
+      - .claude/skills/secrets-management/**
+      - .claude/skills/app-troubleshooting/**
+      - .claude/skills/renovate-pr-review/**
+      - .claude/skills/ci-workflows/**
+      - .claude/skills/grafana-cardinality-guard/**
+      - .claude/skills/op-terraform/**
+      - CLAUDE.md
+      - AGENTS.md
+      - "**/CLAUDE.md"
+      - .github/workflows/**
+      - docker/agents/**
+
+permissions:
+  contents: read
+
+jobs:
+  check-stale-references:
+    name: Check referenced paths still exist
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Grep infra-cd-authored docs for dead path references
+        run: |
+          set -uo pipefail
+
+          # Scoped deliberately to infra-cd's own docs, NOT the generic marketplace
+          # skills under .claude/skills/ — those reference illustrative example
+          # filenames (deploy.yml, ci-cd.yml, ...) that were never claims about
+          # this repo, and would false-positive here.
+          project_skills="ansible-operations terraform-operations flux-operations cluster-operations documentation secrets-management app-troubleshooting renovate-pr-review ci-workflows grafana-cardinality-guard op-terraform"
+
+          docs=""
+          for f in CLAUDE.md AGENTS.md terraform/CLAUDE.md clusters/CLAUDE.md clusters/kubenuc/CLAUDE.md ansible/CLAUDE.md .claude/agents/*.md; do
+            [ -f "$f" ] && docs="$docs $f"
+          done
+          for s in $project_skills; do
+            [ -f ".claude/skills/$s/SKILL.md" ] && docs="$docs .claude/skills/$s/SKILL.md"
+          done
+
+          missing=0
+          for doc in $docs; do
+            for ref in $(grep -oE '\.github/workflows/[A-Za-z0-9_.-]+\.ya?ml' "$doc" 2>/dev/null | sort -u); do
+              if [ ! -f "$ref" ]; then
+                echo "::error file=$doc::references '$ref', which no longer exists in this repo"
+                missing=1
+              fi
+            done
+            for ref in $(grep -oE 'docker/agents/[A-Za-z0-9_./-]+' "$doc" 2>/dev/null | sort -u); do
+              if [ ! -e "$ref" ]; then
+                echo "::error file=$doc::references '$ref', which no longer exists in this repo"
+                missing=1
+              fi
+            done
+          done
+
+          if [ "$missing" -ne 0 ]; then
+            echo "One or more docs/skills reference a repo path that no longer exists. Update or remove the reference."
+            exit 1
+          fi
+
+          echo "No stale .github/workflows or docker/agents references found."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@
 | CI/CD | GitHub Actions (self-hosted runners) |
 | Image builds | Packer |
 | Dependency updates | Renovate |
-| Testing | Robot Framework + KinD + k3s |
+| Testing | Robot Framework + k3s (ephemeral CI clusters) |
 | Storage | OpenEBS, Longhorn |
 | Database | PostgreSQL (Zalando operator) |
 
@@ -72,12 +72,13 @@ Types: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `ci`
 2. **Never commit secrets** — use 1Password references only
 3. **Run `terraform fmt`** before any Terraform commit
 4. **Respect `dependsOn` chains** — storage → database → application ordering is intentional
-5. **YAML validation** — all YAML must pass `yamllint`; pre-commit enforces this
+5. **YAML validation** — all YAML must pass the `check-yaml` pre-commit hook
 6. **Renovate owns versions** — do not manually edit chart versions managed by Renovate unless fixing a break
 7. **Per-cluster isolation** — changes to one cluster's directory should not affect others
 8. **Sync intervals** — do not reduce sync intervals below `5m` without a documented reason
 9. **Self-hosted runners** — Terraform workflows run on self-hosted runners; ensure runner availability before expecting CI to pass
 10. **Submodule awareness** — `ansible/ansible-os-updates` is a git submodule; use `git submodule update --init` after cloning
+11. **Document before opening the PR** — before opening a PR for a structural infra change, a new app/cluster, an incident fix, a security-hardening trade-off, or a version-pin rationale, decide whether README.md, a CLAUDE.md, or Confluence needs updating
 
 ---
 

--- a/terraform/CLAUDE.md
+++ b/terraform/CLAUDE.md
@@ -10,12 +10,7 @@
 - Sensitive values are sourced from 1Password provider — never hardcoded
 - Do not hand-pin provider versions managed by Renovate
 
-**CI workflow per Terraform directory:**
-1. `terraform fmt -check` (PR)
-2. `terraform init` (PR)
-3. `terraform validate` (PR)
-4. `terraform plan` (PR — result posted as PR comment)
-5. `terraform apply` (main branch only)
+**CI workflow stages** (fmt → init → validate → plan-as-PR-comment → apply-on-main): see the `ci-workflows` skill's "Terraform CI workflow pattern" for the full step-by-step and copy-paste template — don't duplicate it here.
 
 ---
 
@@ -40,4 +35,4 @@
 
 1. Create `terraform/{environment}/` with `provider.tf`, `main.tf`, `variables.tf`
 2. Configure a Terraform Cloud workspace for the new environment
-3. Add a corresponding GitHub Actions workflow in `.github/workflows/`
+3. Add a corresponding GitHub Actions workflow — see the `ci-workflows` skill's "Adding a new Terraform workflow" section for the exact steps


### PR DESCRIPTION
## Summary
- Adds `skillOverrides` to `.claude/settings.json`, setting 22 generic marketplace skills to `user-invocable-only` where they overlapped one of this repo's ~10 project-specific skills — removes auto-routing ambiguity while keeping `/skill-name` invocation available.
- Adds `paths:` frontmatter to project-specific skills so they scope auto-activation to their relevant directory.
- Adds `.github/workflows/skill-staleness-check.yml`: greps this repo's own CLAUDE.md/AGENTS.md/agent-definitions/project-skills for referenced `.github/workflows/*` and `docker/agents/*` paths and fails if any no longer exist — deliberately excludes the ~55 generic marketplace skills, which reference illustrative example filenames that were never claims about this repo.
- Fixes the 3 subagents' (`ansible-agent`, `terraform-agent`, `kubernetes-agent`) `description:` frontmatter to state when-to-invoke instead of implementation detail; delegating skills now point at the Agent tool (`subagent_type: X`) instead of raw `docker compose exec`.
- Dedupes Terraform-CI and cluster/flux documentation overlap, and reconciles real drift between `CLAUDE.md` and `AGENTS.md` (stale `yamllint`/"KinD + k3s" claims, a missing rule).
- Closes the `flux-cron.yml` stale reference (workflow was removed in #1339 but still documented as live).
- Reviewed in parallel by Codex, Fable, and Opus; two self-inflicted gaps from the dedup pass (a path-gated skill pointer resolving to nothing, an inert pre-write gate) fixed in a follow-up commit.

## Test plan
- [x] `skill-staleness-check.yml` runs on this PR itself (touches `.claude/**`) and passes
- [x] Confirm `.claude/settings.json` is valid JSON and Claude Code loads without error
- [x] Spot check that `terraform-operations`/`ansible-operations`/`flux-operations`/`cluster-operations` still auto-route correctly when editing files under their respective directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)