### PR TITLE
feat(terraform/semaphore): wire TFC token, fix missing terraform init

### DIFF
--- a/scripts/semaphore-netbox-register.py
+++ b/scripts/semaphore-netbox-register.py
@@ -68,11 +68,19 @@ Env vars:
                                   mint_installation_token()'s docstring
     GITHUB_APP_INSTALLATION_ID
     GITHUB_REPOSITORY             "owner/repo"
-    TF_TOKEN_app_terraform_io     HCP Terraform token, scoped to "Read outputs
-                                  only" on the terraform/proxmox/* workspaces
-                                  (see Design §4) — never the full-Read
-                                  personal/admin token used during this
-                                  design's own live-testing.
+    TF_TOKEN_app_terraform_io     HCP Terraform token. Design §4's original
+                                  intent — scoped to "Read outputs only" on
+                                  the terraform/proxmox/* workspaces via a
+                                  custom Team — needs the Standard tier or
+                                  above; this org is on Free tier (confirmed
+                                  live: no "create team" option). ACCEPTED
+                                  DEVIATION: this is a dedicated bot HCP
+                                  Terraform user's token instead (isolated
+                                  from any individual's own login, but with
+                                  Free tier's full, non-team-scoped access —
+                                  broader than "outputs only"). See
+                                  terraform/semaphore/data.tf's comment on
+                                  this same tradeoff.
 
 Exit codes: 0 = handled (registered, no-op idempotent, or a clean reject of
 an unknown/bogus token — all three are the normal, expected outcomes of a
@@ -123,9 +131,28 @@ def load_manifest_entries() -> list:
     An empty or missing output on a given tree is the normal day-one state
     (before any self-registering VM has been authored there yet) — treat it
     the same as "no entries from this tree", not as an error.
+
+    Each tree's `terraform.tf` uses HCP Terraform's `cloud` backend, which
+    requires a real (non-`-backend=false`) `terraform init` before `output`
+    works at all — confirmed live: running `output` cold, with no prior
+    init, fails outright with "HCP Terraform ... initialization required",
+    not an empty/missing-output result. This is a genuinely different case
+    from run_terraform_fmt_validate()'s `-backend=false` init further down
+    (netbox validate only needs provider schemas, never remote state).
+    Authenticates via TF_TOKEN_app_terraform_io (Terraform's own
+    convention: TF_TOKEN_<hostname, dots as underscores>), which the
+    calling environment must set — see Design §4/module docstring.
     """
     entries = []
     for tree in PROXMOX_TREES:
+        try:
+            subprocess.run(
+                ["terraform", f"-chdir={tree}", "init", "-input=false"],
+                check=True, capture_output=True, text=True,
+            )
+        except subprocess.CalledProcessError as e:
+            print(f"  [{tree}] terraform init failed, skipping: {e.stderr.strip()}", file=sys.stderr)
+            continue
         try:
             result = subprocess.run(
                 ["terraform", f"-chdir={tree}", "output", "-json", "registration_manifest"],

--- a/terraform/semaphore/data.tf
+++ b/terraform/semaphore/data.tf
@@ -43,3 +43,28 @@ data "onepassword_item" "semaphore_github_app" {
   vault = "66qfxcmgwlhutunx6slav6fyve"
   uuid  = "dgupwizpl3lfzd2esxbfrkoyvq"
 }
+
+# HCP Terraform credential for the registration script's `terraform output
+# -json registration_manifest` calls (Design §1/§4/§5 step 1).
+#
+# ACCEPTED DEVIATION FROM THE ORIGINAL DESIGN, not an oversight: Design §4
+# specified a token scoped to the "Read outputs only" workspace permission
+# (narrower than full state read, since terraform/proxmox/* state also
+# holds Proxmox root credentials). That permission is only assignable via
+# custom Teams, which requires HCP Terraform's Standard tier
+# (confirmed live: this org's Settings -> Teams page shows only the
+# default "owners" team with no way to create another — a Free-tier
+# limitation, not a bug or a permissions issue on this account). Rather
+# than upgrading the org's billing tier for this one narrow credential,
+# a dedicated bot HCP Terraform user (isolated from any individual's own
+# login, invited to the org under Free tier's unlimited-users allowance)
+# was created and this is its user API token. Its actual access is
+# whatever this org's default (non-team-scoped) membership grants on
+# Free tier — almost certainly full read on every workspace's state, not
+# just registration_manifest's output. This is a real, accepted security
+# tradeoff, not the original design's intent; revisit if this org ever
+# moves to Standard tier or above.
+data "onepassword_item" "semaphore_tfc_token" {
+  vault = "66qfxcmgwlhutunx6slav6fyve"
+  uuid  = "bhqt7trhp7vftdabmrihvmdnpq"
+}

--- a/terraform/semaphore/main.tf
+++ b/terraform/semaphore/main.tf
@@ -75,12 +75,6 @@ resource "semaphoreui_project_inventory" "selfreg" {
 # mechanism, which is runner-wide and would leak these into unrelated
 # Ansible task executions if used instead. See terraform/CLAUDE.md.
 #
-# GITHUB_APP_ID/GITHUB_APP_INSTALLATION_ID/GITHUB_APP_PRIVATE_KEY_PATH and
-# TF_TOKEN_app_terraform_io are still not added: the GitHub App's
-# credentials aren't in 1Password yet, and the scoped TFC "Read outputs
-# only" token doesn't exist yet either (needs creating in HCP Terraform's
-# own UI first). Add them here once they do, rather than guessing at
-# vault/item references now.
 resource "semaphoreui_project_environment" "selfreg" {
   project_id = semaphoreui_project.proxmox_selfreg.id
   name       = "proxmox-selfreg"
@@ -125,6 +119,25 @@ resource "semaphoreui_project_environment" "selfreg" {
       type  = "env"
       name  = "GITHUB_APP_PRIVATE_KEY"
       value = data.onepassword_item.semaphore_github_app.section_map["GitHub App"].field_map["private-key"].value
+    },
+    {
+      # Terraform's own env var convention: TF_TOKEN_<hostname, dots as
+      # underscores> - picked up automatically by every `terraform`
+      # subprocess call in scripts/semaphore-netbox-register.py, no
+      # explicit --token flag needed. ACCEPTED DEVIATION from Design §4's
+      # original "Read outputs only" scoping intent: that requires a
+      # custom Team, which needs HCP Terraform's Standard tier (confirmed
+      # live - this org's Free-tier Settings->Teams page has no "create
+      # team" option, not a permissions issue). This is a dedicated bot
+      # HCP Terraform user's token instead (isolated from any individual's
+      # own login), but its actual access is whatever Free tier's
+      # non-team-scoped default membership grants - almost certainly full
+      # state read on every terraform/proxmox/* workspace, not just
+      # registration_manifest's output. Revisit if this org ever moves to
+      # Standard tier or above.
+      type  = "env"
+      name  = "TF_TOKEN_app_terraform_io"
+      value = data.onepassword_item.semaphore_tfc_token.credential
     },
   ]
 }


### PR DESCRIPTION
## Summary

Item 3's last piece. Wires `TF_TOKEN_app_terraform_io` into `semaphoreui_project_environment.selfreg`'s `secrets`, sourced from a new 1Password item (`semaphore-tfc-token`) holding a dedicated bot HCP Terraform user's API token.

**Accepted deviation from Design §4**, documented in `data.tf` and the script's docstring: the design specified a token scoped to "Read outputs only" via a custom HCP Terraform Team — narrower than full state read, since `terraform/proxmox/*` state also holds Proxmox root credentials. Custom Teams need HCP Terraform's Standard tier ($0.47/resource/month) or above; this org is on Free tier, confirmed live (Settings → Teams shows only the default "owners" team, no "create team" option — a tier gate, not a permissions bug). Rather than upgrading billing for this one credential, used a dedicated bot HCP Terraform user (isolated from any individual's login) instead — its actual access is Free tier's default, non-team-scoped membership, almost certainly full state read on every workspace, not just this output. Real tradeoff, not the original design intent — revisit if this org ever moves to Standard tier.

**Also fixes a real bug this exposed**: `load_manifest_entries()` called `terraform output -json` directly against `terraform/proxmox/*`, but those trees use HCP Terraform's `cloud` backend, which requires a real `terraform init` first. Confirmed live (scratch copy, read-only): running `output` cold fails outright with "HCP Terraform ... initialization required" — not the empty/missing-output case the existing error handling was built to treat as normal day-one state. Added the missing `init` call.

## Verification

- Fetched the new 1Password item's field and confirmed a plausible token length before wiring (not just presence)
- Reproduced the missing-init bug live against a real proxmox tree (read-only `terraform output`, no state touched) before fixing it
- `python3 -m py_compile` clean
- `terraform fmt`/`validate` clean
- Live `terraform plan` against scratch state — 10 to add, 0 errors

## Test plan

- [x] Script compiles
- [x] Terraform fmt/validate/plan (scratch state)
- [x] Missing-init bug reproduced live, then fixed
- [ ] Real `terraform apply` via `terraform-semaphore.yml` on merge — expected as an in-place `secrets` update (this resource already exists in tracked state)