### PR TITLE
ops(kubenuc): flip exporter sidecar to pgexporter credential (PR-2/3)

### DIFF
--- a/clusters/kubenuc/apps/postgresql/db/cluster.yaml
+++ b/clusters/kubenuc/apps/postgresql/db/cluster.yaml
@@ -48,7 +48,7 @@ spec:
     # has no Reloader wiring under apps/postgresql/). Do not use raw
     # `kubectl rollout restart` on this StatefulSet - it fights Patroni's
     # own leader-aware rolling logic.
-    ops.fastnetserv.io/restart-trigger: "2026-08-01-superuser-rotation"
+    ops.fastnetserv.io/restart-trigger: "2026-08-01-pgexporter-pgmonitor-cutover"
   postgresql:
     version: "15"
     parameters:
@@ -75,12 +75,15 @@ spec:
     - name: DATA_SOURCE_URI
       value: localhost:5432/postgres?sslmode=disable
     - name: DATA_SOURCE_USER
-      value: "postgres"
+      valueFrom:
+        secretKeyRef:
+          name: "pgexporter.postgresql-nuc-cluster.credentials.postgresql.acid.zalan.do"
+          key: username
     - name: DATA_SOURCE_PASS
       valueFrom:
         secretKeyRef:
-          name: "postgresql-exporter-secrets"
-          key: PGPASSWORD
+          name: "pgexporter.postgresql-nuc-cluster.credentials.postgresql.acid.zalan.do"
+          key: password
     - name: PG_EXPORTER_EXTEND_QUERY_PATH
       value: /tmp/queries.yaml
     image: quay.io/prometheuscommunity/postgres-exporter:v0.20.1@sha256:ac5ec343104fae0e2d84a27bb8d69b38430a11910c5382cad85d478d2bab713e


### PR DESCRIPTION
## Summary

Second of three PRs hardening the postgres-exporter sidecar off the `postgres` superuser credential. Builds on #1761 (merged) which added the dedicated `pgexporter` role via `spec.users`.

- Switches the exporter sidecar's `DATA_SOURCE_USER`/`DATA_SOURCE_PASS` from the literal `postgres` superuser + `postgresql-exporter-secrets` to `secretKeyRef`s against the operator-managed `pgexporter.postgresql-nuc-cluster.credentials.postgresql.acid.zalan.do` Secret (`username`/`password` keys).
- `GRANT pg_monitor TO pgexporter;` was already applied live and verified (`pg_has_role(...) = true`).
- All 4 custom queries (`pg_stat_user_tables`, `pg_statio_user_tables`, `pg_database_size()`, `pg_postmaster_start_time()`/`pg_last_xact_replay_timestamp()`) plus the exporter's built-in collector queries (`pg_stat_activity`, `pg_stat_replication`, `pg_settings`, `pg_ls_waldir()`) were dry-run as `pgexporter` via `SET ROLE` on the live master, with zero permission errors — before this PR was even opened.

**This is the one intentional rolling restart** in the rollout: `sidecars[].env` is part of the pod template, so `ops.fastnetserv.io/restart-trigger` is bumped to roll all 3 Postgres pods through the operator's own Patroni-aware rolling update.

## Test plan

- [x] YAML validated (`check-yaml`), dry-run of full exporter privilege surface passed cleanly pre-merge
- [x] Merge in a low-traffic window; watch the rollout (Patroni switchover included)
- [x] Post-merge: confirm all 3 exporter pods healthy, no `BackOff`/`Unhealthy` beyond the expected switchover blip
- [x] Confirm via Grafana that the exporter is actually authenticating and scraping (`pg_up` + real metric freshness), not just that pods came back Ready
- [x] `postgres` superuser no longer referenced anywhere in the exporter's env

🤖 Generated with [Claude Code](https://claude.com/claude-code)