### PR TITLE
fix(k8s-vms-daniele/semaphore): set general.host so webhook URLs work externally

### DIFF
--- a/clusters/k8s-vms-daniele/apps/semaphore/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/semaphore/manifests/release.yml
@@ -71,6 +71,17 @@ spec:
       # `semaphore-runner` Secret regardless of this setting; the runner
       # Deployment just consumes that existing secret.
       useRemoteRunner: true
+      # Maps to SEMAPHORE_WEB_ROOT (deployment.yaml only sets that env var
+      # when this is non-empty) - the base URL the server bakes into every
+      # generated link, including semaphoreui_integration_alias webhook
+      # URLs (terraform/semaphore). Left unset until now, so the server
+      # fell back to its own default (http://localhost:3000) for those -
+      # confirmed live: the first real self-registration webhook came back
+      # as "http://localhost:3000/api/integrations/...", unusable from
+      # outside the cluster. Same host as the ingress below, just with an
+      # explicit scheme since this value is used to build absolute URLs,
+      # not just a Host header match.
+      host: "https://${SEMAPHORE_HOST}"
 
     podSecurityContext:
       allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary

After #1733/#1734's first real apply, the self-registration webhook's generated URL (`semaphoreui_integration_alias.selfreg.url`) came back as `http://localhost:3000/api/integrations/...` — unusable from outside the cluster.

Root cause: `values.general.host` was never set on this HelmRelease. The chart only sets `SEMAPHORE_WEB_ROOT` (the base URL the server bakes into every generated link) when `general.host` is non-empty (confirmed by reading `semaphoreui/charts`' `deployment.yaml` template directly) — left unset, the server falls back to its own `http://localhost:3000` default.

Fixed by setting `general.host` to the same `${SEMAPHORE_HOST}` cluster-var already used for the ingress host/TLS, with an explicit `https://` scheme since this value builds absolute URLs, not just a Host header match.

## Test plan

- [x] YAML parses correctly (`python3 -c "yaml.safe_load_all(...)"`)
- [ ] After merge, Flux reconciles the HelmRelease, the server pod restarts with `SEMAPHORE_WEB_ROOT` set, and re-running `terraform apply` (or checking the existing `semaphoreui_integration_alias.selfreg` resource) shows a real externally-reachable webhook URL instead of `localhost:3000`