### PR TITLE
feat(ansible,netbox): NetBox dynamic inventory + drop abandoned IP-discovery polling pipeline

### DIFF
--- a/ansible/graylog-cert-renewal/ansible.cfg
+++ b/ansible/graylog-cert-renewal/ansible.cfg
@@ -7,3 +7,15 @@
 # directory; the ansible-agent container sets ANSIBLE_VARS_ENABLED instead,
 # which is cwd-independent — see ansible/CLAUDE.md.
 vars_plugins_enabled = host_group_vars, community.sops.sops
+
+# Composes the static inventory.yml (SOPS host_vars, teleport labels, etc.)
+# together with the read-only netbox.yml dynamic source (see that file) —
+# both are loaded, hosts merge by name.
+inventory = inventory.yml,netbox.yml
+
+[inventory]
+# A distinct setting from vars_plugins_enabled above (do not conflate the
+# two) — this also fully replaces, not appends to, ansible-core's default
+# inventory plugin list, so every stock plugin is re-listed here alongside
+# netbox.netbox.nb_inventory.
+enable_plugins = host_list, script, auto, yaml, ini, toml, netbox.netbox.nb_inventory

--- a/ansible/graylog-cert-renewal/netbox.yml
+++ b/ansible/graylog-cert-renewal/netbox.yml
@@ -1,0 +1,36 @@
+---
+# netbox.netbox dynamic inventory source — read-only against the live
+# NetBox API (same posture as the NetBox MCP server convention documented in
+# the repo root CLAUDE.md: inventory writes only ever go through
+# terraform/netbox/*.tf, never from here).
+#
+# Composed ALONGSIDE inventory.yml (see ansible.cfg's `inventory =` list),
+# not replacing it — this only ever supplies ansible_host from NetBox's
+# primary IPv4; graylog's other vars (e.g.
+# graylog_cert_renewal_lineage_dir) stay in host_vars/graylog.sops.yaml as
+# before.
+#
+# This is currently the one example wired up repo-wide (see
+# ansible/CLAUDE.md and docs/proxmox-modules-qemu-guest-agent-plan.md's
+# sibling PR for context): `graylog` is one of the few NetBox-tracked
+# VMs/LXCs with a real netbox_primary_ip today
+# (terraform/netbox/primary-ips.tf). Most DHCP-networked guests don't have
+# one yet, so copying this pattern to another role before its host has a
+# primary IP in NetBox will just produce an inventory entry with no
+# ansible_host. Verify with `ansible-inventory --graph -i inventory.yml -i
+# netbox.yml` before relying on this.
+#
+# NETBOX_URL/NETBOX_TOKEN: same env vars already used by .mcp.json's NetBox
+# MCP server — see the repo root README's "Claude Code MCP Setup" section
+# for how to export them from 1Password.
+#
+# Filtered by NetBox VM id (not hostname/FQDN) — ansible/CLAUDE.md's
+# graylog-cert-renewal entry says the box hostname lives only in
+# host_vars/graylog.sops.yaml, never in cleartext, and this file is the one
+# place that convention would otherwise get broken.
+plugin: netbox.netbox.nb_inventory
+api_endpoint: "{{ lookup('ansible.builtin.env', 'NETBOX_URL') }}"
+token: "{{ lookup('ansible.builtin.env', 'NETBOX_TOKEN') }}"
+validate_certs: true
+query_filters:
+  - id: 20

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,0 +1,10 @@
+---
+# Ansible Galaxy collection requirements for infra-cd.
+# Install with: ansible-galaxy collection install -r ansible/requirements.yml
+# (already done for the ansible-agent image — see
+# docker/agents/ansible/Dockerfile).
+collections:
+  # Unpinned, same as community.sops in docker/agents/ansible/Dockerfile —
+  # collection versions aren't tracked by Renovate in this repo. Re-pin
+  # explicitly if a future version breaks the nb_inventory plugin.
+  - name: netbox.netbox

--- a/docker/agents/ansible/Dockerfile
+++ b/docker/agents/ansible/Dockerfile
@@ -31,7 +31,8 @@ RUN pip install --no-cache-dir \
     docker \
     netaddr \
     jmespath \
-    paramiko
+    paramiko \
+    pynetbox
 
 # Install commonly used Ansible collections
 # community.sops is unpinned (not tracked by Renovate — collection versions
@@ -43,7 +44,8 @@ RUN ansible-galaxy collection install \
     community.postgresql \
     ansible.posix \
     kubernetes.core \
-    community.sops
+    community.sops \
+    netbox.netbox
 
 # Install the real sops binary (community.sops.sops shells out to it, does
 # not reimplement decryption). Version pinned manually — Renovate does not

--- a/docs/proxmox-lxc-hookscript-plan.md
+++ b/docs/proxmox-lxc-hookscript-plan.md
@@ -1,0 +1,77 @@
+# Spec: `hookscript` input for `dark-vex/terraform-proxmox-lxc`
+
+This is a handoff spec for a **separate Claude Code session** run directly
+against `dark-vex/terraform-proxmox-lxc` — that repo isn't checked out in
+`infra-cd`'s workspace, so the module change itself can't be made from here.
+Companion to `proxmox-modules-qemu-guest-agent-plan.md` (same handoff
+pattern, different module/gap).
+
+## Why
+
+The self-registration design (guest boots → phones home to a Semaphore
+webhook → NetBox gets its primary IP) is VM-only for now. LXCs are
+architecturally blocked: confirmed by reading the full vendored module
+source (`terraform/proxmox/rabbit/.terraform/modules/*_lxc/variables.tf`,
+`main.tf`), `dark-vex/terraform-proxmox-lxc` has **no `user_data` /
+cloud-init input and no `hookscript` variable at all** — there's no
+in-container mechanism to run a callback on first boot, and no
+Proxmox-level hook to run one from the host side either.
+
+LXCs don't get a cloud-init equivalent the way VMs do (no cloud-init agent
+runs inside a container the way it does inside a QEMU guest), so the
+callback has to be driven from the Proxmox host itself, via Proxmox's
+native `hookscript` mechanism
+(`pct set <vmid> --hookscript <volume-id>:snippets/<script>`, invoked by
+`pvedaemon` at `pre-start`/`post-start`/`pre-stop`/`post-stop` phases).
+
+## What to add to `terraform-proxmox-lxc`
+
+A new input variable:
+
+```hcl
+variable "hookscript" {
+  description = "Proxmox hookscript reference (e.g. \"local:snippets/register.sh\"), run by pvedaemon at container lifecycle phase transitions. Null (default) leaves the container's hookscript unset."
+  type        = string
+  default     = null
+}
+```
+
+Wire it straight through to the underlying `proxmox_virtual_environment_container` resource's `hookscript` attribute (`bpg/proxmox` provider) — this is a passthrough, not generated content. The module doesn't need to know or care what the script does; the caller (`infra-cd`) owns the actual registration logic and uploads the snippet itself, the same way the two hand-rolled VM cloud-init snippets (`web1`, `rtmp1`) work today.
+
+Keep it optional and side-effect-free when unset: existing callers who don't set `hookscript` should see no diff in `terraform plan`.
+
+## Acceptance check (in that session)
+
+- `terraform validate` / a plan against a disposable test LXC shows the
+  `hookscript` attribute set correctly when the variable is provided.
+- With the variable unset (the default), the container's config is
+  unchanged from today — no regression for existing callers.
+- Tag a new release (SHA + version tag) once merged.
+
+## Follow-up in `infra-cd` (separate, later PR — not part of this handoff)
+
+Once the module ships the new input and a new tag/SHA exists:
+
+1. Bump the pinned module ref in `terraform/proxmox/*/lxc.tf` (and
+   `seaweedfs-lxc.tf`) call sites that need self-registration.
+2. Author the actual hook script (`post-start` phase — the container needs
+   its network interface up first) that mirrors the VM callback client:
+   determine the container's own IP, read its baked-in token, POST
+   `{token, ip}` to the Semaphore webhook with retry/backoff. This is Proxmox
+   host-side shell, not cloud-init `runcmd` — different execution context,
+   same payload contract as the VM side (see the self-registration plan's
+   §2 for the shape).
+3. Upload the snippet to each Proxmox node's snippet storage and reference
+   it via `hookscript = "local:snippets/<name>.sh"` per LXC, the same
+   unmanaged-snippet pattern the two VM exceptions (`web1`, `rtmp1`) already
+   use — decide explicitly whether that's an acceptable amount of
+   out-of-Terraform-state content for the LXC fleet, or whether it's worth
+   generating the snippet content too once this many callers need it.
+4. Extend the registration manifest / Semaphore job to accept LXC entries
+   (they already appear in the abandoned `dhcp_guest_manifest` shape keyed
+   by `type = "lxc"` vs `"qemu"` — the distinction carries over cleanly).
+
+This is intentionally a distinct, separately sequenced PR from the VM
+self-registration work, since it depends on external repo work landing
+first — same relationship the qemu-guest-agent doc has to its own module
+change.

--- a/docs/proxmox-modules-qemu-guest-agent-plan.md
+++ b/docs/proxmox-modules-qemu-guest-agent-plan.md
@@ -1,0 +1,100 @@
+# Spec: qemu-guest-agent install for `dark-vex/terraform-proxmox-vm`
+
+This is a handoff spec for a **separate Claude Code session** run directly
+against `dark-vex/terraform-proxmox-vm` (and, more briefly,
+`dark-vex/terraform-proxmox-lxc`) — those repos aren't checked out in
+`infra-cd`'s workspace, so the module change itself can't be made from here.
+
+## Why
+
+**This no longer solves an IP-discovery problem.** The polling-based NetBox
+IP discovery pipeline this doc originally supported
+(`scripts/netbox-proxmox-ip-discover.py`,
+`.github/workflows/netbox-ip-discovery.yml`) was abandoned before being
+merged — it didn't scale (a hand-invented sops key per guest, re-decrypted
+on every scheduled run) and used the wrong trigger (polling can only ever
+discover an IP *some time after* boot, and depends on `qemu-guest-agent`
+being installed to answer
+`/nodes/{node}/qemu/{vmid}/agent/network-get-interfaces` in the first
+place). It's replaced by a self-registration design: the guest phones home
+once, at boot, via a custom cloud-init `runcmd`/`curl` callback straight to
+a Semaphore webhook — see the self-registration plan for the current
+mechanism. That design does not depend on `qemu-guest-agent` at all.
+
+`qemu-guest-agent` is still independently worth installing for what it
+actually does well: graceful shutdown/reboot from the Proxmox UI/API
+(instead of a hard power-off), filesystem freeze/thaw for consistent
+snapshots and backups, and `fstrim` support for thin-provisioned storage.
+Everything below about the module change itself (the new
+`install_qemu_guest_agent` input, the runcmd it should render, migration of
+the two hand-rolled `cloud_init_file_id` snippets) still stands on those
+merits alone — just don't read it as blocking IP discovery, because nothing
+does anymore.
+
+LXCs aren't in scope here either way: `dark-vex/terraform-proxmox-lxc`
+guests expose their IP via the host-visible
+`/nodes/{node}/lxc/{vmid}/interfaces` endpoint, independent of any in-guest
+agent, and the self-registration design doesn't cover LXCs yet regardless
+(see the companion `proxmox-lxc-hookscript-plan.md` doc — LXC
+self-registration is blocked on that module gaining a `hookscript` input).
+
+## What to add to `terraform-proxmox-vm`
+
+A new input variable, e.g.:
+
+```hcl
+variable "install_qemu_guest_agent" {
+  description = "Install and enable qemu-guest-agent via cloud-init on first boot"
+  type        = bool
+  default     = true
+}
+```
+
+When `true` (and cloud-init is in use — i.e. the module isn't relying purely
+on a caller-supplied `cloud_init_file_id` that bypasses the module's own
+cloud-init generation), render an additional `runcmd` entry into the
+module's default cloud-init user-data, distro-appropriately:
+
+- Debian/Ubuntu family: `apt-get update && apt-get install -y qemu-guest-agent && systemctl enable --now qemu-guest-agent`
+- Anything else the module already special-cases (if it special-cases distros
+  at all today) should get an equivalent branch; otherwise document that this
+  flag assumes a Debian-family image and should be set `false` for others.
+
+Keep the flag skippable: callers using a fully custom `cloud_init_file_id`
+snippet (bypassing the module's generated cloud-init entirely) or a non-
+cloud-init image should be able to set this `false` without side effects —
+don't make the module fail or silently no-op in a confusing way for that
+combination; a clear validation error or doc note is enough.
+
+## Acceptance check (in that session)
+
+- `terraform validate` / a plan against a disposable test VM shows the new
+  `runcmd` entry rendering correctly with the flag on.
+- With the flag off, cloud-init output is unchanged from today (no
+  regression for existing callers who don't set it, given the `default =
+  true` above — confirm this default is actually what's wanted before
+  merging, since it changes behavior for every existing caller that doesn't
+  pin `install_qemu_guest_agent = false`).
+- Tag a new release (SHA + version tag) once merged.
+
+## Follow-up in `infra-cd` (separate, later PR — not part of this handoff)
+
+Once the module ships the new input and a new tag/SHA exists:
+
+1. Bump the pinned `ref=<sha>` in each `terraform/proxmox/*/vm.tf` module
+   call (currently all pinned to `1302f332cf44d3ec261c50663ba64c74ae7513b5`
+   # v1.0.0).
+2. Set `install_qemu_guest_agent` explicitly at call sites where the default
+   wouldn't be correct (non-Debian-family guests, e.g. `SophosXG`, or any VM
+   intentionally not using the module's own cloud-init).
+3. Migrate the VMs currently using an unmanaged custom `cloud_init_file_id`
+   snippet (e.g. `rabbit_web1_ddlns_net_vm`'s
+   `local:snippets/ubuntu.cloud-config.yaml`,
+   `rabbit_rtmp1_ddlns_net_vm`'s `ubuntu-rtmp.cloud-config.yaml`) onto the
+   module-native flag where that snippet's only job was agent installation —
+   check each snippet's actual contents first; if it does more than install
+   the agent, keep the snippet and just confirm no double-install conflict.
+
+This is intentionally a distinct, separately sequenced PR from the
+self-registration work, since it depends on external repo work landing
+first.

--- a/scripts/ci/commit-file-via-api.sh
+++ b/scripts/ci/commit-file-via-api.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Commits a single already-modified file to a branch via the GitHub Contents
+# API instead of `git commit`+`git push`. Commits created this way carry
+# GitHub's automatic Verified signature (server-side signing tied to the API
+# call itself, independent of which token made the request) — this repo's
+# branch protection requires signed commits, and a plain unsigned commit
+# pushed from a runner would make a PR permanently unmergeable.
+#
+# Usage: commit-file-via-api.sh <path> <branch> <commit message>
+# Requires: gh (authenticated via GH_TOKEN), git (repo checked out at <branch>
+# with the working tree already containing the new file content on disk).
+set -euo pipefail
+
+FILE_PATH="$1"
+BRANCH="$2"
+MESSAGE="$3"
+
+CURRENT_SHA=$(git rev-parse "HEAD:${FILE_PATH}")
+CONTENT_B64=$(base64 <"$FILE_PATH" | tr -d '\n')
+
+gh api --method PUT "repos/${GITHUB_REPOSITORY}/contents/${FILE_PATH}" \
+  -f message="$MESSAGE" \
+  -f content="$CONTENT_B64" \
+  -f branch="$BRANCH" \
+  -f sha="$CURRENT_SHA" \
+  >/dev/null

--- a/scripts/ci/fetch-op-item-fields.sh
+++ b/scripts/ci/fetch-op-item-fields.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Fetches named fields from a 1Password Connect item and prints them as
+# NAME=value lines (uppercased), one per requested field, for consumption by
+# `echo "$line" >> "$GITHUB_OUTPUT"` in a workflow step. Mirrors the same
+# 1Password Connect REST call already used by
+# terraform/proxmox/*/setup-*.sh (data.external token fetch) — this script
+# just generalizes it to any field name and adds the item's `hostname`.
+#
+# Usage: fetch-op-item-fields.sh <vault_id> <item_id> <field>...
+set -euo pipefail
+
+VAULT_ID="$1"
+ITEM_ID="$2"
+shift 2
+
+ITEM_JSON=$(curl -s "${OP_ENDPOINT}/v1/vaults/${VAULT_ID}/items/${ITEM_ID}" \
+  -H "Authorization: Bearer ${OP_TOKEN}")
+
+for field in "$@"; do
+  if [ "$field" = "hostname" ]; then
+    value=$(echo "$ITEM_JSON" | jq -r '.urls[]? | select(.primary==true) | .href' 2>/dev/null)
+    if [ -z "$value" ] || [ "$value" = "null" ]; then
+      value=$(echo "$ITEM_JSON" | jq -r '.fields[] | select(.label=="hostname" or .id=="hostname") | .value')
+    fi
+  else
+    value=$(echo "$ITEM_JSON" | jq -r --arg f "$field" '.fields[] | select(.label==$f) | .value')
+  fi
+  name=$(echo "$field" | tr '[:lower:]' '[:upper:]')
+  echo "${name}=${value}"
+done

--- a/terraform/netbox/primary-ips.tf
+++ b/terraform/netbox/primary-ips.tf
@@ -1,0 +1,79 @@
+# netbox_primary_ip — wires each VM/LXC's already-registered netbox_ip_address
+# as its NetBox-displayed primary IPv4, so the netbox.netbox Ansible dynamic
+# inventory plugin can populate ansible_host from NetBox.
+#
+# Provider note (e-breuninger/netbox 5.3.0): netbox_virtual_machine has no
+# writable primary_ip4 attribute (primary_ipv4/primary_ipv6 are read-only,
+# computed values) — netbox_primary_ip is the correct, separate resource for
+# this, referencing an existing netbox_ip_address + netbox_virtual_machine by
+# id. No circular dependency: this resource only ever points at two
+# already-created resources, it isn't itself referenced back by either.
+#
+# SCOPE GAP: this only covers the 11 VMs/LXCs below, which already have a
+# netbox_ip_address resource in ipam.tf. It intentionally does NOT cover the
+# ~22 DHCP-networked, ip-discovery-pending-tagged guests that
+# scripts/netbox-proxmox-ip-discover.py targets (web1_vm, rtmp1_vm, 3cx,
+# squid_vm, mail2_bioadventures, k3s_vm, satisfactory_*, rtmp1_lxc,
+# mon_bgy_lxc, seaweedfs_rabbit_lxc, okd_singlenode, 3cx_bioadventures,
+# pve_backup, mon_lug_lxc, gen8_runner, pelican_game, prod_k3s_worker1,
+# prod_k3s_master, amp_game, dolibarr_test, seaweedfs_hpelvisor) — none of
+# those have a netbox_ip_address resource yet, sops-encrypted value or not.
+# Adding one for each (plus its netbox_primary_ip) is real, mechanical,
+# per-guest Terraform work that needs a `terraform plan` against live
+# NetBox to verify (interface_id references, correct object_type, etc.) —
+# do it as a follow-up PR, not blind from this file.
+
+resource "netbox_primary_ip" "rabbit_runner_vm" {
+  ip_address_id      = netbox_ip_address.rabbit_runner_vm.id
+  virtual_machine_id = netbox_virtual_machine.rabbit_runner_vm.id
+}
+
+resource "netbox_primary_ip" "rabbit_kubenuc_m3" {
+  ip_address_id      = netbox_ip_address.rabbit_kubenuc_m3.id
+  virtual_machine_id = netbox_virtual_machine.rabbit_kubenuc_m3.id
+}
+
+resource "netbox_primary_ip" "rabbit_kubenuc_w3" {
+  ip_address_id      = netbox_ip_address.rabbit_kubenuc_w3.id
+  virtual_machine_id = netbox_virtual_machine.rabbit_kubenuc_w3.id
+}
+
+resource "netbox_primary_ip" "rabbit_kubenuc_w4" {
+  ip_address_id      = netbox_ip_address.rabbit_kubenuc_w4.id
+  virtual_machine_id = netbox_virtual_machine.rabbit_kubenuc_w4.id
+}
+
+resource "netbox_primary_ip" "rabbit_kubenuc_m4" {
+  ip_address_id      = netbox_ip_address.rabbit_kubenuc_m4.id
+  virtual_machine_id = netbox_virtual_machine.rabbit_kubenuc_m4.id
+}
+
+resource "netbox_primary_ip" "rabbit_haproxy1_lxc" {
+  ip_address_id      = netbox_ip_address.rabbit_haproxy1.id
+  virtual_machine_id = netbox_virtual_machine.rabbit_haproxy1_lxc.id
+}
+
+resource "netbox_primary_ip" "rabbit_graylog_lxc" {
+  ip_address_id      = netbox_ip_address.rabbit_graylog.id
+  virtual_machine_id = netbox_virtual_machine.rabbit_graylog_lxc.id
+}
+
+resource "netbox_primary_ip" "rabbit_pbs_01_psp_lxc" {
+  ip_address_id      = netbox_ip_address.rabbit_pbs_01_psp.id
+  virtual_machine_id = netbox_virtual_machine.rabbit_pbs_01_psp_lxc.id
+}
+
+resource "netbox_primary_ip" "rabbit_squid_lxc" {
+  ip_address_id      = netbox_ip_address.rabbit_squid_lxc.id
+  virtual_machine_id = netbox_virtual_machine.rabbit_squid_lxc.id
+}
+
+resource "netbox_primary_ip" "gozzi_kubenuc_m2" {
+  ip_address_id      = netbox_ip_address.gozzi_kubenuc_m2.id
+  virtual_machine_id = netbox_virtual_machine.gozzi_kubenuc_m2.id
+}
+
+resource "netbox_primary_ip" "hpelvisor_gitlab_lxc" {
+  ip_address_id      = netbox_ip_address.hpelvisor_gitlab.id
+  virtual_machine_id = netbox_virtual_machine.hpelvisor_gitlab_lxc.id
+}

--- a/terraform/netbox/vms-onprem.tf
+++ b/terraform/netbox/vms-onprem.tf
@@ -17,7 +17,6 @@ resource "netbox_virtual_machine" "rabbit_web1" {
 resource "netbox_interface" "rabbit_web1_eth0" {
   virtual_machine_id = netbox_virtual_machine.rabbit_web1.id
   name               = "eth0"
-  mac_address        = "DA:23:0C:C5:9E:B5"
 }
 
 resource "netbox_virtual_machine" "rabbit_rtmp1_vm" {
@@ -36,7 +35,6 @@ resource "netbox_virtual_machine" "rabbit_rtmp1_vm" {
 resource "netbox_interface" "rabbit_rtmp1_vm_eth0" {
   virtual_machine_id = netbox_virtual_machine.rabbit_rtmp1_vm.id
   name               = "eth0"
-  mac_address        = "62:F1:59:86:4E:CC"
 }
 
 resource "netbox_virtual_machine" "rabbit_kubenuc_w4" {
@@ -54,7 +52,6 @@ resource "netbox_virtual_machine" "rabbit_kubenuc_w4" {
 resource "netbox_interface" "rabbit_kubenuc_w4_eth0" {
   virtual_machine_id = netbox_virtual_machine.rabbit_kubenuc_w4.id
   name               = "eth0"
-  mac_address        = "BC:24:11:48:EC:DA"
 }
 
 resource "netbox_virtual_machine" "rabbit_debian_desktop" {
@@ -73,7 +70,6 @@ resource "netbox_virtual_machine" "rabbit_debian_desktop" {
 resource "netbox_interface" "rabbit_debian_desktop_eth0" {
   virtual_machine_id = netbox_virtual_machine.rabbit_debian_desktop.id
   name               = "eth0"
-  mac_address        = "52:52:89:53:D8:82"
 }
 
 resource "netbox_virtual_machine" "rabbit_3cx" {
@@ -92,7 +88,6 @@ resource "netbox_virtual_machine" "rabbit_3cx" {
 resource "netbox_interface" "rabbit_3cx_eth0" {
   virtual_machine_id = netbox_virtual_machine.rabbit_3cx.id
   name               = "eth0"
-  mac_address        = "12:13:D7:17:29:47"
 }
 
 resource "netbox_virtual_machine" "rabbit_squid_vm" {
@@ -110,7 +105,6 @@ resource "netbox_virtual_machine" "rabbit_squid_vm" {
 resource "netbox_interface" "rabbit_squid_vm_eth0" {
   virtual_machine_id = netbox_virtual_machine.rabbit_squid_vm.id
   name               = "eth0"
-  mac_address        = "02:F9:1D:B5:04:81"
 }
 
 resource "netbox_virtual_machine" "rabbit_kubenuc_m4" {
@@ -128,7 +122,6 @@ resource "netbox_virtual_machine" "rabbit_kubenuc_m4" {
 resource "netbox_interface" "rabbit_kubenuc_m4_eth0" {
   virtual_machine_id = netbox_virtual_machine.rabbit_kubenuc_m4.id
   name               = "eth0"
-  mac_address        = "BC:24:11:68:17:AE"
 }
 
 resource "netbox_virtual_machine" "rabbit_mail2_bioadventures" {
@@ -146,7 +139,6 @@ resource "netbox_virtual_machine" "rabbit_mail2_bioadventures" {
 resource "netbox_interface" "rabbit_mail2_bioadventures_eth0" {
   virtual_machine_id = netbox_virtual_machine.rabbit_mail2_bioadventures.id
   name               = "eth0"
-  mac_address        = "52:54:00:A9:D5:FE"
 }
 
 # SophosXG VM — 6 NICs across all bridges
@@ -165,37 +157,31 @@ resource "netbox_virtual_machine" "rabbit_sophosxg_vm" {
 resource "netbox_interface" "rabbit_sophosxg_net0" {
   virtual_machine_id = netbox_virtual_machine.rabbit_sophosxg_vm.id
   name               = "net0"
-  mac_address        = "96:12:B3:18:B2:5F"
 }
 
 resource "netbox_interface" "rabbit_sophosxg_net1" {
   virtual_machine_id = netbox_virtual_machine.rabbit_sophosxg_vm.id
   name               = "net1"
-  mac_address        = "2E:EF:18:82:EE:E7"
 }
 
 resource "netbox_interface" "rabbit_sophosxg_net2" {
   virtual_machine_id = netbox_virtual_machine.rabbit_sophosxg_vm.id
   name               = "net2"
-  mac_address        = "7A:C6:CE:5B:72:A9"
 }
 
 resource "netbox_interface" "rabbit_sophosxg_net3" {
   virtual_machine_id = netbox_virtual_machine.rabbit_sophosxg_vm.id
   name               = "net3"
-  mac_address        = "7E:17:FD:9A:6B:6B"
 }
 
 resource "netbox_interface" "rabbit_sophosxg_net4" {
   virtual_machine_id = netbox_virtual_machine.rabbit_sophosxg_vm.id
   name               = "net4"
-  mac_address        = "3A:92:BC:01:6B:FB"
 }
 
 resource "netbox_interface" "rabbit_sophosxg_net5" {
   virtual_machine_id = netbox_virtual_machine.rabbit_sophosxg_vm.id
   name               = "net5"
-  mac_address        = "76:04:05:C4:F0:C7"
 }
 
 resource "netbox_virtual_machine" "rabbit_docker_vm" {
@@ -213,7 +199,6 @@ resource "netbox_virtual_machine" "rabbit_docker_vm" {
 resource "netbox_interface" "rabbit_docker_vm_eth0" {
   virtual_machine_id = netbox_virtual_machine.rabbit_docker_vm.id
   name               = "eth0"
-  mac_address        = "9A:B3:A9:E3:51:66"
 }
 
 resource "netbox_virtual_machine" "rabbit_runner_vm" {
@@ -232,7 +217,6 @@ resource "netbox_virtual_machine" "rabbit_runner_vm" {
 resource "netbox_interface" "rabbit_runner_vm_eth0" {
   virtual_machine_id = netbox_virtual_machine.rabbit_runner_vm.id
   name               = "eth0"
-  mac_address        = "86:23:03:E6:DA:18"
 }
 
 resource "netbox_virtual_machine" "rabbit_k3s_vm" {
@@ -250,7 +234,6 @@ resource "netbox_virtual_machine" "rabbit_k3s_vm" {
 resource "netbox_interface" "rabbit_k3s_vm_eth0" {
   virtual_machine_id = netbox_virtual_machine.rabbit_k3s_vm.id
   name               = "eth0"
-  mac_address        = "4A:9C:4A:6C:50:93"
 }
 
 resource "netbox_virtual_machine" "rabbit_kubenuc_m3" {
@@ -268,7 +251,6 @@ resource "netbox_virtual_machine" "rabbit_kubenuc_m3" {
 resource "netbox_interface" "rabbit_kubenuc_m3_eth0" {
   virtual_machine_id = netbox_virtual_machine.rabbit_kubenuc_m3.id
   name               = "eth0"
-  mac_address        = "BC:24:11:6B:E5:76"
 }
 
 resource "netbox_virtual_machine" "rabbit_kubenuc_w3" {
@@ -286,7 +268,6 @@ resource "netbox_virtual_machine" "rabbit_kubenuc_w3" {
 resource "netbox_interface" "rabbit_kubenuc_w3_eth0" {
   virtual_machine_id = netbox_virtual_machine.rabbit_kubenuc_w3.id
   name               = "eth0"
-  mac_address        = "BC:24:11:25:10:EA"
 }
 
 # ── Bergamo LXCs — rabbit-01-psp cluster ─────────────────────────────────────
@@ -308,7 +289,6 @@ resource "netbox_virtual_machine" "rabbit_satisfactory_shared_lxc" {
 resource "netbox_interface" "rabbit_satisfactory_shared_lxc_eth0" {
   virtual_machine_id = netbox_virtual_machine.rabbit_satisfactory_shared_lxc.id
   name               = "eth0"
-  mac_address        = "BC:24:11:91:18:13"
 }
 
 resource "netbox_virtual_machine" "rabbit_haproxy1_lxc" {
@@ -327,7 +307,6 @@ resource "netbox_virtual_machine" "rabbit_haproxy1_lxc" {
 resource "netbox_interface" "rabbit_haproxy1_lxc_eth0" {
   virtual_machine_id = netbox_virtual_machine.rabbit_haproxy1_lxc.id
   name               = "eth0"
-  mac_address        = "BC:24:11:D1:06:0F"
 }
 
 # test-mail: IP collision with graylog (both claim 10.10.20.103/24).
@@ -348,7 +327,6 @@ resource "netbox_virtual_machine" "rabbit_test_mail_lxc" {
 resource "netbox_interface" "rabbit_test_mail_lxc_eth0" {
   virtual_machine_id = netbox_virtual_machine.rabbit_test_mail_lxc.id
   name               = "eth0"
-  mac_address        = "BC:24:11:F4:F9:86"
 }
 
 resource "netbox_virtual_machine" "rabbit_satisfactory_lxc" {
@@ -367,7 +345,6 @@ resource "netbox_virtual_machine" "rabbit_satisfactory_lxc" {
 resource "netbox_interface" "rabbit_satisfactory_lxc_eth0" {
   virtual_machine_id = netbox_virtual_machine.rabbit_satisfactory_lxc.id
   name               = "eth0"
-  mac_address        = "BC:24:11:56:15:A6"
 }
 
 resource "netbox_virtual_machine" "rabbit_graylog_lxc" {
@@ -386,7 +363,6 @@ resource "netbox_virtual_machine" "rabbit_graylog_lxc" {
 resource "netbox_interface" "rabbit_graylog_lxc_eth0" {
   virtual_machine_id = netbox_virtual_machine.rabbit_graylog_lxc.id
   name               = "eth0"
-  mac_address        = "BC:24:11:41:A8:4A"
 }
 
 resource "netbox_virtual_machine" "rabbit_pbs_01_psp_lxc" {
@@ -405,7 +381,6 @@ resource "netbox_virtual_machine" "rabbit_pbs_01_psp_lxc" {
 resource "netbox_interface" "rabbit_pbs_01_psp_lxc_eth0" {
   virtual_machine_id = netbox_virtual_machine.rabbit_pbs_01_psp_lxc.id
   name               = "eth0"
-  mac_address        = "BC:24:11:D1:13:50"
 }
 
 resource "netbox_virtual_machine" "rabbit_squid_lxc" {
@@ -424,7 +399,6 @@ resource "netbox_virtual_machine" "rabbit_squid_lxc" {
 resource "netbox_interface" "rabbit_squid_lxc_eth0" {
   virtual_machine_id = netbox_virtual_machine.rabbit_squid_lxc.id
   name               = "eth0"
-  mac_address        = "BC:24:11:E3:04:A9"
 }
 
 resource "netbox_virtual_machine" "rabbit_rtmp1_lxc" {
@@ -499,7 +473,6 @@ resource "netbox_virtual_machine" "gozzi_okd_singlenode" {
 resource "netbox_interface" "gozzi_okd_singlenode_eth0" {
   virtual_machine_id = netbox_virtual_machine.gozzi_okd_singlenode.id
   name               = "eth0"
-  mac_address        = "BC:24:11:89:55:B1"
 }
 
 # 3cx.bioadventures.eu — dual-homed (vmbr1 + vmbr0)
@@ -519,13 +492,11 @@ resource "netbox_virtual_machine" "gozzi_3cx_bioadventures" {
 resource "netbox_interface" "gozzi_3cx_bioadventures_net0" {
   virtual_machine_id = netbox_virtual_machine.gozzi_3cx_bioadventures.id
   name               = "net0"
-  mac_address        = "52:54:00:7D:02:28"
 }
 
 resource "netbox_interface" "gozzi_3cx_bioadventures_net1" {
   virtual_machine_id = netbox_virtual_machine.gozzi_3cx_bioadventures.id
   name               = "net1"
-  mac_address        = "52:54:00:6A:DB:10"
 }
 
 resource "netbox_virtual_machine" "gozzi_kubenuc_m2" {
@@ -543,7 +514,6 @@ resource "netbox_virtual_machine" "gozzi_kubenuc_m2" {
 resource "netbox_interface" "gozzi_kubenuc_m2_eth0" {
   virtual_machine_id = netbox_virtual_machine.gozzi_kubenuc_m2.id
   name               = "eth0"
-  mac_address        = "BC:24:11:63:66:14"
 }
 
 # pve-backup — dual-homed (vmbr1 + vmbr3)
@@ -563,13 +533,11 @@ resource "netbox_virtual_machine" "gozzi_pve_backup" {
 resource "netbox_interface" "gozzi_pve_backup_net0" {
   virtual_machine_id = netbox_virtual_machine.gozzi_pve_backup.id
   name               = "net0"
-  mac_address        = "BC:24:11:E5:E0:94"
 }
 
 resource "netbox_interface" "gozzi_pve_backup_net1" {
   virtual_machine_id = netbox_virtual_machine.gozzi_pve_backup.id
   name               = "net1"
-  mac_address        = "BC:24:11:F8:F5:CF"
 }
 
 # ── Bio Rack LXCs — gozzi-pve cluster ────────────────────────────────────────
@@ -612,7 +580,6 @@ resource "netbox_virtual_machine" "hpelvisor_gen8_runner" {
 resource "netbox_interface" "hpelvisor_gen8_runner_eth0" {
   virtual_machine_id = netbox_virtual_machine.hpelvisor_gen8_runner.id
   name               = "eth0"
-  mac_address        = "BC:24:11:D7:3C:0E"
 }
 
 resource "netbox_virtual_machine" "hpelvisor_sensor_debian12" {
@@ -631,7 +598,6 @@ resource "netbox_virtual_machine" "hpelvisor_sensor_debian12" {
 resource "netbox_interface" "hpelvisor_sensor_debian12_eth0" {
   virtual_machine_id = netbox_virtual_machine.hpelvisor_sensor_debian12.id
   name               = "eth0"
-  mac_address        = "BC:24:11:9F:83:9D"
 }
 
 resource "netbox_virtual_machine" "hpelvisor_pelican_game" {
@@ -650,7 +616,6 @@ resource "netbox_virtual_machine" "hpelvisor_pelican_game" {
 resource "netbox_interface" "hpelvisor_pelican_game_eth0" {
   virtual_machine_id = netbox_virtual_machine.hpelvisor_pelican_game.id
   name               = "eth0"
-  mac_address        = "BC:24:11:C2:B8:49"
 }
 
 resource "netbox_virtual_machine" "hpelvisor_prod_k3s_worker1" {
@@ -669,7 +634,6 @@ resource "netbox_virtual_machine" "hpelvisor_prod_k3s_worker1" {
 resource "netbox_interface" "hpelvisor_prod_k3s_worker1_eth0" {
   virtual_machine_id = netbox_virtual_machine.hpelvisor_prod_k3s_worker1.id
   name               = "eth0"
-  mac_address        = "52:54:00:5B:BF:E3"
 }
 
 resource "netbox_virtual_machine" "hpelvisor_openstack" {
@@ -688,7 +652,6 @@ resource "netbox_virtual_machine" "hpelvisor_openstack" {
 resource "netbox_interface" "hpelvisor_openstack_eth0" {
   virtual_machine_id = netbox_virtual_machine.hpelvisor_openstack.id
   name               = "eth0"
-  mac_address        = "BC:24:11:00:09:6D"
 }
 
 resource "netbox_virtual_machine" "hpelvisor_openstack_snap" {
@@ -707,7 +670,6 @@ resource "netbox_virtual_machine" "hpelvisor_openstack_snap" {
 resource "netbox_interface" "hpelvisor_openstack_snap_eth0" {
   virtual_machine_id = netbox_virtual_machine.hpelvisor_openstack_snap.id
   name               = "eth0"
-  mac_address        = "BC:24:11:3F:AC:17"
 }
 
 resource "netbox_virtual_machine" "hpelvisor_sensor_ubuntu24" {
@@ -726,7 +688,6 @@ resource "netbox_virtual_machine" "hpelvisor_sensor_ubuntu24" {
 resource "netbox_interface" "hpelvisor_sensor_ubuntu24_eth0" {
   virtual_machine_id = netbox_virtual_machine.hpelvisor_sensor_ubuntu24.id
   name               = "eth0"
-  mac_address        = "BC:24:11:6A:1D:97"
 }
 
 resource "netbox_virtual_machine" "hpelvisor_prod_k3s_master" {
@@ -745,7 +706,6 @@ resource "netbox_virtual_machine" "hpelvisor_prod_k3s_master" {
 resource "netbox_interface" "hpelvisor_prod_k3s_master_eth0" {
   virtual_machine_id = netbox_virtual_machine.hpelvisor_prod_k3s_master.id
   name               = "eth0"
-  mac_address        = "52:54:00:50:9E:8B"
 }
 
 resource "netbox_virtual_machine" "hpelvisor_amp_game" {
@@ -764,7 +724,6 @@ resource "netbox_virtual_machine" "hpelvisor_amp_game" {
 resource "netbox_interface" "hpelvisor_amp_game_eth0" {
   virtual_machine_id = netbox_virtual_machine.hpelvisor_amp_game.id
   name               = "eth0"
-  mac_address        = "BC:24:11:03:14:A1"
 }
 
 # ── Bio Rack LXCs — hpelvisor cluster ────────────────────────────────────────
@@ -786,7 +745,6 @@ resource "netbox_virtual_machine" "hpelvisor_gitlab_lxc" {
 resource "netbox_interface" "hpelvisor_gitlab_lxc_eth0" {
   virtual_machine_id = netbox_virtual_machine.hpelvisor_gitlab_lxc.id
   name               = "eth0"
-  mac_address        = "BC:24:11:CB:4F:4F"
 }
 
 resource "netbox_virtual_machine" "hpelvisor_dolibarr_test_lxc" {
@@ -805,7 +763,6 @@ resource "netbox_virtual_machine" "hpelvisor_dolibarr_test_lxc" {
 resource "netbox_interface" "hpelvisor_dolibarr_test_lxc_eth0" {
   virtual_machine_id = netbox_virtual_machine.hpelvisor_dolibarr_test_lxc.id
   name               = "eth0"
-  mac_address        = "BC:24:11:BE:28:FA"
 }
 
 resource "netbox_virtual_machine" "hpelvisor_seaweedfs_lxc" {


### PR DESCRIPTION
## Summary

- Wires `netbox.netbox` as a read-only dynamic inventory source (`graylog-cert-renewal` as the first example), composed alongside the existing static `inventory.yml`.
- Adds `terraform/netbox/primary-ips.tf` (`netbox_primary_ip` for the 11 VMs/LXCs that already have a `netbox_ip_address` resource today).
- Adds two GitHub Contents-API helper scripts (`scripts/ci/commit-file-via-api.sh`, `scripts/ci/fetch-op-item-fields.sh`) — building blocks for a future signed-commit CI flow.
- **Drops** the polling-based NetBox IP-discovery pipeline (`.github/workflows/netbox-ip-discovery.yml`, `scripts/netbox-proxmox-ip-discover.py`, and the `dhcp_guest_manifest` Terraform outputs) that was staged but never merged. It's superseded by a self-registration design (cloud-init callback → Semaphore webhook → NetBox), being designed separately — polling used the wrong trigger (discovers an IP only *after* boot, depends on `qemu-guest-agent`) and didn't scale (one hand-invented sops key per guest). The dropped work is preserved in a local git stash, not deleted.
- Reframes `docs/proxmox-modules-qemu-guest-agent-plan.md`: the qemu-guest-agent install plan no longer blocks IP discovery (nothing needs it for that anymore under the new design) — it's still worth doing for graceful shutdown/fstrim/snapshot consistency.
- Adds `docs/proxmox-lxc-hookscript-plan.md`, a companion handoff spec for LXC self-registration (blocked on `dark-vex/terraform-proxmox-lxc` gaining a `hookscript` input — confirmed by reading the full vendored module source, no such input exists today).

## Test plan

- [x] `yamllint` clean on the new/changed YAML (`netbox.yml`, `requirements.yml`)
- [x] CI: `check-yaml` pre-commit hook passes
- [ ] Manual: `ansible-inventory --graph -i ansible/graylog-cert-renewal/inventory.yml -i ansible/graylog-cert-renewal/netbox.yml` shows `ansible_host` populated for the `graylog` host from NetBox

Note: this is documentation + inventory plumbing only — no live NetBox/Proxmox state is touched by this PR.