### PR TITLE
ci(kubenuc): skip stale OperatorConfiguration schema in kubeconform

### DIFF
--- a/.github/workflows/validate-flux-render.yml
+++ b/.github/workflows/validate-flux-render.yml
@@ -112,8 +112,23 @@ jobs:
         # below cover OnePasswordItem, FluxInstance, and Plan (this repo's
         # system-upgrade-controller CRD), contrary to this check's original
         # planning assumption that those three would be gaps.
+        #
+        # OperatorConfiguration (postgres-operator, kubenuc only) is skipped
+        # outright: the datree/CRDs-catalog schema for
+        # acid.zalan.do/operatorconfiguration_v1 is stale and rejects fields
+        # the chart has rendered by default since postgres-operator 2.0.0
+        # (logical_backup_ttl_seconds_after_finished,
+        # logical_backup_failed_jobs_history_limit,
+        # logical_backup_successful_jobs_history_limit,
+        # enable_maintenance_windows) via additionalProperties: false -
+        # confirmed directly against the upstream chart's render, not just
+        # the schema file. Hand-vendoring a corrected copy would need
+        # re-syncing on every future postgres-operator bump against a schema
+        # source that's already unmaintained upstream; a scoped skip of this
+        # one Kind is less fragile than that ongoing maintenance burden.
         run: |
           kubeconform -summary -ignore-missing-schemas \
+            -skip OperatorConfiguration \
             -schema-location default \
             -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
             rendered.yaml


### PR DESCRIPTION
## Summary

Part of the staged Zalando postgres-operator 2.0.1 upgrade sequence for `kubenuc` (PR-A of that plan) — a standalone CI fix, no functional cluster change, safe to merge independently.

- The `datreeio/CRDs-catalog` schema `kubeconform` validates against for `acid.zalan.do/operatorconfiguration_v1` is stale and rejects 4 fields the postgres-operator chart has rendered by default since 2.0.0 (`enable_maintenance_windows`, `logical_backup_ttl_seconds_after_finished`, `logical_backup_failed_jobs_history_limit`, `logical_backup_successful_jobs_history_limit`) via `additionalProperties: false`.
- Confirmed directly against the upstream chart's rendered output (not just the schema file) that these fields are genuinely missing from the schema, not a rendering bug on our side.
- Fix: a scoped `kubeconform -skip OperatorConfiguration`. Chose this over hand-vendoring a corrected schema copy since the datree schema is unmaintained upstream and a vendored copy would need re-syncing on every future postgres-operator bump — a scoped skip of this one Kind is less ongoing maintenance.
- No functional change: confirmed locally with the `kubeconform` binary that this is a no-op against the current live 1.15.1 chart render (8/8 valid before → 7 valid + 1 skipped after). It only becomes load-bearing once the operator chart is actually bumped past 2.0.0 in a later PR.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — YAML syntax valid
- [x] `pre-commit run check-yaml` — passed
- [x] Rendered postgres-operator chart 2.0.1 locally (`helm template`) and confirmed `kubeconform` fails without the skip, passes with it
- [x] Rendered postgres-operator chart 1.15.1 (current live version) and confirmed the skip changes nothing observable (still 0 invalid)
- [ ] CI run on this PR green

🤖 Generated with [Claude Code](https://claude.com/claude-code)