### PR TITLE
ci(kubenuc): fail-closed per-app e2e loop with documented EXCLUDED_APPS

### DIFF
--- a/.github/workflows/validate-kubenuc.yml
+++ b/.github/workflows/validate-kubenuc.yml
@@ -28,9 +28,18 @@ jobs:
           # Infra baseline — always deployed regardless of what changed.
           INFRA_APPS="openebs haproxy-ingress coredns postgresql s3"
 
-          # Detect changed app directories in kubenuc and kubenuc-test
+          # Detect changed app directories in kubenuc and kubenuc-test.
+          # The grep requires a further '/' after 'apps/' so a changed file
+          # sitting directly in apps/ (e.g. apps/kustomization.yaml itself)
+          # is never mistaken for an app name — cut -d'/' -f1 would
+          # otherwise turn a bare 'apps/kustomization.yaml' diff into the
+          # literal bogus app name 'kustomization.yaml'. This used to be a
+          # silent no-op (the old per-app loop skipped anything with no
+          # matching directory), but the fail-closed loop below now
+          # correctly treats an unrecognized app as an error, so this
+          # exclusion has to be structural, not accidental.
           CHANGED=$(git diff --name-only origin/main...HEAD \
-            | grep -E 'clusters/kubenuc(-test)?/apps/' \
+            | grep -E 'clusters/kubenuc(-test)?/apps/.+/' \
             | sed 's|clusters/kubenuc[^/]*/apps/||' \
             | cut -d'/' -f1 \
             | sort -u \

--- a/.github/workflows/validate-kubenuc.yml
+++ b/.github/workflows/validate-kubenuc.yml
@@ -26,8 +26,6 @@ jobs:
         id: detect
         run: |
           # Infra baseline — always deployed regardless of what changed.
-          # cloudflare is deliberately NOT here — see the ALL_APPS exclusion
-          # below for why.
           INFRA_APPS="openebs haproxy-ingress coredns postgresql s3"
 
           # Detect changed app directories in kubenuc and kubenuc-test
@@ -38,19 +36,15 @@ jobs:
             | sort -u \
             | tr '\n' ' ')
 
-          # cloudflare and fluxcd are excluded even if CHANGED would re-add
-          # them: both sync a real secret via CI's real OP_TOKEN that would
-          # have a live effect if applied in an ephemeral e2e cluster -
-          # cloudflare's OnePasswordItem is a real production tunnel token
-          # (throwaway PR pods would register as live tunnel connectors),
-          # and fluxcd's Provider/Alert uses the real shared slack-url
-          # webhook (a real e2e run generates real Flux events, which would
-          # post real messages into the real #infrastructure channel from a
-          # throwaway PR cluster). kubenuc-test has no apps/fluxcd/ today,
-          # so this is a defensive tripwire, not a fix for a live occurrence
-          # - keep it so that stays true if fluxcd is ever added there.
-          # Never deploy either here regardless of what changed.
-          ALL_APPS=$(echo "$INFRA_APPS $CHANGED" | tr ' ' '\n' | sort -u | grep -vE '^(cloudflare|fluxcd)$' | tr '\n' ' ' | xargs)
+          # cloudflare and fluxcd used to be filtered out right here via a
+          # grep -vE, invisibly, before the fail-closed per-app loop in the
+          # "Deploy infra baseline and changed apps" step could ever see
+          # them or say why. That's now consolidated: both are documented
+          # entries in that step's EXCLUDED_APPS array instead, checked
+          # before every other resolution path — the single place an
+          # excluded app's reason is visible. Let everything through here
+          # unfiltered.
+          ALL_APPS=$(echo "$INFRA_APPS $CHANGED" | tr ' ' '\n' | sort -u | tr '\n' ' ' | xargs)
           echo "Deploying apps: $ALL_APPS"
           echo "deploy_apps=$ALL_APPS" >> "$GITHUB_OUTPUT"
 
@@ -374,24 +368,83 @@ jobs:
 
       - name: Deploy infra baseline and changed apps
         run: |
+          set -euo pipefail
           echo "Apps to deploy: $DEPLOY_APPS"
 
+          # EXCLUDED_APPS: apps that would otherwise resolve via the
+          # kubenuc-test mirror or the real clusters/kubenuc/apps/$APP
+          # fallback below, but reconciling them for real in this ephemeral
+          # e2e cluster has a live external side-effect — not just
+          # referencing a secret, but a controller that actually mutates
+          # DNS, posts to Slack, ships telemetry under the real cluster
+          # name, cordons a node, or auto-issues a production TLS cert.
+          # Checked FIRST in the loop below, before both the mirror and
+          # real-path branches — deliberately, so an excluded app can never
+          # slip through either route (e.g. if a kubenuc-test mirror is
+          # ever added for one of these without first neutralizing its live
+          # risk the way kubenuc-test/apps/sso does via a
+          # reconcile:disabled patch on its live-effect HelmReleases). This
+          # array is also now the single place these exclusions are visible
+          # and documented — it folds in cloudflare/fluxcd, which used to
+          # be filtered out invisibly upstream in detect-changes. Every
+          # entry MUST have a real, verified reason. See clusters/CLAUDE.md
+          # and the project_kubenuc_e2e_bootstrap_gap memory for the full
+          # per-app rationale.
+          declare -A EXCLUDED_APPS=(
+            [cloudflare]="real production tunnel token via CI's real OP_TOKEN — a throwaway PR pod would register as a live tunnel connector"
+            [fluxcd]="real shared slack-url webhook — a real e2e run would post real Flux events into the real #infrastructure Slack channel"
+            [system-upgrade-controller]="real upgrade.cattle.io Plan CRDs with cordon: true against real k3s versions — distinct from the safe top-level system-upgrade-controller.yaml Kustomization already applied generically earlier in this workflow; do not remove this exclusion just because that top-level one is safe"
+            [external-dns]="real Cloudflare API token (Zone:Read + DNS:Edit, policy: upsert-only) — reconciling would mutate real production DNS records"
+            [falco]="real Slack webhook + Loki credentials via falcosidekick-credentials"
+            [grafana-alloy]="real Grafana Cloud/Graylog credentials — would ship real telemetry under the real kubenuc cluster name"
+            [velero]="real Backblaze B2 bucket + credentials, active 24h backup Schedule targets the real production bucket"
+            [cert-manager]="letsencrypt ClusterIssuer is hardcoded to production ACME — its ingress-shim would auto-create real Certificate/Order objects for every already-reconciled Ingress carrying cert-manager.io/cluster-issuer: letsencrypt (nextcloud, s3, jellyfin, harbor, portainer, jenkins, forgejo, sso all carry this annotation unmodified)"
+          )
+
           for APP in $DEPLOY_APPS; do
-            APP_PATH="clusters/kubenuc-test/apps/$APP"
-            if [ -d "$APP_PATH" ]; then
-              echo "=== Creating kustomization for: $APP ==="
+            if [[ -v EXCLUDED_APPS[$APP] ]]; then
+              echo "Skipping $APP — excluded: ${EXCLUDED_APPS[$APP]}"
+              continue
+            fi
+
+            TEST_APP_PATH="clusters/kubenuc-test/apps/$APP"
+            if [ -d "$TEST_APP_PATH" ]; then
+              echo "=== Creating kustomization for: $APP (kubenuc-test mirror) ==="
               flux create kustomization "app-${APP}" \
                 --source=flux-system \
-                --path="./$APP_PATH" \
+                --path="./$TEST_APP_PATH" \
                 --interval=5m \
                 --prune=true
 
               # Inject postBuild.substituteFrom so ${TST_*} variables in patches get resolved
               kubectl patch kustomization "app-${APP}" -n flux-system --type=merge -p \
                 '{"spec":{"postBuild":{"substituteFrom":[{"kind":"Secret","name":"cluster-vars","optional":false}]}}}'
-            else
-              echo "Skipping $APP — not found in kubenuc-test (may be kubenuc-only app)"
+              continue
             fi
+
+            REAL_DEPLOY_PATH=""
+            for CANDIDATE in "clusters/kubenuc/apps/$APP/deploy.yaml" "clusters/kubenuc/apps/$APP/deploy.yml"; do
+              if [ -f "$CANDIDATE" ]; then
+                REAL_DEPLOY_PATH="$CANDIDATE"
+                break
+              fi
+            done
+
+            if [ -n "$REAL_DEPLOY_PATH" ]; then
+              # No dependsOn beyond `charts` (already Ready by this point in
+              # the workflow) exists among today's real-path fallback apps,
+              # so applying them here with no extra ordering is safe. A
+              # future app that dependsOn something else must be checked by
+              # hand before relying on this fallback for it — this branch
+              # does not resolve dependency order.
+              echo "=== Applying $APP's real production Kustomization: $REAL_DEPLOY_PATH ==="
+              kubectl apply -f "$REAL_DEPLOY_PATH"
+              continue
+            fi
+
+            echo "ERROR: '$APP' is in DEPLOY_APPS but resolves to none of: a kubenuc-test mirror ($TEST_APP_PATH), an EXCLUDED_APPS entry, or a real clusters/kubenuc/apps/$APP/deploy.y*ml"
+            echo "Fix this by adding a kubenuc-test mirror, adding a documented EXCLUDED_APPS entry above, or checking for a typo in the app name."
+            exit 1
           done
 
           # Wait for all created kustomizations to be ready

--- a/clusters/kubenuc/apps/kustomization.yaml
+++ b/clusters/kubenuc/apps/kustomization.yaml
@@ -1,5 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+# .github/workflows/validate-kubenuc.yml's e2e job now falls back to
+# applying an app's own deploy.y*ml verbatim (same paths as this list) when
+# no kubenuc-test mirror exists for it — unless the app is in that
+# workflow's EXCLUDED_APPS array (real live external side-effect: DNS
+# mutation, Slack webhook, production ACME, etc). A new app added here with
+# neither a kubenuc-test mirror nor an EXCLUDED_APPS entry gets e2e coverage
+# automatically via that fallback; if it has a real live side-effect it
+# needs a documented EXCLUDED_APPS entry or CI will actually exercise it.
 resources:
   - 1password/deploy.yaml
   - 1password/namespace.yaml


### PR DESCRIPTION
## Summary

This is **PR 2 of 2** in the staged rollout that started with #1790 (Mechanism 1, top-level resources). This is the kubenuc-only half of Mechanism 2 (the per-app side) — the k8s-vms-daniele half is blocked on a new `SOPS_AGE_KEY_K3S_PROD_TEST` GitHub Actions secret (this workflow's counterpart already has `SOPS_AGE_KEY_KUBENUC_TEST`, so kubenuc is unblocked today).

`validate-kubenuc.yml`'s per-app loop silently `echo`s and skips any app in `$DEPLOY_APPS` with no matching directory under `clusters/kubenuc-test/apps/`. Diffing `clusters/kubenuc/apps/` vs `clusters/kubenuc-test/apps/` shows **14 real kubenuc apps** get zero e2e coverage today, with no visible indication in the CI log that anything meaningful was skipped versus intentionally excluded — `coredns` (part of the always-deployed `INFRA_APPS` baseline!) has been silently skipped on *every single run* of this workflow since `kubenuc-test/apps/coredns` doesn't exist.

Separately, `cloudflare`/`fluxcd` were excluded via an invisible `grep -vE` filter upstream in `detect-changes` — a second, differently-visible exclusion mechanism for the same class of problem, with its own reasoning that the per-app loop could never see.

### Fix

Replace both with a single three-way, fail-closed resolution per app in the "Deploy infra baseline and changed apps" step:

1. **`kubenuc-test` mirror exists** → unchanged, exactly as today.
2. **Else, a documented `EXCLUDED_APPS` entry exists** → skip with the reason printed in the log. Checked *before* the mirror-exists check above and before the fallback below — deliberately, so an excluded app can never slip through either route even if a future `kubenuc-test` mirror is added for one of them without first neutralizing its live risk (the precedent for that pattern is `kubenuc-test/apps/sso`, which already does this via a `reconcile: disabled` patch on the live-effect HelmReleases).
3. **Else, the app's own real `clusters/kubenuc/apps/$APP/deploy.y*ml` exists** → applied verbatim via `kubectl apply -f`. Safe because every candidate app's Kustomization already declares `sourceRef: {kind: GitRepository, name: flux-system}` pointing at the same GitRepository this workflow creates for the PR branch — same reasoning validated in #1790's Mechanism 1.
4. **Else** → hard `exit 1` with a message naming all three options. This is the actual fix: a typo'd or newly-added-but-unclassified app now fails the job loudly instead of vanishing silently.

### EXCLUDED_APPS (6 apps, each with a verified, documented reason)

| App | Reason |
|---|---|
| `cloudflare` | real production tunnel token via CI's real `OP_TOKEN` |
| `fluxcd` | real shared Slack webhook — would post real Flux events to the real channel |
| `system-upgrade-controller` (app-level) | real `Plan` CRDs with `cordon: true` — distinct from the safe top-level Kustomization of the same base name already applied generically by #1790 |
| `external-dns` | real Cloudflare API token, `policy: upsert-only` — would mutate real production DNS |
| `falco` | real Slack webhook + Loki credentials |
| `grafana-alloy` | real Grafana Cloud credentials — would ship real telemetry under the real cluster name |
| `velero` | real Backblaze B2 bucket + credentials, active backup Schedule |
| `cert-manager` | `letsencrypt` ClusterIssuer hardcoded to production ACME — its ingress-shim would auto-issue real Certificates for every already-reconciled Ingress carrying the `cluster-issuer: letsencrypt` annotation |

(8 rows, not 6 — table includes both `system-upgrade-controller` and `cert-manager` alongside the original 6-app design estimate.)

### Newly-covered apps (8, via the real-path fallback)

`coredns`, `flux-operator`, `mcp-viewer`, `net-mon`, `node-problem-detector`, `nut`, `film-tv-exporter`, `reloader` — verified each has no `dependsOn` beyond `charts` (already Ready by this point in the workflow) and no secret/credential references.

### Known residual risk — not resolvable by static read

`coredns`'s real path applies an HPA (`minReplicas: 2`) and a PDB (`minAvailable: 1`) against k3s's own single-replica CoreDNS Deployment on this workflow's 1-node cluster — the actual CoreDNS Deployment/affinity spec is baked into the k3s binary, not tracked in this repo, so whether the second replica schedules cleanly can only be observed on a live run. If this wedges the later `rollout restart deployment coredns` step, the fix is a one-line addition of `coredns` to `EXCLUDED_APPS` (with `${INGRESS_IP}` DNS test coverage otherwise unaffected).

## Verification done pre-push

- Bash syntax-checked the extracted step script
- Dry-run of the full resolution logic against real repo paths (stubbed `flux`/`kubectl`) — every app in `DEPLOY_APPS` resolves to the expected branch, all 6 excluded apps correctly skip *despite* having a real `deploy.yaml` (confirming exclusion-first ordering works)
- Confirmed the fail-closed path's real exit code is `1` (not just visually similar output) and that it halts the loop before later apps run
- Verified namespace/`dependsOn` shape for all 8 newly-covered apps against the actual manifests

## Test plan

- [ ] Confirm this PR's own `kubenuc-full-cluster-e2e` run: all 8 newly-covered apps reach `Ready`, the 6 `EXCLUDED_APPS` entries print their skip reason and are not deployed, `coredns`'s HPA/PDB doesn't wedge the CoreDNS rollout-restart step

🤖 Generated with [Claude Code](https://claude.com/claude-code)