### PR TITLE
ops(kubenuc): add restart-trigger podAnnotation to postgresql-nuc-cluster

### DIFF
--- a/clusters/kubenuc/apps/postgresql/db/cluster.yaml
+++ b/clusters/kubenuc/apps/postgresql/db/cluster.yaml
@@ -34,6 +34,12 @@ spec:
     prometheus.io/port: "9187"
     prometheus.io/scrape: "true"
     target-version: "15"
+    # Bump this value to force a Patroni-aware rolling pod restart via the
+    # operator (e.g. to pick up a rotated postgres-exporter credential that
+    # has no Reloader wiring under apps/postgresql/). Do not use raw
+    # `kubectl rollout restart` on this StatefulSet - it fights Patroni's
+    # own leader-aware rolling logic.
+    ops.fastnetserv.io/restart-trigger: "2026-08-01-superuser-rotation"
   postgresql:
     version: "15"
     parameters:


### PR DESCRIPTION
## Summary
- Adds a bump-to-restart `podAnnotations` key on the `postgresql-nuc-cluster` CR, routing a rolling pod restart through the postgres-operator's own Patroni-aware logic (never raw `kubectl rollout restart` on this StatefulSet).
- Needed because the postgres-exporter sidecar has no Reloader wiring under `apps/postgresql/` — it's the only way to pick up a rotated `DATA_SOURCE_PASS` without restarting the whole pod out-of-band.

## Context
Prepared ahead of an in-progress superuser (`postgres` role) credential rotation, so PR review/approval isn't on the critical path of the stale-password window between the rotation and the exporter picking up the new credential.

**Do not merge until told the superuser rotation has actually landed** — merging this before that rotates Postgres pods (leader failover included) for no reason yet.

## Test plan
- [ ] Superuser rotation lands (separate, out-of-band action against the live cluster + 1Password)
- [ ] Merge this PR
- [ ] Confirm the postgres-exporter picks up the new credential (Prometheus `pg_up`/`pg_stat_database_*` query)
- [ ] Confirm no unexpected Patroni failover / cluster events during the rolling restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)