### PR TITLE
fix(k3s-rabbit): Added missing namespace that is breaking flux reconciliation

### DIFF
--- a/clusters/k3s-rabbit/apps/teleport-agent/secrets/teleport-agent-secret.yml
+++ b/clusters/k3s-rabbit/apps/teleport-agent/secrets/teleport-agent-secret.yml
@@ -2,5 +2,6 @@ apiVersion: onepassword.com/v1
 kind: OnePasswordItem
 metadata:
   name: teleport-kube-agent-join-token
+  namespace: teleport
 spec:
   itemPath: "vaults/k8s_secrets/items/teleport-prod-k3s-agent-token"


### PR DESCRIPTION
Added missing namespace that is breaking flux reconciliation

```
kustomization/teleport-kube-agent-join-token	refs/heads/main@sha1:d41232f8	False    	False	OnePasswordItem/teleport-kube-agent-join-token namespace not specified: the server could not find the requested resource (patch onepassworditems.onepassword.com teleport-kube-agent-join-token)
```