### PR TITLE
feat(terraform): add DNS record for forgejo

### DIFF
--- a/terraform/DNS/secrets.sops.yaml
+++ b/terraform/DNS/secrets.sops.yaml
@@ -608,6 +608,11 @@ zones:
                 type: ENC[AES256_GCM,data:Cbe6,iv:g7+WWFEwXNDjzvkNoeQIS0KIGd8eaIBdF245OSTov6Q=,tag:vomZWkp02/IiHeMAs0ozaA==,type:str]
                 content: ENC[AES256_GCM,data:QhlNLwDw1ykidjnbvdjyGAwsKPrgPSuf/YMOirEzxwZkU8G6joPYvVfVY1+etXgWj+oc5BHlx+9BmDRLlZGQu0/PQmHUrh6l62TIBbrDc4d5TWE631CMohmvolM=,iv:l1z4zUVSTCNgc8YU31frB/CqP69Q6hXDrjJITfm4QZ4=,tag:ohjSgjux5LQpMSU0wA5rmQ==,type:str]
                 proxied: ENC[AES256_GCM,data:SW0Rf9E=,iv:m2zR/ZrEHxkF2/Ixo5Zw3K6nrKXhrT77X8mBCf32Zbo=,tag:RxvZbNZ2VPF80RZAyRasCw==,type:bool]
+            forgejo:
+                name: ENC[AES256_GCM,data:4kL6Pw==,iv:uZiNWUeQKKO31eUh5D+mnt6ARJctfCojLZr81nGInVw=,tag:N0zjE003pE5aiqdD47TJiQ==,type:str]
+                type: ENC[AES256_GCM,data:BrauHh0=,iv:Pt+lmsvUEGlfAKLp0FrTFdNw/2L/bx69rIGq3Vq5aNE=,tag:iskx/epV/3zHyZNqt3syBA==,type:str]
+                content: ENC[AES256_GCM,data:imuptgFhI+0Y94OeSFCWrWeX45X2FVEHLqCGp+9GQEOw82ISTuBMl5VcW3oBN9sZyJT6Scs=,iv:hxb+Thv8zIN6ibLFosSIPeXKm1taUHYVlYvfILkgakA=,tag:jbvKvuTN6h0tq0kVE+cSzg==,type:str]
+                proxied: ENC[AES256_GCM,data:fcBWUg==,iv:FpyHqFd+ieie8djN3zWIhCnLCe+2hzerDar88W4Oz/U=,tag:OT5gyNmovdtOPCB+ia1eUQ==,type:bool]
     fastnetserv_com:
         id: ENC[AES256_GCM,data:GusgQ8myy0cI+qPvXE0lWVP2GvglXYzkJ+SM+/dEcys=,iv:LbFF79LP3Or3BrhqgwlVuBiKQsH8O9klsTFaqPo7EKM=,tag:54bnYZKWH1zlsXYrsuTXcg==,type:str]
         records:
@@ -1055,7 +1060,7 @@ sops:
             wEWO5i9PwX9UFAFoCLIu7BAXXAGy08bXtFOFGcx67fnGSEOz0FCRtQ==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1gk3jk7r6hvvq4mef56zs2tq94y8dgpde75m7af9hd9mecjx0hvasd4ele5
-    lastmodified: "2026-08-01T21:15:39Z"
-    mac: ENC[AES256_GCM,data:LOOOc1JcdrJzKfr+6zKKGBCLz0P48vkctPoTRcRqtK/dpHOAXFagY0NctlV8gC5+Y9K+8H3VXXkQgSoK0pcf8pVgNQOp+Tk9mPhbE8NWXO0q0xn8i8359+TWEr8qLPrTYu8W5XhJkWX0QiTW4jueOTv55iIZnYttkttVR8OL9X0=,iv:zbk3uUOktxGpejaOKornykl1XC/imQjswnEzChGqLZU=,tag:6jA41MAjdMeHWbFmaD03FQ==,type:str]
+    lastmodified: "2026-08-04T19:47:12Z"
+    mac: ENC[AES256_GCM,data:CV4h+05d1Uodl49gdnWkaprWcpWk/8DhI0086E3pboCPnnpZEu6j+boGutBPiIP2fWNCu8bmXWvjixISBBGhmo9tXJe/yNmRodEkGNeABrv0BOnekULZnT0vdBVoIpUHzebdsY6Rfrdu07CO3GWSVi+I7yULoniAQitQYNqPrf4=,iv:+MbhW7KooLfKVjmdYL6t97XkNT8VLjYCUlClGgQEBO0=,tag:IGJn4W08BXgHVjNkq12iPQ==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.3


### PR DESCRIPTION
## Summary

- Adds the `ddlns_net` zone CNAME record for the Forgejo hostname, pointing at the kubenuc Cloudflare Tunnel — same shape as the existing harbor/portainer/jenkins/cloud/kubenuc records (CNAME to the tunnel target, proxied).
- No `main.tf` change: the `ddlns_net` module's `records` variable is a map consumed via `for_each` inside the module itself, so a new record only needs a `secrets.sops.yaml` entry.
- Follow-up to #1768 (app) and #1771 (tunnel ingress rule) — without this record, the tunnel ingress rule has no DNS pointing traffic at it, so the app is still unreachable externally until this merges.

No FQDN/hostname values are included in this description per repo convention.

## Test plan

- [x] `terraform fmt -check` clean (no `.tf` files touched)
- [x] `terraform validate` clean
- [x] `sops -d` round-trip confirms the new record matches the module's `records` object schema exactly and nothing else in the zone was altered
- [x] `pre-commit` (yaml check, secret detection) clean
- [ ] CI (`terraform-dns.yml`: fmt/init/validate/plan-as-PR-comment)
- [ ] Live: after apply, confirm the hostname resolves and the tunnel serves Forgejo end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)