### PR TITLE
fix(kubenuc): remove prune-disabled annotation from jfrog namespace

### DIFF
--- a/clusters/kubenuc-test/apps/jfrog-acr/deploy.yaml
+++ b/clusters/kubenuc-test/apps/jfrog-acr/deploy.yaml
@@ -4,8 +4,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: jfrog
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization

--- a/clusters/kubenuc/apps/jfrog-acr/manifests/namespace.yml
+++ b/clusters/kubenuc/apps/jfrog-acr/manifests/namespace.yml
@@ -8,5 +8,3 @@ metadata:
     pod-security.kubernetes.io/audit-version: v1.33
     pod-security.kubernetes.io/warn: restricted
     pod-security.kubernetes.io/warn-version: v1.33
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled


### PR DESCRIPTION
First step of decommissioning jfrog-acr (Artifactory): the namespace's
kustomize.toolkit.fluxcd.io/prune: disabled annotation must reconcile
onto the live objects before the app itself is deleted, otherwise
Flux's prune-skip check (evaluated against the live namespace, not
git) would silently keep the namespace around forever. This must
merge and reconcile on both kubenuc and kubenuc-test before the
follow-up PR removes jfrog-acr entirely.