### PR TITLE
fix(kubenuc): restore NetworkPolicy enforcement for nut

### DIFF
--- a/clusters/kubenuc/apps/nut/manifests/kustomization.yaml
+++ b/clusters/kubenuc/apps/nut/manifests/kustomization.yaml
@@ -6,3 +6,5 @@ resources:
 - namespace.yaml
 - deployment.yaml
 - serviceaccount.yaml
+- networkpolicy-allow-ingress.yml
+- networkpolicy-default-deny-ingress.yml


### PR DESCRIPTION
## Summary
- `nut`'s `manifests/kustomization.yaml` has the same silent-drop bug as #1783 (net-mon/film-tv-exporter): its explicit `resources:` list (from PR #1561) omits the two `NetworkPolicy` files on disk (`networkpolicy-allow-ingress.yml`, `networkpolicy-default-deny-ingress.yml`), so the `nut` namespace has had zero NetworkPolicy enforcement since #1561
- Fix is purely additive: append the two missing filenames to `resources:`
- Kept separate from #1783 because `nut` runs `replicas: 1` (a live pod), unlike the other two apps which are scaled to 0 — isolating anything touching a live pod makes it trivial to revert independently if needed
- Checked the live blast radius before opening this: `nut`'s pod has no Service and no `prometheus.io/scrape` annotation, and `grafana-alloy`'s scrape config requires that annotation to pick up a target — so nothing is actually scraping `nut` today. Enforcing the deny-all-plus-scoped-allow baseline doesn't break an active scrape path, it just closes the gap early

## Test plan
- [x] `flux build kustomization nut-exporter --path ./clusters/kubenuc/apps/nut/manifests --kustomization-file ./clusters/kubenuc/apps/nut/deploy.yaml --dry-run` — both `NetworkPolicy` objects (`allow-ingress`, `default-deny-ingress`) now render in namespace `nut`; all other resources unchanged
- [ ] CI: `validate-flux-render.yml` / `security-static-analysis.yml` (KubeLinter + checkov) on this PR
- [ ] Post-merge: confirm both `NetworkPolicy` objects exist live in the `nut` namespace, the pod is still `Ready`, and logs show no newly-blocked connections (read-only, via kubernetes-mcp-server)