### PR TITLE
fix(kubenuc-test): add CLOUDFLARE_TUNNEL_TARGET to cluster-vars

### DIFF
--- a/clusters/kubenuc-test/vars/cluster-vars.sops.yaml
+++ b/clusters/kubenuc-test/vars/cluster-vars.sops.yaml
@@ -27,6 +27,7 @@ stringData:
     TST_JENKINS_HOST: ENC[AES256_GCM,data:7y+c2b5nRAXqeAq7MchHF5IBnZJT,iv:/CxZgoLqC+m2BZh6wpxj7f83q7oeKQOm1e+BhLLxJDQ=,tag:63QRqWNCt3Go2NKzR4/nJQ==,type:str]
     TST_FORGEJO_HOST: ENC[AES256_GCM,data:mD3NG94MznuFiSIwEC+KFiWT,iv:G6PYLnQ5JPRKcynrTVLpHRDxGf8m4UQW5WQQMav8VXc=,tag:IKKqHQqm3uxIqBhDZ2C9qg==,type:str]
     TST_FORGEJO_URL: ENC[AES256_GCM,data:Bb5tRa01VzeZJ0FE+9zrMkknCZoT2SC+Tt4=,iv:p3N+rISctMVn8WcJxmwYYdXmzW+AsNMAHEw88ZdNz70=,tag:VcGXC6ZO3H1ohGGw1OV1iw==,type:str]
+    CLOUDFLARE_TUNNEL_TARGET: ENC[AES256_GCM,data:QD+ooEJR8z5luR+Az0MHKRF2u0yKDLykZClKDw==,iv:XcWfDCUrQLips6gXtsdSMjAgBv6uOj5vXk9yY+Hho94=,tag:6+M+RT8Ds6k70YE6HAyMsw==,type:str]
 sops:
     age:
         - enc: |
@@ -38,7 +39,7 @@ sops:
             Gk530ouLYKT+c7wAQdfKeTNcSN+MGpIx5GXJgHT634UVpyzh70Z1Cg==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1qwhpwjgw3c7trgrtjv7k309suma9l6qu8yrh4at80clrymrczvss8xq69u
-    lastmodified: "2026-08-04T11:37:18Z"
-    mac: ENC[AES256_GCM,data:M+/DAYIotLvs1a9hN4S/uwd7VCX27G+EwH7x6V+ScpnDufW9sw/saAjcMyUvb2P7ufJa1lGjx/KpvA30E173erw4D36GCBO4h6/G+Sv8vDP0pqb2Cq/zxrhfhS5yK64yaWEhOwe2MfBCV0OJgCCaC9EwX0JivA96iJoBYhy3gb8=,iv:bOXGCYITlgTpUN2ChshmMHKRBxqFFG2iFbzGhQJ4LUo=,tag:uwe1nuTs/5MvOfyzTsNXvw==,type:str]
+    lastmodified: "2026-08-05T12:05:56Z"
+    mac: ENC[AES256_GCM,data:a57q5tRZdTL3tueq0709aUiXc3DdQM+0RbOE+qsIabilud4XoTjUARCsDM6o+ujvHpNi7A1s+KRruFzmiT1XPP8ZOXMywAKr8ZBYK8Tl5X1o9MyImCwpk0n3DZ9khQJ8uwgdmoKRcoBG3AOW3tnDPX6BtlpEXVAy7NwGa4o2So0=,iv:Q0VfI0kS6k7hNLCjBfNdZDSOqqnrJm+IGdwhgTuXSpw=,tag:p+FMBPj9cRT5Z0dj5s2h4w==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.3


### PR DESCRIPTION
## Summary
- The `kubenuc-full-cluster-e2e` CI job has been failing on `#1783`/`#1784` (and any other PR touching `clusters/kubenuc/**`) with:
  ```
  post build failed for 'HelmRelease.v2.helm.toolkit.fluxcd.io/s3': envsubst error:
  variable not set (strict mode): "CLOUDFLARE_TUNNEL_TARGET"
  ```
- Root cause: `kubenuc-test/apps/s3/deploy.yaml` overlays the real `clusters/kubenuc/apps/s3/manifests` and declares `postBuild.substituteFrom` against its own `cluster-vars` secret. PR #1780 added `${CLOUDFLARE_TUNNEL_TARGET}` to that shared manifest for external-dns adoption, but `kubenuc-test`'s `cluster-vars.sops.yaml` never got the matching key
- This is **not** a CI-only gap — `clusters/kubenuc-test/vars/cluster-vars.sops.yaml` is the same file the real bare-metal `kubenuc-test` cluster reconciles from via Flux, so its `s3` Kustomization has very likely been failing there too since #1780 merged
- `kubenuc-test` has no `external-dns` app deployed, so the value this key feeds (an `external-dns.alpha.kubernetes.io/target` annotation) is inert on that cluster — used a placeholder value rather than a real tunnel target
- `.github/fixtures/cluster-vars-ci.yaml` (the separate CI-only fixture used by `validate-flux-render.yml`) already has this key — that file was not the problem

## Test plan
- [x] Edited via `sops set` (local `age-kubenuctest.agekey`), confirmed the file is still SOPS-encrypted (all `stringData` values remain `ENC[...]`) and the new key decrypts to the placeholder
- [ ] CI: confirm `kubenuc-full-cluster-e2e`'s `s3` Kustomization now reconciles past the postBuild step on this PR
- [ ] Post-merge: confirm the real `kubenuc-test` cluster's `s3` Kustomization goes `Ready` (read-only check)