### PR TITLE
ops(kubenuc): flip Patroni DCS backend to ConfigMaps on postgres-operator 1.15.1 (PR-D)

### DIFF
--- a/clusters/kubenuc/apps/postgresql/manifests/release.yml
+++ b/clusters/kubenuc/apps/postgresql/manifests/release.yml
@@ -38,6 +38,16 @@ spec:
       # silently change the Spilo image in the same step as anything else -
       # each variable gets its own deliberate, reviewable change.
       docker_image: ghcr.io/zalando/spilo-17:4.0-p3
+      # PR-D of the staged 2.0.1 upgrade sequence: flips Patroni's DCS
+      # backend from Kubernetes Endpoints (the implicit default while this
+      # key is unset) to ConfigMaps, still on chart 1.15.1 - v2.0 makes this
+      # the default, but flipping it in the same step as a major chart bump
+      # on a live cluster is a documented split-brain risk (Zalando's
+      # migrate.md). Done here instead, deliberately isolated, while the
+      # cluster is at numberOfInstances: 1 (PR-C) per Zalando's mandated
+      # procedure. Verify: 3 new ConfigMaps (-config/-failover/-leader)
+      # exist and the sole member stays healthy before PR-E scales back up.
+      kubernetes_use_configmaps: true
     configKubernetes:
       cluster_name_label: ranchernuc
       pod_environment_secret: postgres-object-store-credentials


### PR DESCRIPTION
## Summary

PR-D of the staged Zalando postgres-operator 2.0.1 upgrade sequence for `kubenuc` (see #1746 PR-A, #1747 PR-B, #1748 PR-C, and the closed #1743 for background). Flips `configGeneral.kubernetes_use_configmaps` to `true` — moving Patroni's leader-election backend from Kubernetes Endpoints to ConfigMaps — while still on chart 1.15.1, deliberately isolated from the version bump.

v2.0 makes this the chart default, but flipping it in the same step as a major chart bump on a live cluster is a documented split-brain risk (Zalando's `migrate.md`). Doing it here instead, alone, fully decouples it from the chart bump (PR-F, later).

This runs while `postgresql-nuc-cluster` is at `numberOfInstances: 1` (PR-C, merged), per Zalando's mandated procedure for this migration. Scale back to 3 happens in PR-E, once this is confirmed healthy.

## Correction caught before merge

The original staged-plan draft had this key under `configKubernetes.kubernetes_use_configmaps`. Verified against the actual chart `values.yaml` that this key lives under **`configGeneral`** instead — two distinct top-level sections in this chart. The wrong key would have silently no-op'd this step and let PR-F's chart bump perform the DCS flip in one uncontrolled step on a live cluster — the exact scenario this whole staged sequence exists to prevent.

## Verification performed

- Confirmed the field exists natively in 1.15.1's own bundled `OperatorConfiguration` CRD — not a v2-only addition, just a default flip on an already-valid field.
- Rendered the real 1.15.1 chart locally (`helm template`) with these values and confirmed `kubernetes_use_configmaps` lands at the correct top-level `configuration.kubernetes_use_configmaps` path.
- `kubeconform` passes clean against the rendered output.
- `pre-commit run check-yaml` passed.

## Test plan

- [x] Pre-merge: confirmed field validity and correct key placement via local chart render
- [x] Post-merge: confirm 3 new ConfigMaps (`-config`/`-failover`/`-leader`) exist for `postgresql-nuc-cluster`
- [x] Post-merge: confirm the sole member (`postgresql-nuc-cluster-0`) stays `Leader/running`, no partial-migration state (no member still reading old Endpoints objects)
- [x] Post-merge: WAL archiving status unchanged (already known-broken, not made worse)
- [x] Post-merge: Harbor/Nextcloud/SSO connectivity OK
- [x] CI run on this PR green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
