### PR TITLE
chore(proxmox): move rabbit/gozzi-hpelvisor VM/LXC hostnames into SOPS

### DIFF
--- a/.github/workflows/terraform-bio.yml
+++ b/.github/workflows/terraform-bio.yml
@@ -57,6 +57,7 @@ jobs:
         env:
           OP_TOKEN: '${{ secrets.OP_TOKEN }}'
           OP_ENDPOINT: '${{ secrets.OP_ENDPOINT }}'
+          SOPS_AGE_KEY: '${{ secrets.SOPS_AGE_KEY_BIO }}'
 
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         if: github.event_name == 'pull_request'
@@ -126,6 +127,7 @@ jobs:
         env:
           OP_TOKEN: '${{ secrets.OP_TOKEN }}'
           OP_ENDPOINT: '${{ secrets.OP_ENDPOINT }}'
+          SOPS_AGE_KEY: '${{ secrets.SOPS_AGE_KEY_BIO }}'
 
       - name: Cleanup SSH public key
         if: always()

--- a/.github/workflows/terraform-psp.yml
+++ b/.github/workflows/terraform-psp.yml
@@ -57,6 +57,7 @@ jobs:
         env:
           OP_TOKEN: '${{ secrets.OP_TOKEN }}'
           OP_ENDPOINT: '${{ secrets.OP_ENDPOINT }}'
+          SOPS_AGE_KEY: '${{ secrets.SOPS_AGE_KEY_PSP }}'
 
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         if: github.event_name == 'pull_request'
@@ -126,6 +127,7 @@ jobs:
         env:
           OP_TOKEN: '${{ secrets.OP_TOKEN }}'
           OP_ENDPOINT: '${{ secrets.OP_ENDPOINT }}'
+          SOPS_AGE_KEY: '${{ secrets.SOPS_AGE_KEY_PSP }}'
 
       - name: Cleanup SSH public key
         if: always()

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -48,3 +48,11 @@ creation_rules:
   # ansible/ — Teleport host connection details (VM IPs/hostnames)
   - path_regex: ansible/.*\.sops\.(yaml|yml|json)$
     age: age13h7kx5mcfa0yn4mpf6udw39nup0sl4402mmemra9yfkymmscqd7s9grug2
+
+  # Terraform Proxmox Rabbit (PSP) — VM/LXC hostnames
+  - path_regex: terraform/proxmox/rabbit/secrets\.sops\.yaml$
+    age: age1ygqcr24v9mnmmgaps0kascmh27j9qlk2dmz269lga06n3zjxdeps4znenj
+
+  # Terraform Proxmox Gozzi/Hpelvisor (BIO) — VM/LXC hostnames
+  - path_regex: terraform/proxmox/gozzi-hpelvisor/secrets\.sops\.yaml$
+    age: age1macxjcxh0u58kwran0nap5sqlzja8f4wh6ud5d3uqcvkvzkae9wsldk0js

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,10 +24,10 @@
 
 ## Secrets Management
 
-This repository uses **1Password** for all secrets:
+This repository uses **1Password** for most secrets, and **SOPS** (age-encrypted, `carlpett/sops` Terraform provider) for a subset of Terraform-only, stack-local, non-credential values — hostnames, zone/tunnel IDs, IP addresses. See `terraform/CLAUDE.md` for the per-stack breakdown of which provider each Terraform stack uses.
 
 - **Kubernetes secrets:** 1Password Operator syncs secrets as Kubernetes `Secret` resources via `OnePasswordItem` CRDs
-- **Terraform secrets:** 1Password Terraform provider reads secrets at plan/apply time
+- **Terraform secrets:** 1Password Terraform provider or the SOPS provider (per-stack, see `terraform/CLAUDE.md`) reads secrets at plan/apply time
 - **CI secrets:** Stored as GitHub Actions repository secrets
 
 **Never:**
@@ -36,9 +36,9 @@ This repository uses **1Password** for all secrets:
 - Hardcode hostnames, FQDNs, or internal service URLs — these are treated as sensitive infrastructure details regardless of whether they appear to be "just configuration"
 
 **Always:**
-- Reference secrets via `OnePasswordItem` CRDs or `ExternalSecret` resources
-- Store new secrets in 1Password first, then reference by path
-- Store server URLs and FQDNs in 1Password alongside credentials (e.g. use `.url` or `.hostname` from a `onepassword_item` data source in Terraform, or a `OnePasswordItem` field in Kubernetes)
+- Reference secrets via `OnePasswordItem` CRDs, `ExternalSecret` resources, or a stack's SOPS-encrypted `secrets.sops.yaml`
+- Store new secrets in 1Password (or the relevant stack's SOPS file) first, then reference by path
+- Store server URLs and FQDNs in 1Password alongside credentials (e.g. use `.url` or `.hostname` from a `onepassword_item` data source in Terraform, or a `OnePasswordItem` field in Kubernetes) — unless the stack uses SOPS for hostnames, per `terraform/CLAUDE.md`
 
 ---
 

--- a/terraform/CLAUDE.md
+++ b/terraform/CLAUDE.md
@@ -7,7 +7,11 @@
 - **Format:** Always run `terraform fmt` before committing — CI rejects unformatted files
 - Each `terraform/{environment}/` (or `terraform/proxmox/{host}/`) is independent with its own backend config
 - Reusable modules published as standalone repos: `dark-vex/terraform-proxmox-vm`, `dark-vex/terraform-proxmox-lxc`, `dark-vex/terraform-hetzner-server`, `dark-vex/terraform-cloudflare-dns`, `dark-vex/terraform-cloudflare-tunnel` — referenced via `github.com/dark-vex/<name>?ref=<commit-sha>  # vX.Y.Z` (SHA-pinned for supply-chain safety; the trailing comment records the tag the SHA corresponds to)
-- Sensitive values are sourced from 1Password provider — never hardcoded
+- **Secrets provider by stack** (never hardcode sensitive values — source from the stack's provider(s) below):
+  - **1Password only:** `terraform/hetzner/`, `terraform/proxmox/ec200/`, `terraform/grafana/`, `terraform/semaphore/`, `terraform/oci/*` (k8s-armchair, teleport, test_vpn)
+  - **SOPS only** (`carlpett/sops`, age-encrypted `secrets.sops.yaml`): `terraform/DNS/`, `terraform/cloudflare-tunnel/`
+  - **Both:** `terraform/netbox/` (1Password for API credentials; SOPS for on-prem IP/prefix inventory), `terraform/proxmox/rabbit/`, `terraform/proxmox/gozzi-hpelvisor/` (1Password for Proxmox/API credentials + SSH keys; SOPS for VM/LXC hostnames)
+  - Each SOPS-using stack has its own dedicated age keypair and `SOPS_AGE_KEY_*` GitHub Actions secret — never shared across stacks
 - Do not hand-pin provider versions managed by Renovate
 - **`local-exec`/`terraform_data` escape hatch** (first used in `terraform/semaphore/main.tf`): only reach for this when a provider genuinely doesn't wrap a real, documented API endpoint (confirmed by checking the provider's schema/source, not assumed) — a custom provider is over-engineering for a couple of endpoints, and a manual out-of-band step violates this repo's no-config-drift convention. Make it idempotent (GET-then-match-then-PUT/POST, never a blind POST) and drive re-runs via `triggers_replace` hashing both the desired config and the helper script itself — `terraform_data` provisioners only fire on `create` otherwise. Document the known limitation plainly: this doesn't detect out-of-band drift on an otherwise-unchanged apply.
 

--- a/terraform/proxmox/gozzi-hpelvisor/data.tf
+++ b/terraform/proxmox/gozzi-hpelvisor/data.tf
@@ -39,3 +39,11 @@ data "onepassword_item" "lxc_access" {
   vault = local.onepassword_vault
   uuid  = "ldva6u4clsjb7ueiydldnpsrc4"
 }
+
+data "sops_file" "gozzi_hpelvisor_secrets" {
+  source_file = "secrets.sops.yaml"
+}
+
+locals {
+  gozzi_hpelvisor_secrets = yamldecode(data.sops_file.gozzi_hpelvisor_secrets.raw)
+}

--- a/terraform/proxmox/gozzi-hpelvisor/gozzi_pve-generated.tf
+++ b/terraform/proxmox/gozzi-hpelvisor/gozzi_pve-generated.tf
@@ -109,10 +109,10 @@ module "gozzi_pve_okd_singlenode_vm" {
     proxmox = proxmox.gozzi_pve
   }
 
-  name        = "okd-singlenode"
+  name        = local.gozzi_hpelvisor_secrets.gozzi_pve.vm.okd_singlenode
   vmid        = 800
   node_name   = "gozzi-pve"
-  description = "okd-singlenode"
+  description = local.gozzi_hpelvisor_secrets.gozzi_pve.vm.okd_singlenode
 
   cpu_cores = 8
   cpu_type  = "host"
@@ -271,10 +271,10 @@ module "gozzi_pve_r_3cx_bioadventures_eu_vm" {
     proxmox = proxmox.gozzi_pve
   }
 
-  name        = "3cx.bioadventures.eu"
+  name        = local.gozzi_hpelvisor_secrets.gozzi_pve.vm["3cx_bioadventures"]
   vmid        = 204
   node_name   = "gozzi-pve"
-  description = "3cx.bioadventures.eu"
+  description = local.gozzi_hpelvisor_secrets.gozzi_pve.vm["3cx_bioadventures"]
 
   protection = true
 
@@ -318,10 +318,10 @@ module "gozzi_pve_kubenuc_m2_vm" {
     proxmox = proxmox.gozzi_pve
   }
 
-  name        = "kubenuc-m2"
+  name        = local.gozzi_hpelvisor_secrets.gozzi_pve.vm.kubenuc_m2
   vmid        = 102
   node_name   = "gozzi-pve"
-  description = "kubenuc-m2"
+  description = local.gozzi_hpelvisor_secrets.gozzi_pve.vm.kubenuc_m2
 
   cpu_cores   = 1
   cpu_sockets = 2
@@ -367,10 +367,10 @@ module "gozzi_pve_pve_backup_vm" {
     proxmox = proxmox.gozzi_pve
   }
 
-  name        = "pve-backup"
+  name        = local.gozzi_hpelvisor_secrets.gozzi_pve.vm.pve_backup
   vmid        = 1000
   node_name   = "gozzi-pve"
-  description = "pve-backup"
+  description = local.gozzi_hpelvisor_secrets.gozzi_pve.vm.pve_backup
 
   cpu_cores   = 2
   cpu_sockets = 2

--- a/terraform/proxmox/gozzi-hpelvisor/hpelvisor-generated.tf
+++ b/terraform/proxmox/gozzi-hpelvisor/hpelvisor-generated.tf
@@ -8,10 +8,10 @@ module "hpelvisor_gitlab_ddlns_net_lxc" {
     proxmox = proxmox.hpelvisor
   }
 
-  hostname    = "gitlab.ddlns.net"
+  hostname    = local.gozzi_hpelvisor_secrets.hpelvisor.lxc.gitlab
   vmid        = 700
   node_name   = "hpelvisor"
-  description = "gitlab.ddlns.net"
+  description = local.gozzi_hpelvisor_secrets.hpelvisor.lxc.gitlab
 
   cpu_cores      = 8
   memory         = 12288
@@ -60,10 +60,10 @@ module "hpelvisor_dolibarr_test_bioadventures_eu_lxc" {
     proxmox = proxmox.hpelvisor
   }
 
-  hostname    = "dolibarr.test.bioadventures.eu"
+  hostname    = local.gozzi_hpelvisor_secrets.hpelvisor.lxc.dolibarr_test
   vmid        = 701
   node_name   = "hpelvisor"
-  description = "dolibarr.test.bioadventures.eu"
+  description = local.gozzi_hpelvisor_secrets.hpelvisor.lxc.dolibarr_test
 
   cpu_cores      = 2
   memory         = 2048
@@ -111,10 +111,10 @@ module "hpelvisor_gen8_runner_vm" {
     proxmox = proxmox.hpelvisor
   }
 
-  name        = "gen8-runner"
+  name        = local.gozzi_hpelvisor_secrets.hpelvisor.vm.gen8_runner
   vmid        = 3000
   node_name   = "hpelvisor"
-  description = "gen8-runner"
+  description = local.gozzi_hpelvisor_secrets.hpelvisor.vm.gen8_runner
 
   cpu_cores   = 8
   cpu_sockets = 2
@@ -159,10 +159,10 @@ module "hpelvisor_sensor_debian12_vm" {
     proxmox = proxmox.hpelvisor
   }
 
-  name        = "sensor-debian12"
+  name        = local.gozzi_hpelvisor_secrets.hpelvisor.vm.sensor_debian12
   vmid        = 703
   node_name   = "hpelvisor"
-  description = "sensor-debian12"
+  description = local.gozzi_hpelvisor_secrets.hpelvisor.vm.sensor_debian12
 
   cpu_cores = 4
   cpu_type  = "host"
@@ -207,10 +207,10 @@ module "hpelvisor_pelican_game_vm" {
     proxmox = proxmox.hpelvisor
   }
 
-  name        = "pelican-game"
+  name        = local.gozzi_hpelvisor_secrets.hpelvisor.vm.pelican_game
   vmid        = 7003
   node_name   = "hpelvisor"
-  description = "pelican-game"
+  description = local.gozzi_hpelvisor_secrets.hpelvisor.vm.pelican_game
 
   cpu_cores   = 4
   cpu_sockets = 2
@@ -256,10 +256,10 @@ module "hpelvisor_prod_k3s_worker1_vm" {
     proxmox = proxmox.hpelvisor
   }
 
-  name        = "prod-k3s-worker1"
+  name        = local.gozzi_hpelvisor_secrets.hpelvisor.vm.prod_k3s_worker1
   vmid        = 601
   node_name   = "hpelvisor"
-  description = "prod-k3s-worker1"
+  description = local.gozzi_hpelvisor_secrets.hpelvisor.vm.prod_k3s_worker1
 
   cpu_cores   = 4
   cpu_sockets = 2
@@ -303,10 +303,10 @@ module "hpelvisor_openstack_vm" {
     proxmox = proxmox.hpelvisor
   }
 
-  name        = "openstack"
+  name        = local.gozzi_hpelvisor_secrets.hpelvisor.vm.openstack
   vmid        = 900
   node_name   = "hpelvisor"
-  description = "openstack"
+  description = local.gozzi_hpelvisor_secrets.hpelvisor.vm.openstack
 
   cpu_cores = 4
   cpu_type  = "host"
@@ -361,10 +361,10 @@ module "hpelvisor_openstack_snap_vm" {
     proxmox = proxmox.hpelvisor
   }
 
-  name        = "openstack-snap"
+  name        = local.gozzi_hpelvisor_secrets.hpelvisor.vm.openstack_snap
   vmid        = 2000
   node_name   = "hpelvisor"
-  description = "openstack-snap"
+  description = local.gozzi_hpelvisor_secrets.hpelvisor.vm.openstack_snap
 
   cpu_cores = 4
   cpu_type  = "host"
@@ -413,10 +413,10 @@ module "hpelvisor_sensor_ubuntu24_vm" {
     proxmox = proxmox.hpelvisor
   }
 
-  name        = "sensor-ubuntu24"
+  name        = local.gozzi_hpelvisor_secrets.hpelvisor.vm.sensor_ubuntu24
   vmid        = 702
   node_name   = "hpelvisor"
-  description = "sensor-ubuntu24"
+  description = local.gozzi_hpelvisor_secrets.hpelvisor.vm.sensor_ubuntu24
 
   cpu_cores = 4
   cpu_type  = "host"
@@ -462,10 +462,10 @@ module "hpelvisor_prod_k3s_master_vm" {
     proxmox = proxmox.hpelvisor
   }
 
-  name        = "prod-k3s-master"
+  name        = local.gozzi_hpelvisor_secrets.hpelvisor.vm.prod_k3s_master
   vmid        = 600
   node_name   = "hpelvisor"
-  description = "prod-k3s-master"
+  description = local.gozzi_hpelvisor_secrets.hpelvisor.vm.prod_k3s_master
 
   cpu_cores   = 2
   cpu_sockets = 2
@@ -509,10 +509,10 @@ module "hpelvisor_amp_game_vm" {
     proxmox = proxmox.hpelvisor
   }
 
-  name        = "amp-game"
+  name        = local.gozzi_hpelvisor_secrets.hpelvisor.vm.amp_game
   vmid        = 7000
   node_name   = "hpelvisor"
-  description = "amp-game"
+  description = local.gozzi_hpelvisor_secrets.hpelvisor.vm.amp_game
 
   cpu_cores   = 4
   cpu_sockets = 2

--- a/terraform/proxmox/gozzi-hpelvisor/monitoring-lxc.tf
+++ b/terraform/proxmox/gozzi-hpelvisor/monitoring-lxc.tf
@@ -4,7 +4,7 @@ module "gozzi_mon_lug_lxc" {
     proxmox = proxmox.gozzi_pve
   }
 
-  hostname    = "mon-lug.ddlns.net"
+  hostname    = local.gozzi_hpelvisor_secrets.gozzi_pve.lxc.mon_lug_lxc
   vmid        = 801
   node_name   = "gozzi-pve"
   description = "Proxmox monitoring - LUG site (pve-exporter + Grafana Alloy)"

--- a/terraform/proxmox/gozzi-hpelvisor/provider.tf
+++ b/terraform/proxmox/gozzi-hpelvisor/provider.tf
@@ -4,6 +4,8 @@ provider "onepassword" {
   connect_token = var.onepassword_token
 }
 
+provider "sops" {}
+
 # Proxmox provider for gozzi-01-bio (LUG, Switzerland)
 # Uses username/password authentication
 provider "proxmox" {

--- a/terraform/proxmox/gozzi-hpelvisor/seaweedfs-lxc.tf
+++ b/terraform/proxmox/gozzi-hpelvisor/seaweedfs-lxc.tf
@@ -4,7 +4,7 @@ module "hpelvisor_seaweedfs_lxc" {
     proxmox = proxmox.hpelvisor
   }
 
-  hostname    = "seaweedfs-hpelvisor"
+  hostname    = local.gozzi_hpelvisor_secrets.hpelvisor.lxc.seaweedfs_hpelvisor
   vmid        = 704
   node_name   = "hpelvisor"
   description = "SeaweedFS storage node - replication 100"

--- a/terraform/proxmox/gozzi-hpelvisor/secrets.sops.yaml
+++ b/terraform/proxmox/gozzi-hpelvisor/secrets.sops.yaml
@@ -1,0 +1,38 @@
+gozzi_pve:
+    vm:
+        okd_singlenode: ENC[AES256_GCM,data:II3t2uKhV4spbr1bWV4=,iv:wY4OTFsNs8T05YZKkFq1qDd+nDCb7rHIfc+YPIcnf9M=,tag:N9NWHjgxqJHpnCJ3sVS9QQ==,type:str]
+        3cx_bioadventures: ENC[AES256_GCM,data:qlxsr9Y4qTNwUgBpJf27a3AJYxU=,iv:v9Jslrsq0tVnWonVJ6UqqCk78QwZXD+ikrMeoaS8HME=,tag:W227dHtnmWhHv8WIMQ1ewQ==,type:str]
+        kubenuc_m2: ENC[AES256_GCM,data:UH7f5rsFHGSa/w==,iv:XCIu5ZP8PVo8ztOftK1A8eFjwp7utYYdkl+v4FGt22U=,tag:eSnZTlgGhi00XHAIzDxgOg==,type:str]
+        pve_backup: ENC[AES256_GCM,data:9lM+zM/sxR88jQ==,iv:+6JZkne1Y4IFhS+Y2yUadXjGaKRnARkRnfFxijYgvHs=,tag:IUUKIKnzQLJv1qauYGEd7A==,type:str]
+    lxc:
+        mon_lug_lxc: ENC[AES256_GCM,data:aKG1vTamGGAgg82faVIZPFs=,iv:c7x99/qKanwhqQHNVr82UktfIUNiZ+w7Y68mZAB5ldI=,tag:y8v4QY8isQb6+sqgycLyEw==,type:str]
+hpelvisor:
+    vm:
+        gen8_runner: ENC[AES256_GCM,data:IAyjWh6joH1rmaE=,iv:/wRXHjSlQSPi6sUYLp9JFmosSlYlrrBJqULxtLD5m/U=,tag:n1gJkeNOcZxYgBv8B3WyMw==,type:str]
+        sensor_debian12: ENC[AES256_GCM,data:XnqMmsPfCyEM26eJ5uSd,iv:Qb/R/s5V57OZnRGKCYaFXSNxC6P6VufkQO5npj0JUgg=,tag:+sOTbv0j290I8vFOWVDbhQ==,type:str]
+        pelican_game: ENC[AES256_GCM,data:qM7Q4krOPBYhesvc,iv:1F6CbbnUPeapaTvkdUl1rTgW1qS0CYTMiBjH+jewfW4=,tag:gljN37NLXVKUFvGge5i6tg==,type:str]
+        prod_k3s_worker1: ENC[AES256_GCM,data:NcQiqHzOcXFgK8PpoWE1ow==,iv:Etwbi6cJXKgZE0sitM3kM6ceMtJI812td4iiIztFvwM=,tag:+MF6Y2/L7oHGdHl9f2AdPw==,type:str]
+        openstack: ENC[AES256_GCM,data:QF2B9NhsJpg3,iv:JGMtoFYWip67YFphm9/vvSJmQtoN+SyA9U6ebXmELVo=,tag:570iIlNL1uAHgBJROM6frA==,type:str]
+        openstack_snap: ENC[AES256_GCM,data:x3AHPiI4BX4EBctiF5c=,iv:dl3RlIqsV9gr4n/gXmZ3JePQBYSYsA3DXFjhqeB2Vm8=,tag:/FULU19iWu2pJeYN7xvK/A==,type:str]
+        sensor_ubuntu24: ENC[AES256_GCM,data:7gK+51+4aw0tYl3nE2oI,iv:VBBJRWr3jgUY4CvXCvtfBq94PQf+EwIJJvOUAGM4mrs=,tag:IB14RxkQZ24GHMbLHDsQ0Q==,type:str]
+        prod_k3s_master: ENC[AES256_GCM,data:Ae7YuppzZFc7CFsttWzJ,iv:2YMBM6dEt/2U2kpIgv0vWUed4DPJO/OSzkPawFSBVVI=,tag:C/a5kg9rc+3gB4HYBxF9yQ==,type:str]
+        amp_game: ENC[AES256_GCM,data:EjxJzMHrFN0=,iv:yu+4UQnONr6cgu16ODXx99XS763gOIPWlLFcle/BME0=,tag:TBgh0Pts8ukqtXA1iMvmQg==,type:str]
+    lxc:
+        gitlab: ENC[AES256_GCM,data:e85z+Kdz+M9utHyyBE5csg==,iv:oYVX/zQkABoPGps3l9w6qepyos+ZRko53+8pCoNG0I4=,tag:fA7i/Z388/SRGZKhkgYgOQ==,type:str]
+        dolibarr_test: ENC[AES256_GCM,data:X/bhByhZ41WgsHvxUg1IxLwZpaDty1Qhv1JuLeh7,iv:OQ5FBUEfUjnxYzlH1jAciaJ/x6knlmqarCfRvhXrsWc=,tag:+PTde1cQFoPKQT3f8iYDLg==,type:str]
+        seaweedfs_hpelvisor: ENC[AES256_GCM,data:3AsBXyahJi12w8XygHX1gIDkCg==,iv:+79KZ5SuKAXlRPLvhu43D7PupF0aYW54Bp9YoONz9TQ=,tag:l3vE8f6ea98qrpT9GH8eNA==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjbGVOeS85cnNvaENCc0xv
+            aVNJTFhNSk80di9WYUs4cjdab3lhMDJJVWs4CmltVW1HSUxwQlJtYjBVWk9BSk41
+            VnpDVlNGaWlheFpLdDlIS2R5NmdNTEkKLS0tIEM4amx5dmNGcE0xOStHRC9GVGRO
+            Yk5DSEpSQ3R3M1B6Ly9JL1huQTYyNkUKnjU4wSzJoCWyXz0+YGCsrAdmtv8DmpUc
+            IfgUMtdGBCSS69HbN3jNBAnQB1s7FNnqvxTXl0BIj0anwhWP0O4L6Q==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1macxjcxh0u58kwran0nap5sqlzja8f4wh6ud5d3uqcvkvzkae9wsldk0js
+    lastmodified: "2026-08-08T20:17:44Z"
+    mac: ENC[AES256_GCM,data:E1Ug4YYddpw8IwI6vTrvHLv6USHYboSFiA+sGsgNwRV+gMDaTY8XRxBOdkC4DetFG4PGkcZBwc6ImchihZD1fjk5ho+oF2TF2jMeq3e4n3OlAyahFpbZOGEyASBVL1J/aG73nXwQ+ZF9BMo2Io5qJszH7SLTCMndddcwN3xBUOU=,iv:LI6V8zlHLDQU+j6QJtoKpBHnRLE1LMz1q4glYXLz4wc=,tag:hIB6fnjWFLi3JumDo749rg==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.13.3

--- a/terraform/proxmox/gozzi-hpelvisor/terraform.tf
+++ b/terraform/proxmox/gozzi-hpelvisor/terraform.tf
@@ -18,5 +18,10 @@ terraform {
       source  = "1Password/onepassword"
       version = "~> 3.0"
     }
+
+    sops = {
+      source  = "carlpett/sops"
+      version = "~> 1.1"
+    }
   }
 }

--- a/terraform/proxmox/rabbit/data.tf
+++ b/terraform/proxmox/rabbit/data.tf
@@ -30,3 +30,11 @@ data "onepassword_item" "lxc_access" {
   vault = local.onepassword_vault
   uuid  = "ldva6u4clsjb7ueiydldnpsrc4"
 }
+
+data "sops_file" "rabbit_secrets" {
+  source_file = "secrets.sops.yaml"
+}
+
+locals {
+  rabbit_secrets = yamldecode(data.sops_file.rabbit_secrets.raw)
+}

--- a/terraform/proxmox/rabbit/lxc.tf
+++ b/terraform/proxmox/rabbit/lxc.tf
@@ -8,7 +8,7 @@ module "rabbit_satisfactory_shared_ddlns_net_lxc" {
     proxmox = proxmox.rabbit
   }
 
-  hostname    = "satisfactory-shared.ddlns.net"
+  hostname    = local.rabbit_secrets.lxc.satisfactory_shared_lxc
   vmid        = 806
   node_name   = "rabbit-01-psp"
   description = "Satisfactory shared Container"
@@ -50,7 +50,7 @@ module "rabbit_haproxy1_ddlns_net_lxc" {
     proxmox = proxmox.rabbit
   }
 
-  hostname    = "haproxy1.ddlns.net"
+  hostname    = local.rabbit_secrets.lxc.haproxy1
   vmid        = 800
   node_name   = "rabbit-01-psp"
   description = "HAProxy Container for reverse proxy and load balancing"
@@ -93,10 +93,10 @@ module "rabbit_test_mail_ddlns_net_lxc" {
     proxmox = proxmox.rabbit
   }
 
-  hostname    = "test-mail.ddlns.net"
+  hostname    = local.rabbit_secrets.lxc.test_mail
   vmid        = 804
   node_name   = "rabbit-01-psp"
-  description = "test-mail.ddlns.net"
+  description = local.rabbit_secrets.lxc.test_mail
   console     = {}
 
   cpu_cores      = 2
@@ -138,7 +138,7 @@ module "rabbit_satisfactory_ddlns_net_lxc" {
     proxmox = proxmox.rabbit
   }
 
-  hostname    = "satisfactory.ddlns.net"
+  hostname    = local.rabbit_secrets.lxc.satisfactory_lxc
   vmid        = 805
   node_name   = "rabbit-01-psp"
   description = "Satisfactory Container"
@@ -180,10 +180,10 @@ module "rabbit_graylog_ddlns_net_lxc" {
     proxmox = proxmox.rabbit
   }
 
-  hostname    = "graylog.ddlns.net"
+  hostname    = local.rabbit_secrets.lxc.graylog
   vmid        = 807
   node_name   = "rabbit-01-psp"
-  description = "graylog.ddlns.net"
+  description = local.rabbit_secrets.lxc.graylog
 
   cpu_cores      = 8
   cpu_limit      = 6
@@ -231,10 +231,10 @@ module "rabbit_pbs_01_psp_ddlns_net_lxc" {
     proxmox = proxmox.rabbit
   }
 
-  hostname    = "pbs-01-psp.ddlns.net"
+  hostname    = local.rabbit_secrets.lxc.pbs_01_psp
   vmid        = 802
   node_name   = "rabbit-01-psp"
-  description = "pbs-01-psp.ddlns.net"
+  description = local.rabbit_secrets.lxc.pbs_01_psp
 
   cpu_cores      = 4
   memory         = 4096
@@ -278,7 +278,7 @@ module "rabbit_squid_ddlns_net_lxc" {
     proxmox = proxmox.rabbit
   }
 
-  hostname    = "squid.ddlns.net"
+  hostname    = local.rabbit_secrets.lxc.squid_lxc
   vmid        = 801
   node_name   = "rabbit-01-psp"
   description = "Squid Proxy Container for content filtering"
@@ -321,10 +321,10 @@ module "rabbit_rtmp1_ddlns_net_lxc" {
     proxmox = proxmox.rabbit
   }
 
-  hostname    = "rtmp1.ddlns.net"
+  hostname    = local.rabbit_secrets.lxc.rtmp1_lxc
   vmid        = 803
   node_name   = "rabbit-01-psp"
-  description = "rtmp1.ddlns.net"
+  description = local.rabbit_secrets.lxc.rtmp1_lxc
 
   cpu_cores      = 8
   memory         = 8192
@@ -365,7 +365,7 @@ module "rabbit_mon_bgy_lxc" {
     proxmox = proxmox.rabbit
   }
 
-  hostname    = "mon-bgy.ddlns.net"
+  hostname    = local.rabbit_secrets.lxc.mon_bgy_lxc
   vmid        = 808
   node_name   = "rabbit-01-psp"
   description = "Proxmox monitoring - BGY site (pve-exporter + Grafana Alloy)"

--- a/terraform/proxmox/rabbit/provider.tf
+++ b/terraform/proxmox/rabbit/provider.tf
@@ -4,6 +4,8 @@ provider "onepassword" {
   connect_token = var.onepassword_token
 }
 
+provider "sops" {}
+
 # Proxmox provider for rabbit-01-psp (BGY, Italy)
 # Uses API token authentication
 provider "proxmox" {

--- a/terraform/proxmox/rabbit/seaweedfs-lxc.tf
+++ b/terraform/proxmox/rabbit/seaweedfs-lxc.tf
@@ -4,7 +4,7 @@ module "rabbit_seaweedfs_lxc" {
     proxmox = proxmox.rabbit
   }
 
-  hostname    = "seaweedfs-rabbit"
+  hostname    = local.rabbit_secrets.lxc.seaweedfs_rabbit_lxc
   vmid        = 809
   node_name   = "rabbit-01-psp"
   description = "SeaweedFS storage node - replication 100"

--- a/terraform/proxmox/rabbit/secrets.sops.yaml
+++ b/terraform/proxmox/rabbit/secrets.sops.yaml
@@ -1,0 +1,47 @@
+vm:
+    web1_vm: ENC[AES256_GCM,data:rsKlEpjaSkGRxNWsGIk=,iv:DtfeY54ehXCWdxl86yoA7ixvZIbTUrlIh9OH1I30NUY=,tag:6QVNQ0wl2G9llnmyn55/yA==,type:str]
+    rtmp1_vm: ENC[AES256_GCM,data:zKp4QdMXvR1a3h1BePA9,iv:JmBd5tQFdiWQ9i2wgWQcJzXWB6CJR/DmtuW37q/TOWk=,tag:N37Nn60WUu/5fpztioBlhQ==,type:str]
+    kubenuc_w4: ENC[AES256_GCM,data:ClRqgx9IQ2almg==,iv:XeBDqOcaIw6wlmbNKw4t7NZeLF+u85cWFHBe2+JAB4A=,tag:G1WPbdPKgFlRoips6xYUHw==,type:str]
+    debiandesktop: ENC[AES256_GCM,data:+T3FqqhNw51GDh4Sgw==,iv:STc8iRXK13gN9YydP24OoAuQyNwKHoSzDOaHn3WdbUM=,tag:7EhIVnt7tH1NJNJR5JqevQ==,type:str]
+    3cx: ENC[AES256_GCM,data:GiDD,iv:JTHN4K57m91nok16UOQlEkIoFdZb0I5ENOWj9Q2C2Qw=,tag:cdtzQPBrJ1Pnn8NRbriUag==,type:str]
+    squid_vm: ENC[AES256_GCM,data:NIHEtcadnmP5yTAdFv1V,iv:pId5r/Fuu059fUl2ADlR/E6cc51IWKdqHtF31qqAy9I=,tag:MWROUpx9pC6POmwniWZ9kg==,type:str]
+    kubenuc_m4: ENC[AES256_GCM,data:+QCvXJ2GrXRB8g==,iv:vmAlCSDL0NrpaOfJux9ThGa0szupHvxecAcyljqJQ1Y=,tag:Dsnh7et2Mm3TbyWCXLxH7Q==,type:str]
+    mail2_bioadventures: ENC[AES256_GCM,data:oYxg+eS/bzNNbFU+XrynhVlPS9ZcwQ==,iv:CxMCFUNQD/UoGLPwePur7PljHfPeVXo78Sp9h+hJ9wI=,tag:44Q+xgEe6nNzcQCcO5J+Cw==,type:str]
+    sophosxg: ENC[AES256_GCM,data:VeboDNjKTx8=,iv:XGc22dV0NFGBH81JkeOmDK0p9Sa2wddQbmHj00mRBRE=,tag:qpM8AU6nWtXeKMB6ci4KHg==,type:str]
+    docker: ENC[AES256_GCM,data:VinEpJcg,iv:2tdJRiWGVHUv9t9VPIjXb2Mh+HHmwRVYhxMD0l9OvAM=,tag:GPrAzi7Pvw1SAlYMotsMiA==,type:str]
+    runner: ENC[AES256_GCM,data:A10DHupA,iv:BWRn4h+Yt7G5j8uahJgzb4sRDynOKbZsnfhoQf9qYHk=,tag:TvyVnoGJiiNj87gmK+s4VQ==,type:str]
+    k3s_vm: ENC[AES256_GCM,data:Qa3B,iv:y+Nbn0qxh51U5itJ5Mf86iBHvroBP/hx28y40yOBty4=,tag:64SCSTaHsHoi6FViWKhGGw==,type:str]
+    kubenuc_m3: ENC[AES256_GCM,data:kINr3b1oX57lYQ==,iv:9lcx5RGxpp312brNAVEqOdLV+Y7IU3Ayn9YLmgUuoK4=,tag:KhFvUIv/y3dh0bFP/j1zGw==,type:str]
+    kubenuc_w3: ENC[AES256_GCM,data:hfSy3aiBullUYg==,iv:Q86tcaFRZoBWACQ0NLUxMbxXhGP9b7a134eJ5e/3DhI=,tag:Bc2qttjaRJ2xvwxBsCFnLQ==,type:str]
+lxc:
+    satisfactory_shared_lxc: ENC[AES256_GCM,data:6LvYPPzFHRP6ymJmvJMTKLU7pVpi1mioZhsg4Rg=,iv:4TLRS6nUMkm832BYLDQfFXB7ekJnog7fAadPtWe1/eQ=,tag:CCGISVK4tEKsPVkOqK337g==,type:str]
+    haproxy1: ENC[AES256_GCM,data:MLqzroy0e8W2RAxHVTKBUCvQ,iv:NLZ8dh3t+P+gXjy2A8TQaz1vNxiddGbf43EvL2oeq2U=,tag:3ZFN6dJ5yMB8HlRX4UHnRw==,type:str]
+    test_mail: ENC[AES256_GCM,data:U7VL0zxz8Xv5wzXZc9AvDDud9w==,iv:4cOtF7uV6fQ1oxqEZJCTRG/KvOtDzyoTE+YXuGPLJAc=,tag:NuA6GDZN3+R4YNjJ5EmC0Q==,type:str]
+    satisfactory_lxc: ENC[AES256_GCM,data:SK0R6B5bXkTrgnT/oZV7BQ0Nzl5K4w==,iv:IEbvI6pJ1+XQPNCDEYQmXD5EPsC0Y8wHAABX4qceztk=,tag:gLsKD7uCaEeGmJ/pP7CkHw==,type:str]
+    graylog: ENC[AES256_GCM,data:xDFeQ52Jgp+4jXn4GwsCYwY=,iv:s4ekv5WkKdFlNXYWfNxwU+uSqEudnPp2/l2VX1e0iH0=,tag:Mf2lxJcIj8XnCkL7ZHrzBw==,type:str]
+    pbs_01_psp: ENC[AES256_GCM,data:ECYAGyEAHgnfkGvrDqx5D25gjBc=,iv:fKk9pBRcPOdT9UjXabClWoTF7qPB5+pNnGlXfe4Ts04=,tag:/PxOvwtNT5ouOzB6e9KlTg==,type:str]
+    #ENC[AES256_GCM,data:av0XIwkKfb83cHJwTnP0r+eos3zxrWRmRJfF3WpeI8neImgy3tcQv0rXLVdhH0uFbRslWmZGnrYJ+6C9FAriPBS5J4ztqnQ6XtrD,iv:PM09qnPPjqG/FBeoOS9s3qEpwp0wSt3bfNxl1YyatOQ=,tag:emXsiGzza3MBKEUCmI9Nzw==,type:comment]
+    #ENC[AES256_GCM,data:RtZvPEdNjMIzrVVq/xAuC82tN7jUGq5uAnPTy6xfksHrw2lmc2xLNlDOcufiJwyLQcie4+YRB4VcUUolWn6KuFnYZtXPVcudul14qQ==,iv:HDb2QxbVWPRf5nMFuyT+Cob2JRhi0Pz3GSBoxTzMPd4=,tag:cuTSLdYFhKyGXgsuK77QhA==,type:comment]
+    #ENC[AES256_GCM,data:BqiXRWtVZh2rgpDTybhZyj8D3Yonth2JuyNb8Yq4bl9iTEkawzXSSTBxOqffJ5bpqhm9aV5ewTirxxmTRStc4p8S4xh8p0Dckw==,iv:VWFxpJCOeNCFhBsM3wXR3392Ur+6vKecLj/uGRzLzMw=,tag:vdWwkAwNSpikA74jobNAHQ==,type:comment]
+    squid_lxc: ENC[AES256_GCM,data:2j2mFCCJEhzAE9m/j1Sd,iv:LBaLOb27yWCcI4zaHuoC7i4b9b5AqXf+D9HvkxhHSsw=,tag:0Zg1ccGZaThoYyTZGIz57Q==,type:str]
+    #ENC[AES256_GCM,data:eo6guDfy9z/FgJg5yudvdLD/2B4hmCa5xKwspNmVHaVNGWu+7mqL8o/Uh2/1pKlkipOHdUARAv0ZDWPNcq8RMsmFFSBmA3WNlL7T,iv:gH0uQtcLGkMpetZC/injbtQibtlFLmJ2Q9TkDRihy6I=,tag:IYmHe/18VbeM+3DmF9gcmg==,type:comment]
+    #ENC[AES256_GCM,data:iVqLzuElKbeGNJK1RFu4xhmTocjbNa2WUeCZ5+Mg9JaaRfHPDINgQRNtIXEUjFJuq8/HmRZIJBCPSTH+cP5CIOY/R+svX1Ph0zbDSQ==,iv:Nio2OgSW4tpWkUnrApkrSrGYAM2U6mRlQov0Wun7uTQ=,tag:RK/vco14oInGZyGFFpJWdA==,type:comment]
+    #ENC[AES256_GCM,data:nrpT6TH+4QU2lc15ULHEnxWH+4IkQ7RzV19yl8E+XeYGPhK2eLs6pyOp61OnfYb9X28r1X2jICDqPv4xYpOe1sSe4fp5VF5G7A==,iv:82ppFR9YXhgVW6O/Gevru2VyM4BGTj2p9AALufX2uhg=,tag:PZ42VSp9GyFA+p0/2UTRHA==,type:comment]
+    rtmp1_lxc: ENC[AES256_GCM,data:oxVlLMScrtxi31STsy/P,iv:0E4EvM8jWKHcjE91VjCxO3ojMd1ZxkaEFR47flh+ZnE=,tag:59W5F6QJScvmrBL9gsE+tg==,type:str]
+    mon_bgy_lxc: ENC[AES256_GCM,data:x2658t2zxPkJMqqC8zf/QRY=,iv:RzNH73yC+FdmmniNmMvLhJYQMj5dOPlFLhwmZY/+DyQ=,tag:Dasqhp7urXN275C6Fptjig==,type:str]
+    seaweedfs_rabbit_lxc: ENC[AES256_GCM,data:1wOHsso5VQmz1k8gH5DMhA==,iv:pa05yd/xHoKsTYAOgJNY2h3czYDgozc7OF+Za89vzhY=,tag:9WFo8Pq8ZKpQE8SPEB6tYg==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaVy8yZFQ0Z1o4cFZ6SHpx
+            MnBpajFXSndZSC9la3ltclNUNmhPV2Nzc1JJCkVwSi9KSU5kTDBvWUVsMVdjR2cy
+            elpkMmkxN3U3dXhpKytXNlUxU0cyTGcKLS0tIHYyd09WeWYzSjV5WjZYYm9ET00z
+            dVNCaklIQ3FjU2crSlJ6UlRsUUtFUmMK+P+2zhgR6XH9KF82jts0l4mbd6nby53p
+            zmGtkdhwnPWNOK8zRM6UTIu0HG24bY8lA96LPB0fPUwEe+wYOcWYeQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1ygqcr24v9mnmmgaps0kascmh27j9qlk2dmz269lga06n3zjxdeps4znenj
+    lastmodified: "2026-08-08T20:08:04Z"
+    mac: ENC[AES256_GCM,data:9PJ7LSQ5c678M0QP6mAk/Rv5EBO4ys0/+1+PxDnPZ4rrX7UFYgLp3xkwzGCxfClHLS6o6sPgex+0A9MbVgQOdH/SVeNNACL4cmgWx68Ly2tYc+rdEXvDlYyFVUyFmVUvTYp5Wi1mYQ7UsEZx7XcNF1E3iVDjjfbgEG8/a728CFE=,iv:d0kPNet01x/SWqo1Neze/AyyjHE10km/8ZwWd719f5U=,tag:gpWarl9Uu+s+m2XFTnX0Wg==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.13.3

--- a/terraform/proxmox/rabbit/terraform.tf
+++ b/terraform/proxmox/rabbit/terraform.tf
@@ -23,5 +23,10 @@ terraform {
       source  = "hashicorp/external"
       version = "~> 2.3"
     }
+
+    sops = {
+      source  = "carlpett/sops"
+      version = "~> 1.1"
+    }
   }
 }

--- a/terraform/proxmox/rabbit/vm.tf
+++ b/terraform/proxmox/rabbit/vm.tf
@@ -4,7 +4,7 @@ module "rabbit_web1_ddlns_net_vm" {
     proxmox = proxmox.rabbit
   }
 
-  name        = "web1.ddlns.net"
+  name        = local.rabbit_secrets.vm.web1_vm
   vmid        = 501
   node_name   = "rabbit-01-psp"
   description = "Web1 Server"
@@ -60,7 +60,7 @@ module "rabbit_rtmp1_ddlns_net_vm" {
     proxmox = proxmox.rabbit
   }
 
-  name        = "rtmp1.ddlns.net"
+  name        = local.rabbit_secrets.vm.rtmp1_vm
   vmid        = 601
   node_name   = "rabbit-01-psp"
   description = "rtmp1 Server"
@@ -100,10 +100,10 @@ module "rabbit_kubenuc_w4_vm" {
     proxmox = proxmox.rabbit
   }
 
-  name        = "kubenuc-w4"
+  name        = local.rabbit_secrets.vm.kubenuc_w4
   vmid        = 4002
   node_name   = "rabbit-01-psp"
-  description = "kubenuc-w4"
+  description = local.rabbit_secrets.vm.kubenuc_w4
 
   cpu_cores   = 4
   cpu_sockets = 2
@@ -162,7 +162,7 @@ module "rabbit_debiandesktop_vm" {
     proxmox = proxmox.rabbit
   }
 
-  name        = "DebianDesktop"
+  name        = local.rabbit_secrets.vm.debiandesktop
   vmid        = 101
   node_name   = "rabbit-01-psp"
   description = "Debian-Desktop"
@@ -199,10 +199,10 @@ module "rabbit_r_3cx_vm" {
     proxmox = proxmox.rabbit
   }
 
-  name        = "3cx"
+  name        = local.rabbit_secrets.vm["3cx"]
   vmid        = 105
   node_name   = "rabbit-01-psp"
-  description = "3cx"
+  description = local.rabbit_secrets.vm["3cx"]
 
   cpu_cores = 2
   cpu_type  = "host"
@@ -243,10 +243,10 @@ module "rabbit_squid_ddlns_net_vm" {
     proxmox = proxmox.rabbit
   }
 
-  name        = "squid.ddlns.net"
+  name        = local.rabbit_secrets.vm.squid_vm
   vmid        = 104
   node_name   = "rabbit-01-psp"
-  description = "squid.ddlns.net"
+  description = local.rabbit_secrets.vm.squid_vm
 
   cpu_cores   = 1
   cpu_sockets = 2
@@ -282,10 +282,10 @@ module "rabbit_kubenuc_m4_vm" {
     proxmox = proxmox.rabbit
   }
 
-  name        = "kubenuc-m4"
+  name        = local.rabbit_secrets.vm.kubenuc_m4
   vmid        = 4003
   node_name   = "rabbit-01-psp"
-  description = "kubenuc-m4"
+  description = local.rabbit_secrets.vm.kubenuc_m4
 
   cpu_cores = 2
   cpu_type  = "host"
@@ -333,10 +333,10 @@ module "rabbit_mail2_bioadventures_eu_vm" {
     proxmox = proxmox.rabbit
   }
 
-  name        = "mail2.bioadventures.eu"
+  name        = local.rabbit_secrets.vm.mail2_bioadventures
   vmid        = 1001
   node_name   = "rabbit-01-psp"
-  description = "mail2.bioadventures.eu"
+  description = local.rabbit_secrets.vm.mail2_bioadventures
 
   bios_type = "ovmf"
 
@@ -394,10 +394,10 @@ module "rabbit_sophosxg_vm" {
     proxmox = proxmox.rabbit
   }
 
-  name        = "SophosXG"
+  name        = local.rabbit_secrets.vm.sophosxg
   vmid        = 100
   node_name   = "rabbit-01-psp"
-  description = "SophosXG"
+  description = local.rabbit_secrets.vm.sophosxg
 
   cpu_cores   = 2
   cpu_sockets = 2
@@ -452,10 +452,10 @@ module "rabbit_docker_vm" {
     proxmox = proxmox.rabbit
   }
 
-  name        = "docker"
+  name        = local.rabbit_secrets.vm.docker
   vmid        = 103
   node_name   = "rabbit-01-psp"
-  description = "docker"
+  description = local.rabbit_secrets.vm.docker
 
   cpu_cores   = 2
   cpu_sockets = 2
@@ -499,10 +499,10 @@ module "rabbit_runner_vm" {
     proxmox = proxmox.rabbit
   }
 
-  name        = "runner"
+  name        = local.rabbit_secrets.vm.runner
   vmid        = 5000
   node_name   = "rabbit-01-psp"
-  description = "runner"
+  description = local.rabbit_secrets.vm.runner
 
   cpu_cores   = 6
   cpu_sockets = 2
@@ -552,10 +552,10 @@ module "rabbit_k3s_vm" {
     proxmox = proxmox.rabbit
   }
 
-  name        = "k3s"
+  name        = local.rabbit_secrets.vm.k3s_vm
   vmid        = 102
   node_name   = "rabbit-01-psp"
-  description = "k3s"
+  description = local.rabbit_secrets.vm.k3s_vm
 
   cpu_cores   = 4
   cpu_sockets = 2
@@ -588,10 +588,10 @@ module "rabbit_kubenuc_m3_vm" {
     proxmox = proxmox.rabbit
   }
 
-  name        = "kubenuc-m3"
+  name        = local.rabbit_secrets.vm.kubenuc_m3
   vmid        = 4000
   node_name   = "rabbit-01-psp"
-  description = "kubenuc-m3"
+  description = local.rabbit_secrets.vm.kubenuc_m3
 
   cpu_cores   = 1
   cpu_sockets = 2
@@ -642,10 +642,10 @@ module "rabbit_kubenuc_w3_vm" {
     proxmox = proxmox.rabbit
   }
 
-  name        = "kubenuc-w3"
+  name        = local.rabbit_secrets.vm.kubenuc_w3
   vmid        = 4001
   node_name   = "rabbit-01-psp"
-  description = "kubenuc-w3"
+  description = local.rabbit_secrets.vm.kubenuc_w3
 
   cpu_cores   = 4
   cpu_sockets = 2


### PR DESCRIPTION
## Summary
- Moves hardcoded VM/LXC hostnames in `terraform/proxmox/rabbit/` and `terraform/proxmox/gozzi-hpelvisor/` into per-stack SOPS-encrypted `secrets.sops.yaml` files (via the `carlpett/sops` provider), per root `CLAUDE.md`'s ban on hardcoded hostnames/FQDNs. Each stack has its own freshly generated, dedicated age keypair (`SOPS_AGE_KEY_PSP` / `SOPS_AGE_KEY_BIO`), matching the existing per-stack key convention already used by `terraform/DNS/`, `terraform/cloudflare-tunnel/`, and `terraform/netbox/`.
- Every touched `name`/`hostname`/`description` literal was byte-matched against its decrypted secret before conversion. CI plan output on every touched resource showed only the expected Terraform sensitivity-transition diff (`~ attr = (sensitive value)`, explicitly annotated "the value is unchanged") — no real infrastructure changes from the hostname migration itself.
- **`terraform/netbox/` is dropped from this PR.** The original plan assumed `terraform/netbox/secrets.sops.yaml`'s `vms:` map already held pre-encrypted hostname values reusable for `vms-onprem.tf`. Direct verification showed that map actually holds IPv4 CIDRs (already consumed as `ip_address` in `ipam.tf`), not hostnames — the plan had confused the map's keys (hostname-derived names) with its values (IPs). Executing that part as originally planned would have set `netbox_virtual_machine.name` to an IP/CIDR string across 41 resources on a workflow that auto-applies on push to `main`. Netbox hostname deduplication needs its own correctly-scoped follow-up (a new key namespace, no reuse of the IP map).
- **Explicitly out of scope** (tracked as a possible follow-up, not silently dropped): `node_name` literals, hostname-derived `tags` entries, static IPs, and commented-out/inactive module blocks.

## Post-merge apply results
- 39 of 41 touched resources applied cleanly on merge. 2 resources (`rabbit_graylog_ddlns_net_lxc`, `hpelvisor_gen8_runner_vm`) were blocked by pre-existing `disk_size` drift between code and live Proxmox disks (both predate this PR — the SOPS migration never touched disk attributes). Both fixed and merged separately: #1820 (graylog, live disk 100G vs code's 80G) and #1821 (gen8_runner, live disk 245G vs code's 138G).
- Both follow-up PRs' post-apply plans showed **"No changes. Your infrastructure matches the configuration"** — confirming both resources' hostname/description changes had already applied successfully during the original merge (the provider updates attributes independently; only the disk-size call failed), and the disk-size fixes were the only remaining gap.

## Test plan
- [x] `terraform fmt -check` clean on all touched files
- [x] Pre-flight byte-match: every converted literal matches its decrypted SOPS value exactly, before conversion
- [x] CI `terraform plan` on this PR: rabbit shows `24 to change` (all 24 touched resources, each only the sensitivity-transition cosmetic diff; 2 resources also showed pre-existing unrelated drift — disk size, started state — that predates this PR)
- [x] CI `terraform plan` on this PR: gozzi-hpelvisor shows `17 to change` (all 17 touched resources, purely sensitivity-transition diffs, no other drift)
- [x] `terraform validate` passed in CI on every run, both stacks
- [x] CLAUDE.md and terraform/CLAUDE.md documentation updates landed (per-stack 1Password/SOPS breakdown)
- [x] Post-merge apply verified end-to-end: all 41 hostname migrations are live and clean (2 required the disk-size follow-ups above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)