### PR TITLE
fix(proxmox-rabbit): correct graylog LXC disk_size drift

### DIFF
--- a/terraform/proxmox/rabbit/lxc.tf
+++ b/terraform/proxmox/rabbit/lxc.tf
@@ -189,7 +189,7 @@ module "rabbit_graylog_ddlns_net_lxc" {
   cpu_limit      = 6
   memory         = 16384
   swap           = 4096
-  disk_size      = 80
+  disk_size      = 100
   disk_datastore = "data-ssd"
 
   template_file_id = proxmox_download_file.rabbit_ubuntu_24_04_lxc.id


### PR DESCRIPTION
## Summary
- PR #1819's post-merge apply failed on `rabbit_graylog_ddlns_net_lxc` with `new disk size (80G) has to be greater than the current disk (100G)` — Proxmox disks can't be shrunk via this provider.
- The code's `disk_size = 80` predates #1819 entirely (not something that PR touched); it just happened to block that PR's hostname/SOPS change for this one resource from applying, since Terraform rejects the whole resource update atomically.
- Bumps `disk_size` to `100` to match the live disk, unblocking the next apply.

## Test plan
- [x] `terraform fmt -check` clean
- [x] CI `terraform plan` shows `graylog` moving from blocked to a clean apply (no more disk-size error); on merge, expect the apply to pick up both the disk-size correction and the still-pending hostname/description SOPS values for this resource

🤖 Generated with [Claude Code](https://claude.com/claude-code)