### PR TITLE
ci(k3s-prod-test): add SOPS cluster-vars for k8s-vms-daniele e2e

### DIFF
--- a/.github/workflows/validate-k8s-vms.yml
+++ b/.github/workflows/validate-k8s-vms.yml
@@ -257,6 +257,23 @@ jobs:
 
           kubectl -n flux-system wait kustomization/charts --for=condition=ready --timeout=10m
 
+      - name: Create SOPS age secret and cluster-vars
+        run: |
+          kubectl create secret generic sops-age \
+            --namespace=flux-system \
+            --from-literal=age.agekey='${{ secrets.SOPS_AGE_KEY_K3S_PROD_TEST }}'
+
+          flux create kustomization cluster-vars \
+            --source=flux-system \
+            --path=./clusters/k3s-prod-test/vars \
+            --interval=1h \
+            --prune=true \
+            --decryption-provider=sops \
+            --decryption-secret=sops-age \
+            --wait --timeout=5m
+
+          kubectl -n flux-system wait kustomization/cluster-vars --for=condition=ready --timeout=5m
+
       - name: Deploy 1password operator
         run: |
           flux create kustomization 1p-operator \

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -19,6 +19,10 @@ creation_rules:
   - path_regex: clusters/kubenuc-test/vars/.*\.sops\.yaml$
     age: age1qwhpwjgw3c7trgrtjv7k309suma9l6qu8yrh4at80clrymrczvss8xq69u
 
+  # k3s-prod-test cluster — replace with actual age public key after `age-keygen`
+  - path_regex: clusters/k3s-prod-test/vars/.*\.sops\.yaml$
+    age: age1we4kjkxtqxd6ne9tx458tw2jsswwfzll8rs6mjsa4g40zn8nj97qk9mf46
+
   # kubenuc 1password bootstrap secret
   - path_regex: clusters/kubenuc/apps/1password/secrets/.*\.sops\.yaml$
     age: age182k0gk669fkgkq697d86huftt94cfg7s9hq56jaj9qffwu9k648qyyx5dd

--- a/clusters/k3s-prod-test/vars/cluster-vars.sops.yaml
+++ b/clusters/k3s-prod-test/vars/cluster-vars.sops.yaml
@@ -1,0 +1,37 @@
+#ENC[AES256_GCM,data:16zllV1MZsDceprJhC5HNGPmA+I0WToD6yh8TE4HLwrJi72LPUFARhUda4mQSYaLfJNfRs1nTS8F,iv:TsCyu+dVo4cadF9tHRqwnkD++LODeNBxUzPXjNg5Eqc=,tag:uCejU1CSIA2mkDfe3vqINg==,type:comment]
+#ENC[AES256_GCM,data:j675Xh+5jtsIyY+Nslpt0LLS46hc9rwYB2prp6Fp8dVyZcJtLoLqFVKOa/OtOfebvMR78UbXQCH6K9H0gbj65TFPD4glfvnVRPnpQKRj+dmjxw==,iv:hXdoi1qbVxtJBy1+XI4e0JnI+lpjXPAEmcVRoVRiuBU=,tag:GEe9PCQckZ+QHIg5AVA7Kg==,type:comment]
+#
+#ENC[AES256_GCM,data:ClHpwcqLR9MGiX9hKafKd/5gzjoR27Fu5G4fL75NDEzgudxvQXOnMQ==,iv:cu0zag9akpv/cX/Ej74x9+f5BNTYlmPNs9egRTrZPEA=,tag:dCIei78+Ln/4hDGFnK/Hsg==,type:comment]
+#ENC[AES256_GCM,data:jZsbV/oiM2Md1qPtMhpPyZy3Snc8rJ/hGc9g0AQxOGdblNs0b5r3,iv:JFHKX1as0Yy3sRjsv89MJkJPAFtbbGTGWVns13yd0j4=,tag:sP5iTABk3S6zffEsiHxG3w==,type:comment]
+#ENC[AES256_GCM,data:t6Tkp3Ek+Q+qskKR2EmqKvuS8xTrtTN0oVwgPMQWj8to1n/a1XGERM5HzQ==,iv:OLOCYUFHU6jDCOgoFUA1M7GhVP4IdHQIhGWXMRLgXck=,tag:bazQ+zqc+NT88Gq/KH287w==,type:comment]
+#ENC[AES256_GCM,data:U66wB/UmGVQq4VwBh1T+kHOd5yKd8BN50ppxxfOd,iv:UEcHBYdNaQ1eMloCUGqECLQtwLLu5mINmyKT3iVhPBc=,tag:yZ/RhBnQ8n3gcUbWDO+qsA==,type:comment]
+#ENC[AES256_GCM,data:RFtn0S4V3a70gFDzMu5H/BXofs5JlmuhTLXZoNVNZeG4zMILu1T+VxyV0Wfh7VoaBIYEEw==,iv:8DVMtG6nZKEswXoheF2GTm1ku7CH7mXtJypDgRo/nv8=,tag:sbDlDG/1Y52n92wI4oTXPg==,type:comment]
+#ENC[AES256_GCM,data:cQdSzCmzFlA2K5NTiFSnA5jGxIi91BdexZVgKgDpd0Zs63/d928=,iv:o72u+WXjn+gnRxCxDpYP2mafGjmRTRnja46mCWfShOQ=,tag:5JGziwRIUM1Ir8uRwydqag==,type:comment]
+#ENC[AES256_GCM,data:Yw5wDQVK7Vf7x9Q4pcuFNRl1DXOKO635TRJuEAZdzpPTcGJq/eefl5nWfZ3Np1cr5/cTvNZSMxcko4TyUyjjvN6aPg==,iv:rw5vPw1q/uMb3ctAEacduy8ezlEgm+k1vfkejerh+6w=,tag:VNBUre2EUC7EJdgbNzOlgw==,type:comment]
+#ENC[AES256_GCM,data:PaOlv1+nCiD2KmdDtTnDZnRe4bSgR1RfzvdKsAedX9HCUCoi5U6AcOFOHKBdu5TMSP7Vz6WTf6twTA==,iv:jUqsZ4NUeAArwThiOWUxdz1GGf2G0vzqfDvlh4u6asQ=,tag:IpkLtD6gOajdvsfdggZBWg==,type:comment]
+apiVersion: ENC[AES256_GCM,data:UVk=,iv:BPKOq2yJPmYdjZeYAuPvCOiQx5spXOnof5S4MMCN9Aw=,tag:REk6Ok79HqYuZ0xMDn1UbA==,type:str]
+kind: ENC[AES256_GCM,data:ORn7z7kH,iv:zEWrYlI1aKTsmPPhMpgDMUYIp7lPvYbmnPFs5cpKhew=,tag:qRgZZkvVRsD+6H1YiUrEmQ==,type:str]
+metadata:
+    name: ENC[AES256_GCM,data:+wc5wuoCgpAE9A1s,iv:7xr+k9ecDRWHRAbwYEebSTugKTEcbMYzcxMum7jWS3A=,tag:IX0a9vlc9uEeoFnMvzOjbQ==,type:str]
+    namespace: ENC[AES256_GCM,data:sYYcTjQY2AMwaZw=,iv:9AJa7j1RUikn9H7fwXnCmB8sP1QQDdeMscV+GhKWGuc=,tag:YWe3Mzzsw9wrCfN5/Iyoqg==,type:str]
+stringData:
+    TST_AWX_HOST: ENC[AES256_GCM,data:FI+qjwwFaKFJ2qIUMWqvKZPvkjuJDYE=,iv:cVO4Im4DjzrinCHcsfZltfTIVSIoKepEkTHRzWn3F/o=,tag:nllb6WOK8g/OjDtSmGc0pg==,type:str]
+    TST_SEMAPHORE_HOST: ENC[AES256_GCM,data:6jeVwu/AUMvOMWCHXCKPf6ycC+pZM4A=,iv:yvK1r9uA0o/blvv9vt0W6CZU5e2mWfNrFHLm+66pT9A=,tag:A8oL0pUDrJLEUX7guYBgkA==,type:str]
+    TST_TELEPORT_HOST: ENC[AES256_GCM,data:CjYgoNYfrls3meuGMpXOhEcrOSivZgY=,iv:39JvfS6h5dxXLrBewZRj9rGXc3KDiuvlIxysBvAmsPY=,tag:nS8XScz99Za+dUCo1Wo5ug==,type:str]
+    TST_ACME_EMAIL: ENC[AES256_GCM,data:BMslyCiSOpmMCaQfyIeDWnaCW+cDORhKhBo2vCTjMFcNDEpKtVq0,iv:GSD2VS+hDS0sd91v9gbqfV1OuGxSZrqWb3alde1wrsc=,tag:bnQdr/F6Jhdt1HD6qlw8gA==,type:str]
+    TST_CLOUDFLARE_TUNNEL_TARGET: ENC[AES256_GCM,data:7NGFVae84pyyW5/FWE+VYBEcW0sbMDU=,iv:E3+nSlfe9MjhAw7d3QaqTBvTP6OMjSLh1j7FmZjYdKM=,tag:mcdWELfl1Z7dOBc2yLGmdA==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBCckJFd3ZBWWU3bS90OVpN
+            OVJvbitHMkNFWDd0SDZweFpVQ2x0SFBRcGpBClpmNjRpY0JvbHR2TlVJVnVRUjFi
+            QTZ4Yy94TTFqV0xtVjVQTWViTVZkTWcKLS0tIGkwSGd6SSttck0vTWZPN2N3OC9S
+            dkQ4cG1mSHB6ZmoycWl0TkNDL0kwTUUKQIfr7HaEE+9Wq66ziHT7XgZBApsjE7w7
+            qVN5wnZDY52mP6cEXEbi+L+HzNcuQeCvV6QlWYALPRLMjx3DS++kzg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1we4kjkxtqxd6ne9tx458tw2jsswwfzll8rs6mjsa4g40zn8nj97qk9mf46
+    lastmodified: "2026-08-06T10:07:02Z"
+    mac: ENC[AES256_GCM,data:Z8YP9J2E78V94n0igdaaC9LYb6poPV/pXMpLjK71ewjvMGgf9DIXic/sXxck55MXd4tvE1wNnwhntsmqUsQGy0Mc2H2xk7VRYwjCj3nJ2Q6xAID6qw6eI6c1ebMZcOvZS/nz5JUXeCABJ4C+EZBmjfqltpAI16tqjoBoyrUa/hU=,iv:dY4X8QCtTb8OGVPUh3BqjRFYdkfN4pZrc+AWoIXzvD8=,tag:lJAg8sOIwUUUkxBTONScLg==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.13.3

--- a/clusters/k8s-vms-daniele/cluster-vars.yaml
+++ b/clusters/k8s-vms-daniele/cluster-vars.yaml
@@ -1,4 +1,8 @@
 ---
+# .github/workflows/validate-k8s-vms.yml's ephemeral e2e cluster has its own
+# equivalent Kustomization (also named cluster-vars) pointed at
+# clusters/k3s-prod-test/vars instead of this path — same shape, TST_*
+# placeholder values, mirroring the kubenuc / kubenuc-test convention.
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:


### PR DESCRIPTION
## Summary

Follow-up to #1791 (kubenuc's fail-closed per-app e2e loop) — this is the first of two PRs needed to bring the same mechanism to `k8s-vms-daniele`.

`validate-k8s-vms.yml` creates no `cluster-vars` Kustomization/Secret at all today, yet `cloudnative-pg-operator` (`dependsOn: cluster-vars`) and other apps reference it. Without it, a dependent app hangs to the 30-minute catch-all timeout instead of failing fast — this blocks landing the k8s-vms-daniele per-app fail-closed loop.

### Changes

- `.sops.yaml`: new `creation_rules` entry for `clusters/k3s-prod-test/vars/.*\.sops\.yaml$`, keyed to a newly-generated age public key
- New `clusters/k3s-prod-test/vars/cluster-vars.sops.yaml`: SOPS-encrypted, `TST_*`-prefixed, obviously-synthetic placeholder values (e.g. `*.invalid` hosts) — mirrors `kubenuc-test`'s existing convention. Verified fully encrypted (`sops filestatus` → `encrypted: true`), recipient key matches exactly, zero plaintext leaked.
- `validate-k8s-vms.yml`: new "Create SOPS age secret and cluster-vars" step, identical in shape to `validate-kubenuc.yml`'s existing step — creates the `sops-age` Secret from `secrets.SOPS_AGE_KEY_K3S_PROD_TEST` (already added as a GitHub Actions repo secret, out of band) and a `cluster-vars` Kustomization pointed at the new vars path.
- `clusters/k8s-vms-daniele/cluster-vars.yaml`: comment-only, documents the CI-side equivalent.

### Scope

Deliberately scoped to `cluster-vars` only — no per-app loop changes here. Per the original design, `cluster-vars` needs to be independently verified `Ready` on a real run *before* any Tier-1 app that depends on it (`cloudnative-pg-operator`) gets included in the k8s-vms-daniele per-app loop. That loop is a separate follow-up PR.

## Test plan

- [ ] Confirm this PR's own `k8s-vms-e2e` run: `cluster-vars` Kustomization reaches `Ready`

🤖 Generated with [Claude Code](https://claude.com/claude-code)