### PR TITLE
feat(kubenuc): opt forgejo into external-dns

### DIFF
--- a/clusters/kubenuc/apps/forgejo/manifests/release.yml
+++ b/clusters/kubenuc/apps/forgejo/manifests/release.yml
@@ -48,6 +48,14 @@ spec:
       className: haproxy
       annotations:
         cert-manager.io/cluster-issuer: letsencrypt
+        # Opt-in to external-dns (see the External DNS runbook). Adopts the
+        # existing live record created in terraform/DNS (#1772) - proxied:
+        # "true" matches its current state, confirmed via dig resolving to
+        # Cloudflare edge IPs before this change. Tunnel target comes from
+        # cluster-vars (never hardcode FQDNs/tunnel targets in git).
+        external-dns.alpha.kubernetes.io/managed-by: external-dns
+        external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
+        external-dns.alpha.kubernetes.io/target: ${CLOUDFLARE_TUNNEL_TARGET}
       hosts:
         - host: ${FORGEJO_HOST}
           paths:

--- a/clusters/kubenuc/apps/forgejo/manifests/release.yml
+++ b/clusters/kubenuc/apps/forgejo/manifests/release.yml
@@ -48,11 +48,13 @@ spec:
       className: haproxy
       annotations:
         cert-manager.io/cluster-issuer: letsencrypt
-        # Opt-in to external-dns (see the External DNS runbook). Adopts the
-        # existing live record created in terraform/DNS (#1772) - proxied:
-        # "true" matches its current state, confirmed via dig resolving to
-        # Cloudflare edge IPs before this change. Tunnel target comes from
-        # cluster-vars (never hardcode FQDNs/tunnel targets in git).
+        # Opt-in to external-dns (see the External DNS runbook). Unlike
+        # jenkins/portainer's opt-in (which adopted an already-live,
+        # manually-managed record), Forgejo has no pre-existing DNS record -
+        # external-dns' upsert-only policy creates it directly from this
+        # annotated Ingress, no separate Terraform DNS record needed. Tunnel
+        # target comes from cluster-vars (never hardcode FQDNs/tunnel
+        # targets in git).
         external-dns.alpha.kubernetes.io/managed-by: external-dns
         external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
         external-dns.alpha.kubernetes.io/target: ${CLOUDFLARE_TUNNEL_TARGET}


### PR DESCRIPTION
## Summary

- Adds the `external-dns.alpha.kubernetes.io/{managed-by,cloudflare-proxied,target}` annotation set to Forgejo's Ingress — same pattern already live on `jenkins` (#1612) and `portainer`.
- external-dns' `annotationFilter` gate (`external-dns/manifests/release.yml`) means it only touches Ingresses carrying `managed-by: external-dns`, so this is a deliberate opt-in, not implicit.
- `policy: upsert-only` creates the record directly since Forgejo has no pre-existing DNS record to adopt (unlike jenkins/portainer, which were migrating an already-live manually-managed record). No separate Terraform DNS PR is needed — a prior one (#1772) was opened and closed as unnecessary once this was confirmed.
- Cert issuance has no dependency on this record existing first: the `letsencrypt` ClusterIssuer uses a DNS-01 challenge via the Cloudflare API directly (`clusters/kubenuc/apps/cert-manager/issuers/cluster-issuer.yml`), not HTTP-01.

No FQDN/hostname values are included in this description per repo convention.

## Test plan

- [x] `helm template` against the real chart confirms the annotation block renders correctly into the generated Ingress
- [x] `pre-commit` (yaml check, secret detection) clean
- [x] `CLOUDFLARE_TUNNEL_TARGET` already exists as a cluster-var (used by jenkins/portainer already) — no new var needed
- [ ] After merge: confirm external-dns creates the record (TXT ownership record + CNAME to the tunnel target) and it resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)