### PR TITLE
fix(kubenuc): restore NetworkPolicy enforcement for net-mon and film-tv-exporter

### DIFF
--- a/clusters/kubenuc/apps/film-tv-exporter/manifests/kustomization.yaml
+++ b/clusters/kubenuc/apps/film-tv-exporter/manifests/kustomization.yaml
@@ -7,3 +7,5 @@ resources:
 - deployment.yaml
 - secret.yaml
 - serviceaccount.yaml
+- networkpolicy-allow-ingress.yml
+- networkpolicy-default-deny-ingress.yml

--- a/clusters/kubenuc/apps/net-mon/manifests/kustomization.yaml
+++ b/clusters/kubenuc/apps/net-mon/manifests/kustomization.yaml
@@ -7,3 +7,5 @@ resources:
 - configmap.yaml
 - deployment.yaml
 - serviceaccount.yaml
+- networkpolicy-allow-ingress.yml
+- networkpolicy-default-deny-ingress.yml


### PR DESCRIPTION
## Summary
- `net-mon` and `film-tv-exporter`'s `manifests/kustomization.yaml` (both added in PR #1561, same scaffolding pattern) declare an explicit `resources:` list that omits two `NetworkPolicy` files present on disk (`networkpolicy-allow-ingress.yml`, `networkpolicy-default-deny-ingress.yml`)
- Kustomize's `resources:` list is exhaustive, not additive — files left off never render, no error. Both namespaces have had zero NetworkPolicy enforcement since #1561 instead of the intended deny-all-plus-scoped-allow baseline
- Fix is purely additive: append the two missing filenames to each `resources:` list
- Both apps are scaled to `replicas: 0` today, so this has zero live blast radius — no pods running to be affected by newly-enforced ingress policies

## Test plan
- [x] `flux build kustomization net-mon --path ./clusters/kubenuc/apps/net-mon/manifests --kustomization-file ./clusters/kubenuc/apps/net-mon/deploy.yaml --dry-run` — both `NetworkPolicy` objects (`allow-ingress`, `default-deny-ingress`) now render in namespace `net-mon`; all other resources unchanged
- [x] `flux build kustomization film-tv-app --path ./clusters/kubenuc/apps/film-tv-exporter/manifests --kustomization-file ./clusters/kubenuc/apps/film-tv-exporter/deploy.yaml --dry-run` — both `NetworkPolicy` objects now render in namespace `film-tv`; all other resources unchanged
- [x] CI: `validate-flux-render.yml` / `security-static-analysis.yml` (KubeLinter + checkov) on this PR
- [ ] Post-merge: confirm both `NetworkPolicy` objects exist live in each namespace (read-only, via kubernetes-mcp-server)