### PR TITLE
fix(kubenuc): freeze password_encryption and pin Spilo image on postgres-operator 1.15.1

### DIFF
--- a/clusters/kubenuc/apps/postgresql/db/cluster.yaml
+++ b/clusters/kubenuc/apps/postgresql/db/cluster.yaml
@@ -33,6 +33,11 @@ spec:
       extwlist.extensions: btree_gin,btree_gist,citext,hstore,intarray,ltree,pgcrypto,pgq,pg_trgm,postgres_fdw,tablefunc,uuid-ossp,hypopg,pg_partman
       log_rotation_age: 1h
       max_connections: "300"
+      # Explicit, not implicit: the postgres-operator chart defaults this to
+      # scram-sha-256 as of v2.0, forcing a rolling credential rotation on
+      # every user. Pinning to today's actual value (md5) decouples that
+      # rotation into its own deliberate, separately-scheduled change.
+      password_encryption: md5
   resources:
     limits:
       cpu: "4"

--- a/clusters/kubenuc/apps/postgresql/manifests/release.yml
+++ b/clusters/kubenuc/apps/postgresql/manifests/release.yml
@@ -32,6 +32,12 @@ spec:
   driftDetection:
     mode: warn
   values:
+    configGeneral:
+      # Pinned to the exact image the 1.15.1 chart defaults to today (live-
+      # verified against the running pods) so a future chart bump can't
+      # silently change the Spilo image in the same step as anything else -
+      # each variable gets its own deliberate, reviewable change.
+      docker_image: ghcr.io/zalando/spilo-17:4.0-p3
     configKubernetes:
       cluster_name_label: ranchernuc
       pod_environment_secret: postgres-object-store-credentials


### PR DESCRIPTION
## Summary

PR-B of the staged Zalando postgres-operator 2.0.1 upgrade sequence for `kubenuc` (see #1746 for PR-A, the CI schema fix, and the closed #1743 for background). Freezes two variables that today silently ride the chart's built-in defaults, so a future chart bump can't change them as an uncontrolled side effect:

- **`password_encryption: md5`** added to `postgresql-nuc-cluster`'s `spec.postgresql.parameters`. The postgres-operator chart defaults this to `scram-sha-256` as of v2.0, which forces a rolling credential rotation on every Postgres user. Pinning to today's actual value defers that rotation to its own separately-scheduled decision instead of bundling it into a version-bump PR.
- **`configGeneral.docker_image: ghcr.io/zalando/spilo-17:4.0-p3`** pinned on the `postgres-operator` HelmRelease. Live-verified against the running pods (image + digest) — this is the exact image already in place today, previously unpinned (riding the chart's `values.yaml` default). Prevents a future chart bump from changing the Spilo image in the same step as anything else.

Both changes are zero-functional-change on the currently-deployed chart version (1.15.1).

## Test plan

- [x] Live-checked via the kubernetes-agent: all 3 `postgresql-nuc-cluster` pods run the identical Spilo image/digest (`ghcr.io/zalando/spilo-17@sha256:b7db9e8f...`), matching the pinned tag exactly — confirms the pin is a true no-op today
- [x] Live-checked cluster baseline before this change: `patronictl list` — leader `postgresql-nuc-cluster-2`, both replicas streaming with 0 MB lag, consistent timeline
- [x] Confirmed `spec.postgresql.parameters` is a free-form `additionalProperties: string` map in the CRD — `password_encryption` is schema-valid
- [x] Rendered the real 1.15.1 chart locally with these values (`helm template`) and confirmed `docker_image` lands at the correct `configuration.docker_image` path, matching live state exactly
- [x] `kubeconform` passes clean against the rendered output
- [x] `pre-commit run check-yaml` passed on both files
- [ ] CI run on this PR green
- [ ] Post-merge: confirm no unexpected pod rollout is triggered (or if one is, it's expected/clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)