### PR TITLE
fix(validate-kubenuc,validate-k8s-vms): don't fail the job on zero HelmReleases

### DIFF
--- a/.github/workflows/validate-k8s-vms.yml
+++ b/.github/workflows/validate-k8s-vms.yml
@@ -473,10 +473,18 @@ jobs:
             kubectl -n "$ns" wait hr "$name" --for=condition=ready --timeout=30m || true
           done
 
+      # Purely informational — `flux get` exits non-zero when it finds zero
+      # matching objects (confirmed live on the companion k3s-rabbit
+      # workflow, which hit exactly this before `|| true` was added there).
+      # k8s-vms-daniele has no INFRA_APPS baseline and a large
+      # EXCLUDED_APPS set, so a PR touching only excluded apps deploys zero
+      # real HelmReleases here — structurally the same exposure that broke
+      # k3s-rabbit. A purely informational step shouldn't be able to fail
+      # the job regardless.
       - name: Check resource deployment status
         run: |
-          flux get kustomizations -A
-          flux get helmreleases -A
+          flux get kustomizations -A || true
+          flux get helmreleases -A || true
 
       - name: Validate critical deployments
         run: |

--- a/.github/workflows/validate-kubenuc.yml
+++ b/.github/workflows/validate-kubenuc.yml
@@ -698,10 +698,18 @@ jobs:
           echo "=== Verifying CoreDNS configuration ==="
           kubectl -n kube-system get configmap coredns-custom -o yaml
 
+      # Purely informational — `flux get` exits non-zero when it finds zero
+      # matching objects (confirmed live on the companion k3s-rabbit
+      # workflow, which hit exactly this before `|| true` was added there).
+      # kubenuc's INFRA_APPS baseline (openebs haproxy-ingress coredns
+      # postgresql s3) means every run deploys at least those real
+      # HelmReleases, so zero HelmReleases here is rare — but not
+      # impossible, and a purely informational step shouldn't be able to
+      # fail the job regardless.
       - name: Check resource deployment status
         run: |
-          flux get kustomizations -A
-          flux get helmreleases -A
+          flux get kustomizations -A || true
+          flux get helmreleases -A || true
 
       - name: Validate critical deployments
         run: |


### PR DESCRIPTION
## Summary

- Same latent bug fixed reactively on `validate-k3s-rabbit.yml` (`8454ea67`, after a real CI run failed) and preventively on `validate-oc-ampere.yml` (`a817d22b`): the "Check resource deployment status" step calls `flux get kustomizations -A` and `flux get helmreleases -A` with no `|| true`. `flux`'s CLI exits non-zero when it finds zero matching objects ("no HelmRelease objects found in any namespace"), which under GitHub Actions' default `set -eo pipefail` fails the whole step and the job — even though this step is purely informational (the real gating checks are the earlier `kubectl wait` calls).
- `validate-kubenuc.yml` and `validate-k8s-vms.yml` have the exact same unguarded step and are structurally exposed to the same bug. They've never hit it in practice, but not because they're immune:
  - kubenuc's `INFRA_APPS` baseline (`openebs haproxy-ingress coredns postgresql s3`) means it almost always deploys real HelmReleases — rare, not impossible.
  - k8s-vms-daniele has no `INFRA_APPS` baseline and a large `EXCLUDED_APPS` set, so a PR touching only excluded apps deploys zero real HelmReleases there — the same exposure that broke k3s-rabbit.
- Added `|| true` to both `flux get` calls in each file, consistent with the "Check for failed reconciliations" step right below, which already treats itself as informational-only the same way.
- Left the `flux get all -A` call in each file's `Debug failure` step untouched — it's a separate pre-existing pattern shared unguarded across all four workflows, out of scope here.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open(...))"` on both edited files — valid YAML
- [x] `grep -n "flux get"` confirms exactly the two targeted lines per file now carry `|| true`, and the `Debug failure` step's `flux get all -A` is untouched
- [ ] No live re-trigger: both workflows' `paths:` filters are scoped to `clusters/kubenuc/**` and `clusters/k8s-vms-daniele/**` respectively, so this PR (touching only `.github/workflows/**`) does not trigger either e2e job. Verified by code inspection, YAML validity, and direct precedent (`8454ea67` proved this exact fix live on k3s-rabbit) — same verification approach used for the preventive oc-ampere fix in `a817d22b`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)