### PR TITLE
fix(terraform/semaphore): stop double-prefixing the Semaphore API URL

### DIFF
--- a/terraform/semaphore/main.tf
+++ b/terraform/semaphore/main.tf
@@ -200,7 +200,10 @@ resource "terraform_data" "selfreg_extract_values" {
     interpreter = ["bash", "-c"]
     environment = {
       # See provider.tf's comment: .url doesn't resolve for this item, the
-      # host lives in the "Config" section's "hostname" field instead.
+      # host lives in the "Config" section's "hostname" field instead —
+      # and that stored value already includes its own "https://" scheme,
+      # so no second one is prepended here either (same live bug
+      # provider.tf hit).
       #
       # SEMAPHORE_API_TOKEN here is the same admin token provider.tf uses —
       # unlike the webhook secret above (password_wo, never persisted),
@@ -208,7 +211,7 @@ resource "terraform_data" "selfreg_extract_values" {
       # config, same as it already does via provider.tf's own api_token.
       # Not a new exposure, but don't assume password_wo's treatment
       # covers this credential too.
-      SEMAPHORE_API_URL   = "https://${data.onepassword_item.semaphore.section_map["Config"].field_map["hostname"].value}/api"
+      SEMAPHORE_API_URL   = "${trimsuffix(data.onepassword_item.semaphore.section_map["Config"].field_map["hostname"].value, "/")}/api"
       SEMAPHORE_API_TOKEN = data.onepassword_item.semaphore.credential
       PROJECT_ID          = tostring(semaphoreui_project.proxmox_selfreg.id)
       INTEGRATION_ID      = tostring(semaphoreui_project_integration.selfreg.id)

--- a/terraform/semaphore/provider.tf
+++ b/terraform/semaphore/provider.tf
@@ -15,6 +15,12 @@ provider "semaphoreui" {
   # credential is a real Semaphore API token (minted via Admin -> API
   # Tokens in the Semaphore UI, not a static generatable secret), stored
   # in this item's `credential` field.
-  api_base_url = "https://${data.onepassword_item.semaphore.section_map["Config"].field_map["hostname"].value}/api"
+  # No "https://" prefix here — the stored "hostname" field value already
+  # includes the scheme (confirmed live: prepending a second "https://"
+  # produced "https://https://<host>/api", which the CI apply hit for
+  # real — "dial tcp: lookup https ... server misbehaving" — since nothing
+  # in this session's testing had exercised this exact interpolation
+  # against a live HTTP call end-to-end before the real apply did).
+  api_base_url = "${trimsuffix(data.onepassword_item.semaphore.section_map["Config"].field_map["hostname"].value, "/")}/api"
   api_token    = data.onepassword_item.semaphore.credential
 }


### PR DESCRIPTION
## Summary

#1733's merge-to-main apply failed for real: `Post "https://https:/api/projects": dial tcp: lookup https on 127.0.0.53:53: server misbehaving`.

The 1Password item's `hostname` field (read via `section_map["Config"].field_map["hostname"].value`) already stores the value with its own `https://` scheme. Both `provider.tf` and `main.tf`'s `local-exec` block were prepending a second `https://`, producing a doubled scheme that got mangled into a bogus host (`https`) by the URL parser.

Fixed by using the stored value as-is (trimming any trailing slash) instead of re-prepending a scheme.

## Verification

- Raw `curl` using the exact same construction Terraform now builds (`trimsuffix(hostname, "/") + "/api"`) against the live Semaphore API — `HTTP 200` on `GET /api/projects`.
- `terraform fmt`/`validate` clean.
- Live `terraform plan` against a scratch, untracked state (`-backend=false`) — 10 to add, 0 errors, unchanged from before this fix.
- No real resources were created by the failed apply — it errored on the very first resource (`semaphoreui_project.proxmox_selfreg`) before anything succeeded, so there's no partial/orphaned state to clean up.

## Test plan

- [x] `terraform fmt -check`
- [x] `terraform validate`
- [x] Live plan (scratch state, no real resources touched)
- [x] Raw HTTP call confirming the exact URL construction against the live API
- [ ] Real `terraform apply` via `terraform-semaphore.yml` on merge — expected to succeed now