### PR TITLE
ci(kubenuc,k8s-vms): derive top-level cluster resources instead of hand-enumerating

### DIFF
--- a/.github/workflows/validate-k8s-vms.yml
+++ b/.github/workflows/validate-k8s-vms.yml
@@ -269,6 +269,81 @@ jobs:
 
           kubectl -n flux-system wait kustomization/1p-operator --for=condition=ready --timeout=10m
 
+      - name: Deploy generic top-level cluster resources
+        run: |
+          set -euo pipefail
+
+          # clusters/k8s-vms-daniele/kustomization.yaml's flat resources: list
+          # is the real production entry point. Rather than hand-enumerating
+          # each top-level resource here (which silently stops covering
+          # anything added to that list later — see the
+          # system-upgrade-controller gap this step closes), parse it and
+          # apply everything not already handled by a dedicated step above.
+          # Every current and plausible future entry of this kind carries its
+          # own sourceRef pointing at the flux-system GitRepository this job
+          # already created, so no per-resource CLI-flag reconstruction is
+          # needed.
+          CLUSTER=k8s-vms-daniele
+          KUST_FILE="clusters/${CLUSTER}/kustomization.yaml"
+          SKIP_LIST="apps.yaml charts.yaml cluster-vars.yaml flux-instance.yaml"
+
+          RAW_LINES=$(sed -n '/^resources:/,/^[^ -]/p' "$KUST_FILE" | tr -d '\r' | grep -E '^[[:space:]]*-[[:space:]]' || true)
+          RAW_COUNT=$(printf '%s\n' "$RAW_LINES" | grep -c . || true)
+
+          if [ "$RAW_COUNT" -eq 0 ]; then
+            echo "ERROR: found zero 'resources:' entries in $KUST_FILE — the resources: block format may have changed; update this parser, don't silently skip it"
+            exit 1
+          fi
+
+          RESOURCES=()
+          while IFS= read -r LINE; do
+            [ -z "$LINE" ] && continue
+            if [[ "$LINE" =~ ^[[:space:]]*-[[:space:]]+([A-Za-z0-9._-]+\.ya?ml)[[:space:]]*$ ]]; then
+              RESOURCES+=("${BASH_REMATCH[1]}")
+            else
+              echo "ERROR: could not parse a 'resources:' entry in $KUST_FILE: '$LINE'"
+              echo "This step fails closed on any format it doesn't recognize — update the parser, don't ignore it."
+              exit 1
+            fi
+          done <<< "$RAW_LINES"
+
+          if [ "${#RESOURCES[@]}" -ne "$RAW_COUNT" ]; then
+            echo "ERROR: parsed ${#RESOURCES[@]} resource entries but found $RAW_COUNT raw lines under resources: in $KUST_FILE"
+            exit 1
+          fi
+
+          for RESOURCE in "${RESOURCES[@]}"; do
+            SKIP=false
+            for S in $SKIP_LIST; do
+              [ "$RESOURCE" = "$S" ] && SKIP=true
+            done
+            if [ "$SKIP" = true ]; then
+              echo "Skipping $RESOURCE (handled by a dedicated step, or — for cluster-vars.yaml — not yet supported by this workflow)"
+              continue
+            fi
+
+            RESOURCE_PATH="clusters/${CLUSTER}/${RESOURCE}"
+            if [ ! -f "$RESOURCE_PATH" ]; then
+              echo "ERROR: resources entry '$RESOURCE' in $KUST_FILE does not resolve to exactly one existing file at $RESOURCE_PATH"
+              exit 1
+            fi
+
+            # No interdependency exists among today's top-level extras
+            # (system-upgrade-controller is the only one right now), so
+            # sequential apply-then-wait is safe. If a future top-level
+            # resource depends on another, that must be handled by explicit,
+            # hand-reviewed ordering here — this loop does not resolve
+            # dependency order.
+            echo "=== Applying top-level resource: $RESOURCE ==="
+            OBJ=$(kubectl apply -f "$RESOURCE_PATH" -o name)
+            mapfile -t OBJS <<< "$OBJ"
+            for O in "${OBJS[@]}"; do
+              [ -z "$O" ] && continue
+              echo "Waiting for $O to be ready"
+              kubectl -n flux-system wait "$O" --for=condition=ready --timeout=5m
+            done
+          done
+
       - name: Deploy infra baseline and changed apps
         run: |
           echo "Apps to deploy: $DEPLOY_APPS"

--- a/.github/workflows/validate-kubenuc.yml
+++ b/.github/workflows/validate-kubenuc.yml
@@ -269,18 +269,6 @@ jobs:
 
           kubectl -n flux-system wait kustomization/charts --for=condition=ready --timeout=10m
 
-      - name: Deploy priority classes
-        run: |
-          flux create kustomization priority-classes \
-            --source=flux-system \
-            --path=./clusters/kubenuc/priority-classes \
-            --interval=5m \
-            --prune=true \
-            --timeout=5m \
-            --wait
-
-          kubectl -n flux-system wait kustomization/priority-classes --for=condition=ready --timeout=5m
-
       - name: Create SOPS age secret and cluster-vars
         run: |
           kubectl create secret generic sops-age \
@@ -309,6 +297,80 @@ jobs:
             --wait
 
           kubectl -n flux-system wait kustomization/1p-operator --for=condition=ready --timeout=10m
+
+      - name: Deploy generic top-level cluster resources
+        run: |
+          set -euo pipefail
+
+          # clusters/kubenuc/kustomization.yaml's flat resources: list is the
+          # real production entry point. Rather than hand-enumerating each
+          # top-level resource here (which silently stops covering anything
+          # added to that list later — see the system-upgrade-controller gap
+          # this step closes), parse it and apply everything not already
+          # handled by a dedicated step above. Every current and plausible
+          # future entry of this kind carries its own sourceRef pointing at
+          # the flux-system GitRepository this job already created, so no
+          # per-resource CLI-flag reconstruction is needed.
+          CLUSTER=kubenuc
+          KUST_FILE="clusters/${CLUSTER}/kustomization.yaml"
+          SKIP_LIST="apps.yaml charts.yaml cluster-vars.yaml flux-instance.yaml"
+
+          RAW_LINES=$(sed -n '/^resources:/,/^[^ -]/p' "$KUST_FILE" | tr -d '\r' | grep -E '^[[:space:]]*-[[:space:]]' || true)
+          RAW_COUNT=$(printf '%s\n' "$RAW_LINES" | grep -c . || true)
+
+          if [ "$RAW_COUNT" -eq 0 ]; then
+            echo "ERROR: found zero 'resources:' entries in $KUST_FILE — the resources: block format may have changed; update this parser, don't silently skip it"
+            exit 1
+          fi
+
+          RESOURCES=()
+          while IFS= read -r LINE; do
+            [ -z "$LINE" ] && continue
+            if [[ "$LINE" =~ ^[[:space:]]*-[[:space:]]+([A-Za-z0-9._-]+\.ya?ml)[[:space:]]*$ ]]; then
+              RESOURCES+=("${BASH_REMATCH[1]}")
+            else
+              echo "ERROR: could not parse a 'resources:' entry in $KUST_FILE: '$LINE'"
+              echo "This step fails closed on any format it doesn't recognize — update the parser, don't ignore it."
+              exit 1
+            fi
+          done <<< "$RAW_LINES"
+
+          if [ "${#RESOURCES[@]}" -ne "$RAW_COUNT" ]; then
+            echo "ERROR: parsed ${#RESOURCES[@]} resource entries but found $RAW_COUNT raw lines under resources: in $KUST_FILE"
+            exit 1
+          fi
+
+          for RESOURCE in "${RESOURCES[@]}"; do
+            SKIP=false
+            for S in $SKIP_LIST; do
+              [ "$RESOURCE" = "$S" ] && SKIP=true
+            done
+            if [ "$SKIP" = true ]; then
+              echo "Skipping $RESOURCE (handled by a dedicated step)"
+              continue
+            fi
+
+            RESOURCE_PATH="clusters/${CLUSTER}/${RESOURCE}"
+            if [ ! -f "$RESOURCE_PATH" ]; then
+              echo "ERROR: resources entry '$RESOURCE' in $KUST_FILE does not resolve to exactly one existing file at $RESOURCE_PATH"
+              exit 1
+            fi
+
+            # No interdependency exists among today's top-level extras
+            # (system-upgrade-controller is the only one right now), so
+            # sequential apply-then-wait is safe. If a future top-level
+            # resource depends on another, that must be handled by explicit,
+            # hand-reviewed ordering here — this loop does not resolve
+            # dependency order.
+            echo "=== Applying top-level resource: $RESOURCE ==="
+            OBJ=$(kubectl apply -f "$RESOURCE_PATH" -o name)
+            mapfile -t OBJS <<< "$OBJ"
+            for O in "${OBJS[@]}"; do
+              [ -z "$O" ] && continue
+              echo "Waiting for $O to be ready"
+              kubectl -n flux-system wait "$O" --for=condition=ready --timeout=5m
+            done
+          done
 
       - name: Deploy infra baseline and changed apps
         run: |

--- a/clusters/k8s-vms-daniele/kustomization.yaml
+++ b/clusters/k8s-vms-daniele/kustomization.yaml
@@ -1,5 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+# .github/workflows/validate-k8s-vms.yml parses this resources: list directly
+# (anything not one of apps.yaml/charts.yaml/cluster-vars.yaml/flux-instance.yaml
+# gets kubectl apply + wait'd generically) — a new entry here needs no matching
+# workflow change to get e2e coverage, but must still resolve to a real file.
 resources:
   - apps.yaml
   - charts.yaml

--- a/clusters/kubenuc/kustomization.yaml
+++ b/clusters/kubenuc/kustomization.yaml
@@ -1,5 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+# .github/workflows/validate-kubenuc.yml parses this resources: list directly
+# (anything not one of apps.yaml/charts.yaml/cluster-vars.yaml/flux-instance.yaml
+# gets kubectl apply + wait'd generically) — a new entry here needs no matching
+# workflow change to get e2e coverage, but must still resolve to a real file.
 resources:
   - apps.yaml
   - charts.yaml


### PR DESCRIPTION
## Summary

Both `validate-kubenuc.yml` and `validate-k8s-vms.yml` hand-enumerate what gets deployed into their ephemeral e2e clusters instead of deriving it from each cluster's real `kustomization.yaml`. A new top-level resource silently gets zero e2e coverage until someone notices — this already happened once (the `priority-classes` incident, #1597) and is happening again right now: `system-upgrade-controller.yaml` was added to both `clusters/kubenuc/` and `clusters/k8s-vms-daniele/` in 92005ab7 (#1696) and is referenced nowhere in either workflow.

This is **PR 1 of 2** in a staged rollout — see the followup for the larger per-app fail-closed mechanism (Mechanism 2), which needs a new SOPS age keypair + GitHub Actions secret as a prerequisite before it can be implemented/validated.

- Replace the hardcoded "Deploy priority classes" step with a generic loop, added to **both** workflows, that parses `clusters/$CLUSTER/kustomization.yaml`'s `resources:` list and applies (`kubectl apply -f ... -o name` + `kubectl wait`) anything not already handled by a dedicated step (`apps.yaml`, `charts.yaml`, `cluster-vars.yaml`, `flux-instance.yaml`). This is a class-level fix, not a one-off patch: any future top-level resource is picked up automatically, no workflow change required.
- Parsing is fail-closed: an unparseable `resources:` entry or an unexpectedly empty block hard-fails the step with a clear message instead of silently skipping.
- Verified locally: the parser correctly picks up `priority-classes.yaml` + `system-upgrade-controller.yaml` for kubenuc and `system-upgrade-controller.yaml` for k8s-vms-daniele, correctly skips the four special-cased files, and correctly fails closed against an empty `resources:` block.
- Verified the top-level `system-upgrade-controller` Kustomization is safe to apply generically: it only contains the CRD definition + controller Deployment + Namespace/RBAC, not any actual `Plan` objects (those live only in the separate, still-excluded `apps/system-upgrade-controller/manifests/plan.yml`, which has real `cordon: true` behavior).

## Out of scope / not fixed here

- `k3s-rabbit` and `oc-ampere` have **zero** e2e workflow coverage at all today — a strictly larger version of this same problem, not addressed by this PR.
- The larger per-app "silently skip if the test-mirror app dir doesn't exist" gap (Mechanism 2 in the full plan) — deferred to a followup PR, blocked on a new `SOPS_AGE_KEY_K3S_PROD_TEST` repo secret.

## Test plan

- [x] Both workflow files pass YAML parsing and the `check-yaml` pre-commit hook
- [x] Parser logic tested locally against the real `clusters/kubenuc/kustomization.yaml` and `clusters/k8s-vms-daniele/kustomization.yaml`, plus an empty-`resources:` edge case
- [ ] Confirm on this PR's own CI run that `system-upgrade-controller` reaches Ready on both clusters (the healthCheck depends on a CRD-schema-vs-image-tag convergence noted in `clusters/CLAUDE.md` / #1787 — this is the first real exercise of that path in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)