### PR TITLE
fix(kubenuc,jfrog): Fix Artifactory mandatory keys

### DIFF
--- a/clusters/kubenuc-test/apps/jfrog-acr/deploy.yaml
+++ b/clusters/kubenuc-test/apps/jfrog-acr/deploy.yaml
@@ -41,3 +41,13 @@ spec:
           value:
             hosts:
             - ${TST_ARTIFACTORY_HOST}
+    - target:
+        group: onepassword.com
+        version: v1
+        kind: OnePasswordItem
+        name: artifactory-mandatory-keys
+        namespace: jfrog
+      patch: |
+        - op: replace
+          path: /spec/itemPath
+          value: "vaults/k8s_secrets/items/jfrog_artifactory_keys_test"

--- a/clusters/kubenuc/apps/jfrog-acr/manifests/secret.yml
+++ b/clusters/kubenuc/apps/jfrog-acr/manifests/secret.yml
@@ -1,0 +1,12 @@
+---
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: artifactory-mandatory-keys
+  namespace: jfrog
+spec:
+  # 1Password item must expose fields named exactly "master-key" and
+  # "join-key" - these map 1:1 to the Kubernetes Secret data keys the
+  # artifactory-jcr chart reads verbatim (stable/artifactory/templates/
+  # artifactory-statefulset.yaml at chart artifactory-107.161.15).
+  itemPath: "vaults/k8s_secrets/items/jfrog_artifactory_keys"


### PR DESCRIPTION
artifactory-107.161.15 helm chart does require a mandatory `master-key` and `join-key`