### PR TITLE
docs: remove stray OVH references from provider docs

### DIFF
--- a/.claude/agents/terraform-agent.md
+++ b/.claude/agents/terraform-agent.md
@@ -47,7 +47,7 @@ All Terraform environments are mounted read-only at `/workspace/terraform/`:
 - `/workspace/terraform/netbird/`          — Netbird VPN (networks, groups, policies)
 - `/workspace/terraform/oci/`              — Oracle Cloud Infrastructure (two accounts)
 - `/workspace/terraform/proxmox/`          — Proxmox hosts (one workspace each)
-  - `ec200/`             — OVH EC200 (MXP)
+  - `ec200/`             — EC200 (MXP)
   - `gozzi-hpelvisor/`   — Gozzi-01 BIO + hpelvisor
   - `rabbit/`            — Rabbit-01 PSP
 - `/workspace/terraform/tailscale/`        — Tailscale VPN (ACLs, DNS, auth keys)

--- a/.claude/skills/ci-workflows/SKILL.md
+++ b/.claude/skills/ci-workflows/SKILL.md
@@ -28,7 +28,7 @@ All Terraform workflows follow the same pattern. Copy from `.github/workflows/te
 |---|---|
 | `self-hosted` | Generic / Hetzner VPS / PSP (BGY) |
 | `LGU` | Gozzi-01 + hpelvisor (Lugano, Switzerland) |
-| `mxp` | OVH EC200 (Milan, Italy) |
+| `mxp` | EC200 (Milan, Italy) |
 
 Choose based on network proximity to the managed infrastructure, or `self-hosted` for cloud providers with no locality requirement.
 

--- a/.claude/skills/terraform-operations/SKILL.md
+++ b/.claude/skills/terraform-operations/SKILL.md
@@ -112,7 +112,7 @@ Copy from `.github/workflows/terraform.yml`. Adjust:
 - `runs-on` to the appropriate runner:
   - `self-hosted` — generic / Hetzner / PSP (BGY)
   - `LGU` — Gozzi-01 / hpelvisor (LUG, Switzerland)
-  - `mxp` — OVH EC200 (MXP, Italy)
+  - `mxp` — EC200 (MXP, Italy)
 
 Workflow stages: `fmt -check` → `init` → `validate` → `plan` (PR comment) → `apply` (main only).
 

--- a/.codex/agents/terraform-agent.toml
+++ b/.codex/agents/terraform-agent.toml
@@ -42,7 +42,7 @@ All Terraform environments are mounted read-only at `/workspace/terraform/`:
 - `/workspace/terraform/netbird/`          — Netbird VPN (networks, groups, policies)
 - `/workspace/terraform/oci/`              — Oracle Cloud Infrastructure (two accounts)
 - `/workspace/terraform/proxmox/`          — Proxmox hosts (one workspace each)
-  - `ec200/`             — OVH EC200 (MXP)
+  - `ec200/`             — EC200 (MXP)
   - `gozzi-hpelvisor/`   — Gozzi-01 BIO + hpelvisor
   - `rabbit/`            — Rabbit-01 PSP
 - `/workspace/terraform/tailscale/`        — Tailscale VPN (ACLs, DNS, auth keys)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md — AI Assistant Guide for infra-cd
 
-`infra-cd` is a **production-grade GitOps infrastructure-as-code repository** managing multiple Kubernetes clusters, Terraform-managed cloud infrastructure (Hetzner, OCI, Proxmox, OVH), FluxCD v2 continuous deployment, Ansible automation, and automated dependency management via Renovate. **Changes to this repository drive infrastructure state** — handle all modifications carefully.
+`infra-cd` is a **production-grade GitOps infrastructure-as-code repository** managing multiple Kubernetes clusters, Terraform-managed cloud infrastructure (Hetzner, OCI, Proxmox), FluxCD v2 continuous deployment, Ansible automation, and automated dependency management via Renovate. **Changes to this repository drive infrastructure state** — handle all modifications carefully.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — AI Assistant Guide for infra-cd
 
-`infra-cd` is a **production-grade GitOps infrastructure-as-code repository** managing multiple Kubernetes clusters, Terraform-managed cloud infrastructure (Hetzner, OCI, Proxmox, OVH), FluxCD v2 continuous deployment, Ansible automation, and automated dependency management via Renovate. **Changes to this repository drive infrastructure state** — handle all modifications carefully.
+`infra-cd` is a **production-grade GitOps infrastructure-as-code repository** managing multiple Kubernetes clusters, Terraform-managed cloud infrastructure (Hetzner, OCI, Proxmox), FluxCD v2 continuous deployment, Ansible automation, and automated dependency management via Renovate. **Changes to this repository drive infrastructure state** — handle all modifications carefully.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This project is a personal exercise in infrastructure-as-code. My infrastructure
 | `terraform/DNS/` | Cloudflare DNS records | — |
 | `terraform/hetzner/` | Hetzner Cloud VPS | self-hosted |
 | `terraform/oci/` | Oracle Cloud Infrastructure | — |
-| `terraform/proxmox/ec200/` | OVH EC200 Proxmox host (MXP) | mxp |
+| `terraform/proxmox/ec200/` | EC200 Proxmox host (MXP) | mxp |
 | `terraform/proxmox/gozzi-hpelvisor/` | Gozzi-01 + hpelvisor Proxmox hosts (LUG) | LGU |
 | `terraform/proxmox/rabbit/` | Rabbit-01 Proxmox host (BGY) | self-hosted |
 | `terraform/cloudflare-tunnel/` | Cloudflare Tunnel routing | self-hosted |

--- a/terraform/CLAUDE.md
+++ b/terraform/CLAUDE.md
@@ -21,7 +21,7 @@
 |---|---|---|
 | `terraform.yml` | PR/push to `terraform/hetzner/` | Hetzner infrastructure |
 | `terraform-bio.yml` | PR/push to `terraform/proxmox/gozzi-hpelvisor/` | Gozzi-01 BIO + hpelvisor Proxmox hosts |
-| `terraform-mxp.yml` | PR/push to `terraform/proxmox/ec200/` | OVH EC200 (MXP) Proxmox host |
+| `terraform-mxp.yml` | PR/push to `terraform/proxmox/ec200/` | EC200 (MXP) Proxmox host |
 | `terraform-psp.yml` | PR/push to `terraform/proxmox/rabbit/` | Rabbit-01 PSP Proxmox host |
 | `terraform-dns.yml` | PR/push to `terraform/DNS/` | DNS records (Cloudflare) |
 | `terraform-cloudflare-tunnel.yml` | PR/push to `terraform/cloudflare-tunnel/` | Cloudflare Tunnel remote ingress config (kubenuc, prod-k3s) |


### PR DESCRIPTION
## Summary
- The EC200 Proxmox host has never been OVH-hosted, it's always been at different location. Removes the incorrect "OVH" label from prose/tables across docs, skills, and agent files.
- Doc-only cleanup: no Terraform, Ansible, or CI logic changes. The `ec200`/`mxp`/`mon-mxp` naming is unchanged (it's just an identifier, not a provider claim).

Files changed:
- `CLAUDE.md`, `AGENTS.md` — provider list drops OVH
- `README.md`, `terraform/CLAUDE.md` — EC200 table rows
- `.claude/agents/terraform-agent.md`, `.codex/agents/terraform-agent.toml` — directory listings
- `.claude/skills/ci-workflows/SKILL.md`, `.claude/skills/terraform-operations/SKILL.md` — runner tables

## Test plan
- [x] `git grep -in "ovh"` confirms only pre-existing SOPS ciphertext false positives remain (3 files, unchanged), zero prose/doc hits
- [x] `git diff --stat` confirms exactly the 8 files changed, one line each
- [x] No `.tf`/`.yml` config values touched — Markdown/TOML prose only, so no fmt/validate/lint needed