### PR TITLE
ci(validate-flux-render): add timeout to the flate build step

### DIFF
--- a/.github/workflows/validate-flux-render.yml
+++ b/.github/workflows/validate-flux-render.yml
@@ -92,6 +92,15 @@ jobs:
         run: flate test all --path ./clusters/${{ matrix.cluster }} --allow-missing-secrets
 
       - name: flate build (full render, for schema validation)
+        # Has hung indefinitely at least 3 times (2026-08-06, PRs #1791 and
+        # #1793) with zero forward progress and no error - only on the
+        # kubenuc cluster, never k8s-vms-daniele/k3s-rabbit/oc-ampere, which
+        # consistently finish this step in a few seconds. Root cause not
+        # yet identified (see feedback_flate_build_kubenuc_hang memory).
+        # Normal runtime is a few seconds; 5m is generous headroom that
+        # still fails fast and visibly instead of blocking a PR's
+        # mergeStateStatus for hours with no automatic recovery.
+        timeout-minutes: 5
         run: flate build all --path ./clusters/${{ matrix.cluster }} --allow-missing-secrets -o yaml > rendered.yaml
 
       - name: Append FluxInstance (not covered by flate's render)


### PR DESCRIPTION
## Summary

`flate + kubeconform (kubenuc)` has hung indefinitely at least 3 times (2026-08-06, PRs #1791 and #1793), always on the same "flate build (full render, for schema validation)" step, with zero forward progress and no error. The other three cluster jobs in the same matrix (`k8s-vms-daniele`, `k3s-rabbit`, `oc-ampere`) consistently finish in 15–20s.

Root cause is not yet identified. Neither the step nor the job had any `timeout-minutes` set, so a hang blocked a PR's `mergeStateStatus` for up to hours (observed: ~2h once) until someone noticed and manually cancelled it.

## Change

Add `timeout-minutes: 5` to the "flate build" step — generous headroom over its normal few-second runtime, but short enough to fail fast and visibly instead of silently blocking a PR indefinitely. This is a stopgap, not a root-cause fix: on timeout the step just fails (no automatic retry), so a hang still fails the check — just in 5 minutes instead of hours, which at least makes it obviously actionable in the PR checks instead of looking like a stuck/hanging job someone has to notice and manually intervene on.

## Test plan

- [x] This PR's own diff touches `.github/workflows/validate-flux-render.yml`, so `validate-flux-render` runs across all 4 clusters on this PR itself — confirm all 4 pass normally within the new timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)