### PR TITLE
fix(proxmox-gozzi-hpelvisor): correct gen8_runner disk_size drift

### DIFF
--- a/terraform/proxmox/gozzi-hpelvisor/hpelvisor-generated.tf
+++ b/terraform/proxmox/gozzi-hpelvisor/hpelvisor-generated.tf
@@ -125,7 +125,7 @@ module "hpelvisor_gen8_runner_vm" {
     boot = {
       datastore_id = "data-hdd"
       interface    = "scsi0"
-      size         = 138
+      size         = 245
       ssd          = false
       discard      = "ignore"
     }


### PR DESCRIPTION
## Summary
- PR #1819's post-merge apply failed on `hpelvisor_gen8_runner_vm` (VM 3000) with `Cannot shrink data-hdd:vm-3000-disk-1 in VM 3000, it is not supported!` — Proxmox disks can't be shrunk via this provider.
- The code's `disks.boot.size = 138` predates #1819 entirely; it just blocked that PR's hostname/SOPS change for this one resource from applying. Live disk size (245G) was confirmed from the plan's own refresh-drift diff (`size = 245 -> 138`), not guessed.
- Bumps `size` to `245` to match the live disk, unblocking the next apply. Same fix pattern and root cause as #1820 (graylog).

## Test plan
- [x] `terraform fmt -check` clean
- [x] CI `terraform plan` shows `gen8_runner` moving from blocked to a clean apply; on merge, expect a no-op apply picking up both the disk-size correction and the already-pending hostname/description SOPS values for this resource (same pattern observed in #1820)

🤖 Generated with [Claude Code](https://claude.com/claude-code)