### PR TITLE
ops(kubenuc): scale postgresql-nuc-cluster to 1 instance (PR-C)

### DIFF
--- a/clusters/kubenuc/apps/postgresql/db/cluster.yaml
+++ b/clusters/kubenuc/apps/postgresql/db/cluster.yaml
@@ -22,7 +22,12 @@ spec:
   volume:
     size: 20Gi
     storageClass: "openebs-hostpath"
-  numberOfInstances: 3
+  # PR-C of the staged 2.0.1 upgrade sequence: scaled to 1 to allow the
+  # DCS backend flip (PR-D) to happen on a single member, per Zalando's
+  # documented migrate-to-v2 procedure. Scale back to 3 (PR-E) once the
+  # flip is confirmed healthy. Node maintenance/drains on kubenuc are
+  # frozen for the duration of this window.
+  numberOfInstances: 1
   podAnnotations:
     prometheus.io/port: "9187"
     prometheus.io/scrape: "true"


### PR DESCRIPTION
## Summary

PR-C of the staged Zalando postgres-operator 2.0.1 upgrade sequence for `kubenuc` (see #1746 PR-A, #1747 PR-B, and the closed #1743 for background). Scales `postgresql-nuc-cluster` from 3 to 1 instance so the DCS backend flip (PR-D next: `kubernetes_use_configmaps: true`) can happen on a single member, per Zalando's documented migrate-to-v2 procedure — flipping the leader-election backend on a live multi-instance cluster in one step is a documented split-brain risk.

Scale back to 3 happens in PR-E, once PR-D is confirmed healthy. Node maintenance/drains on `kubenuc` are frozen for the duration of this window (through PR-E).

## Pre-merge live verification performed

- **Backup gap closed for today's window**: a pre-flight check found Harbor's pg_dump backup unconfirmed since its CronJob was recreated on 2026-07-24 (the only visible run had failed). Manually triggered a fresh run — succeeded end-to-end (job exit 0, real 24.7 MiB object uploaded to S3, CronJob's own `status.lastSuccessfulTime` now set). Nextcloud's own backup was already healthy (last success 4 days prior).
- **Controlled switchover performed ahead of merge**: StatefulSet scale-down removes the highest ordinals first, so scaling 3→1 without acting first would have force-failed-over away from the then-leader (`-2`) mid-scale-down. Performed a `patronictl switchover` to `postgresql-nuc-cluster-0` (the ordinal that survives) beforehand. Confirmed clean: single switchover event in the logs, no conflicts/duplicates, timeline advanced 1518→1519 as expected, 0 lag on both replicas, zero pod restarts.
- **Node maintenance freeze confirmed clean**: no `system-upgrade-controller` Plan currently active or pending on `kubenuc`.

## Known pre-existing gap (flagged, not fixed by this PR)

WAL archiving to S3 (`wal-g`) has been failing continuously since 2026-07-11 with zero base backups ever recorded, and Velero does not cover the `databases` namespace. During the single-replica window, the only redundancy for this cluster is the remaining pod itself plus the fresh Harbor logical dump taken above. Separate remediation tracked outside this staged sequence.

## Test plan

- [x] Pre-merge: confirmed primary identity (switched over to `-0`), replication lag (0 MB on both replicas), backup freshness (Harbor fresh dump + Nextcloud already healthy)
- [x] Post-merge: `patronictl list` — single healthy leader on `-0`
- [x] Post-merge: WAL archiving status unchanged (already known-broken, not made worse)
- [x] Post-merge: backup CronJobs unaffected
- [x] Post-merge: Harbor/Nextcloud/SSO connectivity OK
- [x] CI run on this PR green

🤖 Generated with [Claude Code](https://claude.com/claude-code)