### PR TITLE
feat(terraform): add Cloudflare Tunnel ingress rule for forgejo

### DIFF
--- a/terraform/cloudflare-tunnel/main.tf
+++ b/terraform/cloudflare-tunnel/main.tf
@@ -80,6 +80,13 @@ module "kubenuc" {
         origin_server_name = local.cf.kubenuc.flux_webhook_host
       }
     },
+    {
+      hostname = local.cf.kubenuc.forgejo_host
+      service  = "http://haproxy-ingress-kubernetes-ingress.haproxy-ingress.svc.cluster.local"
+      origin_request = {
+        origin_server_name = local.cf.kubenuc.forgejo_host
+      }
+    },
     { service = "http_status:404" }, # catch-all, must stay last
   ]
 }

--- a/terraform/cloudflare-tunnel/secrets.sops.yaml
+++ b/terraform/cloudflare-tunnel/secrets.sops.yaml
@@ -13,6 +13,7 @@ kubenuc:
     s3_host: ENC[AES256_GCM,data:S4FCNGTHPNBBVdYT,iv:NDNInjKL/OYHTdy2gfj+/+YhrFIkf9uyvl9YWL/wLEs=,tag:t3SqR1bm1iLFTcPV5Os82Q==,type:str]
     artifactory_host: ENC[AES256_GCM,data:M5c25KF4TejlM0jguKeB4ll0JyI8,iv:jeoY1cAV6pQAzK2fPDoXzzF1hM5nVVAPCzC14nE0ots=,tag:C9/tGiBhPdeGjdDvwr6jMw==,type:str]
     flux_webhook_host: ENC[AES256_GCM,data:xINMbbUEZxFznMJ/9TQo7gfNNEHw1oYgJKCrF0pe,iv:CrISP6Zq7Nhp6Dk0eJu9tLZSZ6vfneNUF9RuR2P4vZ4=,tag:bCiFBFQWLVjYmWE3Kn0hzQ==,type:str]
+    forgejo_host: ENC[AES256_GCM,data:dSiP2z1VoEnFabb8c9g=,iv:l3T4L8wuEwQeINib+QIODA/fBctGQI8+whGT8YZrohA=,tag:Uu838Xmm4Va1jwXz/R48PQ==,type:str]
 prod_k3s:
     tunnel_id: ENC[AES256_GCM,data:9PdwOEyIHyKH9VQzEZM42akk9KZJPUK793Fss5JzCManmisw,iv:VzrvxKtHRNpwm481cf/PTv9N9mpDPdS5DJo17s/J2Ps=,tag:y4qVo+sDrSSrcJXVF8+LVw==,type:str]
     semaphore_host: ENC[AES256_GCM,data:kbixWap9bEQVIzfTAFcNJcmWwt6jEHu5yA==,iv:6hZF5o0G4U70xImJKlzCUQ10TVrtB/Odkx2GO67Mra4=,tag:BmJAtIPm0cjEz3Se55kcDA==,type:str]
@@ -29,7 +30,7 @@ sops:
             9bKYVyCv9AR8tI5p2Mp+kv95X7q5NEo6VkArG+I12YtDkUQqoXQLUA==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1tce0mlehlddhnlsun7l2kd5mymuf5czk3dk8gs62u7vsxn76hfsq0ajkqv
-    lastmodified: "2026-08-02T12:19:10Z"
-    mac: ENC[AES256_GCM,data:1L4bleGAqZvNv2vKSkZi5Q+zqfqb+SvpRIy84eq+I5eJGGp9PGP1uB9x802J3l7t0JiSP0H9N6vA2nUJ8sZzP51HxwPDUbwAmSsVoaSfi5+fXPQblMlek0z8YkLn9bkX+oSf1k78mw1/3zmixVkLcbGdalAzX3BtLknBCK1vOOw=,iv:xCCMu6jnaEIyQqmaLVkCNlhhjRch7S2Rg9axdAAF5hs=,tag:mBaun4kQXi7z1maoAlW0qQ==,type:str]
+    lastmodified: "2026-08-04T19:39:59Z"
+    mac: ENC[AES256_GCM,data:/62K2xdx7f3X1n7nwh2J4JJnLPC1UlDcnA60vsOlvMSeo4iGdPtR7EezhV0TbNaPaOA2c/J/gF/B/cet+Ri4wUgFsWarBjEi0UrXYfcKNno2SQ0g3IIL+3m707DPCURhhKRnAGaLUmRH/UAv+Yx+5Xqf/vLS6dt6s9dr1YHf3Ek=,iv:4TOj4PTPz24bHHfhKoecExQFeHRtBE8Xa+MpVodEiWs=,tag:izsrVS8GiFfqtXReGZ8sYg==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.2


### PR DESCRIPTION
## Summary

- Adds the `kubenuc` Cloudflare Tunnel ingress rule for the Forgejo app (#1768, merged and live), routing to `haproxy-ingress` — same shape as every other kubenuc service in this module.
- New `forgejo_host` key added to `terraform/cloudflare-tunnel/secrets.sops.yaml`'s `kubenuc` block, matching the `FORGEJO_HOST` value already live in the cluster's own `cluster-vars.sops.yaml` (verified by decrypting both locally and comparing — not guessed).
- Landed after the app PR, not alongside it — per that PR's own design notes, to avoid repeating the dangling dead-ingress-rule situation cleaned up in #1765 (tunnel rule merged before the app, then had to be cleaned up separately when the app was abandoned).

No FQDN/hostname values are included in this description per repo convention.

## Test plan

- [x] `terraform fmt -check` clean
- [x] `terraform validate` clean (`init -backend=false`, no state/backend touched)
- [x] `sops -d` round-trip confirms the new key sits alongside the existing ones with nothing else altered
- [x] `pre-commit` (yaml check, secret detection) clean
- [x] CI (`terraform-cloudflare-tunnel.yml`: fmt/init/validate/plan-as-PR-comment) on this PR
- [ ] Live: after apply, confirm the tunnel hostname resolves and proxies to Forgejo's ingress correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)