### PR TITLE
docs(k3s-rabbit): migrate flux-instance/notifications comments to Confluence

### DIFF
--- a/clusters/k3s-rabbit/CLAUDE.md
+++ b/clusters/k3s-rabbit/CLAUDE.md
@@ -1,0 +1,11 @@
+# k3s-rabbit — Cluster-Specific Notes
+
+## Cluster Bootstrap
+
+- `flux-instance` — `spec.cluster.multitenant: false` is single-tenant-by-design, not an oversight. See [Confluence: FluxCD — Multitenancy (k3s-rabbit)](https://fastnetserv.atlassian.net/wiki/spaces/IT/pages/748322817).
+
+## App-Specific Gotchas
+
+Terse pointers to decisions that used to be inline comments — full rationale now lives in Confluence.
+
+- `fluxcd` (notifications) — the `fluxcd-notifications` Alert deliberately omits `eventMetadata.region`, unlike kubenuc/k8s-vms-daniele. See [Confluence: FluxCD — Notification Region Omission (k3s-rabbit)](https://fastnetserv.atlassian.net/wiki/spaces/IT/pages/748322817).

--- a/clusters/k3s-rabbit/apps/fluxcd/notifications.yaml
+++ b/clusters/k3s-rabbit/apps/fluxcd/notifications.yaml
@@ -18,10 +18,6 @@ metadata:
 spec:
   providerRef:
     name: slack
-  # kubenuc/k8s-vms-daniele's Alerts also set eventMetadata.region (milan /
-  # switzerland) - deliberately omitted here, not dropped by accident: this
-  # cluster's physical region wasn't confirmed against any source in this
-  # repo, and region isn't required by the schema.
   eventMetadata:
     summary: "cluster status"
     env: "production"

--- a/clusters/k3s-rabbit/flux-instance.yaml
+++ b/clusters/k3s-rabbit/flux-instance.yaml
@@ -33,10 +33,6 @@ spec:
     - notification-controller
   cluster:
     type: kubernetes
-    # Single-tenant by design: one team/owner operates this cluster, no
-    # per-namespace Flux RBAC isolation between tenants is required.
-    # Multi-tenant mode would add tenant-scoped ServiceAccounts/RBAC that
-    # this repo's single-operator model doesn't need.
     multitenant: false
     networkPolicy: true
     domain: "cluster.local"


### PR DESCRIPTION
## Summary
- Migrates the two substantive inline YAML comments on `k3s-rabbit` (`flux-instance.yaml` multitenancy rationale, `apps/fluxcd/notifications.yaml` region-omission rationale) to Confluence, following the same pattern PR #1638 established for `kubenuc`/`k8s-vms-daniele` `release.yml` comments.
- Adds new subsections "Multitenancy — k3s-rabbit" and "Notification Region Omission — k3s-rabbit" to the existing shared "FluxCD" Confluence page (no new page — matches the existing one-page-per-topic convention).
- Adds `clusters/k3s-rabbit/CLAUDE.md` (didn't exist before) with a "Cluster Bootstrap" section for `flux-instance.yaml` (not an app) and an "App-Specific Gotchas" section for `fluxcd`/notifications, each linking to its Confluence subsection.
- Second commit strips the now-migrated inline comments; YAML content (`multitenant: false`, `eventMetadata`) is unchanged — verified by diff.

## Test plan
- [x] Confluence page re-fetched after edit to confirm both new subsections landed
- [x] Manual diff confirms only comment lines removed from `flux-instance.yaml` / `notifications.yaml`
- [x] `validate-flux-render.yml` passes (kubeconform + flate render for `k3s-rabbit`, triggers on any PR touching `clusters/k3s-rabbit/**`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)