### PR TITLE
ops(kubenuc): enable Reloader reloadOnCreate/reloadOnDelete

### DIFF
--- a/clusters/kubenuc/apps/reloader/manifests/release.yml
+++ b/clusters/kubenuc/apps/reloader/manifests/release.yml
@@ -32,6 +32,17 @@ spec:
   values:
     reloader:
       readOnlyRootFileSystem: true
+      # Chart defaults to false/false: Reloader only reacts to Secret/ConfigMap
+      # *updates* by default, not delete+recreate. A common ops pattern - force
+      # an immediate resync of a 1Password-Operator-managed Secret via
+      # `kubectl delete secret`, relying on the operator to recreate it - looks
+      # like a delete event followed by a create event, which the default
+      # config silently ignores. Confirmed missed on kubenuc 2026-08-01 during
+      # a live DB-credential rotation (Harbor/Nextcloud/Authentik pods never
+      # restarted; had to be restarted manually). Enabling both closes that
+      # gap cluster-wide for every Reloader-annotated app.
+      reloadOnCreate: true
+      reloadOnDelete: true
       deployment:
         securityContext:
           runAsNonRoot: true


### PR DESCRIPTION
## Summary
- Reloader only reacted to Secret/ConfigMap *updates* by default (chart defaults `reloadOnCreate: false`, `reloadOnDelete: false`).
- Forcing an immediate resync of a 1Password-Operator-managed Secret via `kubectl delete secret <name>` produces a delete event followed by a create event — never an update — so Reloader silently never evaluated either.
- Confirmed missed on kubenuc 2026-08-01 during a live DB-credential rotation: Harbor/Nextcloud/Authentik pods never auto-restarted after their Secrets were force-resynced, had to be restarted manually.
- This sets both flags to `true` so Reloader reacts cluster-wide to delete+recreate Secret events, not just in-place updates.

## Test plan
- [ ] `flux reconcile` / PR CI validates the HelmRelease values (no schema/type errors)
- [ ] After merge, confirm live: `kubectl get pod -n reloader` shows the new values applied, e.g. via `kubectl get helmrelease reloader -n reloader`
- [ ] Functional check: delete a Reloader-annotated app's Secret and confirm the derived Deployment auto-restarts without a manual `kubectl rollout restart`

🤖 Generated with [Claude Code](https://claude.com/claude-code)