### PR TITLE
ci(k8s-vms): fail-closed per-app e2e loop with documented EXCLUDED_APPS

### DIFF
--- a/.github/workflows/validate-k8s-vms.yml
+++ b/.github/workflows/validate-k8s-vms.yml
@@ -26,34 +26,34 @@ jobs:
         id: detect
         run: |
           # Infra baseline for k3s-prod-test — always deployed.
-          # cloudflare is deliberately NOT here — see the ALL_APPS exclusion
-          # below for why.
           INFRA_APPS=""
 
-          # Detect changed app directories in k8s-vms-daniele
+          # Detect changed app directories in k8s-vms-daniele.
+          # The grep requires a further '/' after 'apps/' so a changed file
+          # sitting directly in apps/ (e.g. apps/kustomization.yaml itself)
+          # is never mistaken for an app name — cut -d'/' -f1 would
+          # otherwise turn a bare 'apps/kustomization.yaml' diff into the
+          # literal bogus app name 'kustomization.yaml'. The fail-closed
+          # per-app loop below correctly treats an unrecognized app as an
+          # error, so this exclusion has to be structural, not accidental
+          # (see clusters/kubenuc's validate-kubenuc.yml for where this bit
+          # first, on PR #1791).
           CHANGED=$(git diff --name-only origin/main...HEAD \
-            | grep -E 'clusters/k8s-vms-daniele/apps/' \
+            | grep -E 'clusters/k8s-vms-daniele/apps/.+/' \
             | sed 's|clusters/k8s-vms-daniele/apps/||' \
             | cut -d'/' -f1 \
             | sort -u \
             | tr '\n' ' ')
 
-          # cloudflare and fluxcd are excluded even if CHANGED would re-add
-          # them: both sync a real secret via CI's real OP_TOKEN that would
-          # have a live effect if applied in an ephemeral e2e cluster -
-          # cloudflare's OnePasswordItem is a real production tunnel token
-          # (throwaway PR pods would register as live tunnel connectors),
-          # and fluxcd's Provider/Alert uses the real shared slack-url
-          # webhook. This one is a live fix, not just a tripwire:
-          # clusters/k3s-prod-test/apps/fluxcd/deploy.yaml already exists
-          # (it cross-references clusters/k8s-vms-daniele/apps/fluxcd), so
-          # today any PR touching k8s-vms-daniele's real apps/fluxcd/ already
-          # detects "fluxcd" as changed and would deploy the real Slack
-          # Provider/Alert into this ephemeral cluster - a real e2e run
-          # generates real Flux events, which would post real messages into
-          # the real #infrastructure channel from a throwaway PR cluster.
-          # Never deploy either here regardless of what changed.
-          ALL_APPS=$(echo "$INFRA_APPS $CHANGED" | tr ' ' '\n' | sort -u | grep -vE '^(cloudflare|fluxcd)$' | tr '\n' ' ' | xargs)
+          # cloudflare and fluxcd used to be filtered out right here via a
+          # grep -vE, invisibly, before the fail-closed per-app loop in the
+          # "Deploy infra baseline and changed apps" step could ever see
+          # them or say why. That's now consolidated: both are documented
+          # entries in that step's EXCLUDED_APPS array instead, checked
+          # before every other resolution path — the single place an
+          # excluded app's reason is visible. Let everything through here
+          # unfiltered.
+          ALL_APPS=$(echo "$INFRA_APPS $CHANGED" | tr ' ' '\n' | sort -u | tr '\n' ' ' | xargs)
           echo "Deploying apps: $ALL_APPS"
           echo "deploy_apps=$ALL_APPS" >> "$GITHUB_OUTPUT"
 
@@ -363,20 +363,103 @@ jobs:
 
       - name: Deploy infra baseline and changed apps
         run: |
+          set -euo pipefail
           echo "Apps to deploy: $DEPLOY_APPS"
 
+          # EXCLUDED_APPS: apps that would otherwise resolve via the
+          # k3s-prod-test mirror or the real clusters/k8s-vms-daniele/apps/$APP
+          # fallback below, but reconciling them for real in this ephemeral
+          # e2e cluster has a live external side-effect — not just
+          # referencing a secret, but a controller that actually mutates
+          # DNS, posts to Slack, ships telemetry under the real cluster
+          # name, cordons a node, auto-issues a production TLS cert, or
+          # decrypts real Ansible secrets against real Teleport infra.
+          # Checked FIRST in the loop below, before both the mirror and
+          # real-path branches — deliberately, so an excluded app can never
+          # slip through either route. This array is also now the single
+          # place these exclusions are visible and documented — it folds in
+          # cloudflare/fluxcd, which used to be filtered out invisibly
+          # upstream in detect-changes. Every entry MUST have a real,
+          # verified reason. See clusters/CLAUDE.md and the
+          # project_k8s_vms_e2e_ci_gap memory for the full per-app
+          # rationale. Same shape as kubenuc's EXCLUDED_APPS (PR #1791).
+          declare -A EXCLUDED_APPS=(
+            [cloudflare]="real production tunnel token via CI's real OP_TOKEN — a throwaway PR pod would register as a live tunnel connector"
+            [fluxcd]="real shared slack-url webhook — a real e2e run would post real Flux events into the real #infrastructure Slack channel"
+            [system-upgrade-controller]="real upgrade.cattle.io Plan CRDs with cordon: true against real k3s versions — distinct from the safe top-level system-upgrade-controller.yaml Kustomization already applied generically earlier in this workflow; do not remove this exclusion just because that top-level one is safe"
+            [external-dns]="real Cloudflare API token, policy: upsert-only, real txtOwnerId — reconciling would mutate real production DNS records"
+            [falco]="real Slack webhook credentials via falcosidekick-credentials"
+            [grafana-alloy]="real Grafana Cloud credentials — would ship real telemetry under the real k8s-vms-daniele cluster name"
+            [awx]="real admin/secret-key credentials fetched via the awx-secrets child Kustomization that awx's own deploy.yaml applies (the backup CronJob's separate B2 credentials are NOT pulled in by this path, but that's not why this is excluded)"
+            [semaphore]="its own manifest documents that the SOPS age key it imports can decrypt every ansible/*/host_vars/*.sops.yaml file, plus a live 1Password Connect token used by Ansible playbooks against real Teleport infra"
+            [cert-manager]="letsencrypt ClusterIssuer is hardcoded to production ACME — its ingress-shim would auto-create real Certificate/Order objects for any already-reconciled Ingress carrying cert-manager.io/cluster-issuer: letsencrypt (fluxcd and semaphore both carry this annotation today; both are separately excluded, but a future app that isn't could combine with an included cert-manager)"
+          )
+
+          # semaphore-db has no k3s-prod-test mirror (always resolves via the
+          # real-path fallback below) and its own deploy.yaml only
+          # dependsOn: cloudnative-pg-operator — but the Cluster CR it
+          # creates lives in namespace `semaphore`, which is a *separate*
+          # root apps/kustomization.yaml entry (semaphore/namespace.yml)
+          # that semaphore-db's own path never pulls in. Applying only
+          # semaphore-db on a clean cluster fails: no namespace, and
+          # cloudnative-pg-operator may not even be in this run's
+          # DEPLOY_APPS. This is a small, explicit, hand-maintained static
+          # rule for this one known chain — not a general dependency
+          # resolution engine. If semaphore-db is ever added to a
+          # kubenuc-test-style mirror, this block becomes unnecessary and
+          # should be removed rather than left as silent dead code.
+          if [[ " $DEPLOY_APPS " == *" semaphore-db "* ]]; then
+            if [[ -v EXCLUDED_APPS[cloudnative-pg-operator] ]]; then
+              echo "ERROR: semaphore-db needs cloudnative-pg-operator, but cloudnative-pg-operator is now in EXCLUDED_APPS — this hand-maintained prereq rule is stale, fix it before proceeding"
+              exit 1
+            fi
+            echo "=== semaphore-db present — ensuring its prerequisites exist first ==="
+            kubectl apply -f clusters/k8s-vms-daniele/apps/semaphore/namespace.yml
+            kubectl apply -f clusters/k8s-vms-daniele/apps/cloudnative-pg-operator/deploy.yaml
+            kubectl -n flux-system wait kustomization/cloudnative-pg-operator --for=condition=ready --timeout=15m
+          fi
+
           for APP in $DEPLOY_APPS; do
-            APP_PATH="clusters/k3s-prod-test/apps/$APP"
-            if [ -d "$APP_PATH" ]; then
-              echo "=== Creating kustomization for: $APP ==="
+            if [[ -v EXCLUDED_APPS[$APP] ]]; then
+              echo "Skipping $APP — excluded: ${EXCLUDED_APPS[$APP]}"
+              continue
+            fi
+
+            TEST_APP_PATH="clusters/k3s-prod-test/apps/$APP"
+            if [ -d "$TEST_APP_PATH" ]; then
+              echo "=== Creating kustomization for: $APP (k3s-prod-test mirror) ==="
               flux create kustomization "app-$APP" \
                 --source=flux-system \
-                --path="./$APP_PATH" \
+                --path="./$TEST_APP_PATH" \
                 --interval=5m \
                 --prune=true
-            else
-              echo "Skipping $APP — not found in k3s-prod-test"
+              continue
             fi
+
+            REAL_DEPLOY_PATH=""
+            for CANDIDATE in "clusters/k8s-vms-daniele/apps/$APP/deploy.yaml" "clusters/k8s-vms-daniele/apps/$APP/deploy.yml"; do
+              if [ -f "$CANDIDATE" ]; then
+                REAL_DEPLOY_PATH="$CANDIDATE"
+                break
+              fi
+            done
+
+            if [ -n "$REAL_DEPLOY_PATH" ]; then
+              # No dependsOn beyond `charts`/`cluster-vars` (both already
+              # Ready by this point in the workflow) exists among today's
+              # real-path fallback apps other than semaphore-db, which is
+              # handled above before this loop starts. A future app that
+              # dependsOn something else must be checked by hand before
+              # relying on this fallback for it — this branch does not
+              # resolve dependency order.
+              echo "=== Applying $APP's real production Kustomization: $REAL_DEPLOY_PATH ==="
+              kubectl apply -f "$REAL_DEPLOY_PATH"
+              continue
+            fi
+
+            echo "ERROR: '$APP' is in DEPLOY_APPS but resolves to none of: a k3s-prod-test mirror ($TEST_APP_PATH), an EXCLUDED_APPS entry, or a real clusters/k8s-vms-daniele/apps/$APP/deploy.y*ml"
+            echo "Fix this by adding a k3s-prod-test mirror, adding a documented EXCLUDED_APPS entry above, or checking for a typo in the app name."
+            exit 1
           done
 
           # Wait for all created kustomizations to be ready

--- a/clusters/k8s-vms-daniele/apps/kustomization.yaml
+++ b/clusters/k8s-vms-daniele/apps/kustomization.yaml
@@ -1,5 +1,15 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+# .github/workflows/validate-k8s-vms.yml's e2e job now falls back to
+# applying an app's own deploy.y*ml verbatim (same paths as this list) when
+# no k3s-prod-test mirror exists for it — unless the app is in that
+# workflow's EXCLUDED_APPS array (real live external side-effect: DNS
+# mutation, Slack webhook, production ACME, real Ansible secret decryption,
+# etc). A new app added here with neither a k3s-prod-test mirror nor an
+# EXCLUDED_APPS entry gets e2e coverage automatically via that fallback; if
+# it has a real live side-effect it needs a documented EXCLUDED_APPS entry
+# or CI will actually exercise it. semaphore-db is a special case — see the
+# workflow's hand-maintained prereq block for why.
 resources:
   - 1password/namespace.yaml
   - 1password/deploy.yml

--- a/clusters/k8s-vms-daniele/apps/semaphore-db/manifests/cluster.yml
+++ b/clusters/k8s-vms-daniele/apps/semaphore-db/manifests/cluster.yml
@@ -10,6 +10,11 @@ spec:
   # image/version rather than guessing a pin here.
   storage:
     size: 5Gi
+    # local-path is k3s's built-in default provisioner (Rancher's
+    # local-path-provisioner) — present on both production k8s-vms-daniele
+    # and validate-k8s-vms.yml's ephemeral e2e cluster (that workflow's
+    # "Setup k3s" step only disables traefik, not local-storage), so this
+    # Cluster provisions the same way in both places.
     storageClass: local-path
   # Single instance, no standby to fail over to - a minAvailable:1 PDB would
   # permanently block node drains (same reasoning as this repo's kubenuc


### PR DESCRIPTION
## Summary

This is the k8s-vms-daniele half of Mechanism 2, mirroring kubenuc's fail-closed per-app loop (#1791), unblocked now that `cluster-vars` exists for `k3s-prod-test` (#1792).

`validate-k8s-vms.yml`'s per-app loop silently `echo`s and skips any app in `$DEPLOY_APPS` with no matching directory under `clusters/k3s-prod-test/apps/` — 12 real k8s-vms-daniele apps get zero e2e coverage today.

### Fix

Same three-way, fail-closed resolution as kubenuc's PR #1791:

1. **`k3s-prod-test` mirror exists** → unchanged.
2. **Else, a documented `EXCLUDED_APPS` entry exists** → skip with reason printed. Checked *before* the mirror check and the fallback below.
3. **Else, the app's own real `clusters/k8s-vms-daniele/apps/$APP/deploy.y*ml` exists** → applied verbatim.
4. **Else** → hard `exit 1`.

Also proactively fixes the same `CHANGED`-parsing bug found on kubenuc's first real run (#1791): the grep now requires a further `/` after `apps/` so a bare `apps/kustomization.yaml` diff (this PR's own diff, in fact) is never mistaken for a bogus app name.

### EXCLUDED_APPS (9 apps, each with a verified reason)

| App | Reason |
|---|---|
| `cloudflare` | real production tunnel token via CI's real `OP_TOKEN` |
| `fluxcd` | real shared Slack webhook |
| `system-upgrade-controller` (app-level) | real `Plan` CRDs with `cordon: true` |
| `external-dns` | real Cloudflare API token, `policy: upsert-only`, real `txtOwnerId` |
| `falco` | real Slack webhook credentials |
| `grafana-alloy` | real Grafana Cloud credentials |
| `awx` | real admin/secret-key credentials via the `awx-secrets` child Kustomization its own `deploy.yaml` applies (the backup CronJob's B2 credentials are a separate root entry, not pulled in by this path — but that's not why it's excluded) |
| `semaphore` | its own manifest documents that its SOPS age key can decrypt every `ansible/*/host_vars/*.sops.yaml` file, plus a live 1Password Connect token used against real Teleport infra |
| `cert-manager` | `letsencrypt` ClusterIssuer hardcoded to production ACME — same risk class as kubenuc's exclusion; `fluxcd` and `semaphore` both carry the `cluster-issuer: letsencrypt` annotation today (both separately excluded, but a future un-excluded app could combine with an included cert-manager) |

### Newly-covered apps (4, via the real-path fallback)

`flux-operator`, `mcp-viewer`, `cloudnative-pg-operator`, `reloader` — verified no `dependsOn` beyond `charts`/`cluster-vars` (both Ready by this point) and no secret/credential references.

### `semaphore-db` — hand-maintained prereq rule, not general dependency resolution

`semaphore-db` has no test mirror; its `deploy.yaml` only `dependsOn: cloudnative-pg-operator`, but the `Cluster` CR it creates lives in namespace `semaphore` — a *separate* root `apps/kustomization.yaml` entry (`semaphore/namespace.yml`) its own path never pulls in. If `semaphore-db` is in `DEPLOY_APPS`, the workflow now explicitly applies `semaphore/namespace.yml` and `cloudnative-pg-operator/deploy.yaml` first (idempotent even if `cloudnative-pg-operator` is also independently in `DEPLOY_APPS`), guarded against staleness if `cloudnative-pg-operator` is ever added to `EXCLUDED_APPS`.

Checked the storage class before pushing: `semaphore-db`'s `Cluster` CR requests `storageClass: local-path`, which is k3s's built-in default provisioner — this workflow's k3s install only disables `traefik`, so `local-path` should be present.

## Verification done pre-push

- Bash syntax-checked the extracted step scripts
- Dry-run of the full resolution logic against real repo paths (stubbed `flux`/`kubectl`) — every app resolves to the expected branch, all 9 excluded apps correctly skip despite having a real `deploy.yaml`, `semaphore-db`'s prereq block runs correctly
- Confirmed the fail-closed path's real exit code is `1` and halts the loop before later apps run
- Confirmed the `apps/kustomization.yaml`-as-bogus-app bug (hit on kubenuc's first run) doesn't recur here

## Test plan

- [x] Confirm this PR's own `k8s-vms-e2e` run: the 4 newly-covered apps reach `Ready`, the 9 `EXCLUDED_APPS` entries correctly skip, and — not resolvable by static read — the `semaphore-db` CNPG `Cluster` actually provisions Postgres on the ephemeral k3s cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)