### PR TITLE
fix(terraform): start mon-bgy LXC monitoring container

### DIFF
--- a/terraform/proxmox/rabbit/lxc.tf
+++ b/terraform/proxmox/rabbit/lxc.tf
@@ -395,7 +395,7 @@ module "rabbit_mon_bgy_lxc" {
   password     = data.onepassword_item.lxc_access.password
   unprivileged = true
 
-  started       = false
+  started       = true
   start_on_boot = false
 
   manage_user_account = true


### PR DESCRIPTION
## Summary
- Sets `started = true` for `rabbit_mon_bgy_lxc` (`terraform/proxmox/rabbit/lxc.tf`) so the container actually runs. It was previously created with `started = false`.
- This container's Terraform state was separately removed (`terraform state rm`) after confirming its stored SSH keys/root password never actually took effect on the live container (both SSH key auth and console password login failed, despite state holding values that match current config). Merging this PR will recreate the container fresh via a normal `pct create`, which should correctly apply today's credentials.

## Context
Related module-side documentation PR: dark-vex/terraform-proxmox-lxc#1 (explains why `initialization.user_account` must stay in the module's `lifecycle.ignore_changes` — it's `ForceNew` in the provider schema, so removing that ignore would conflict with `prevent_destroy` on any real credential diff, rather than update in place).

## Test plan
- [ ] CI plan (`terraform-psp.yml`) shows a `create` for `module.rabbit_mon_bgy_lxc.proxmox_virtual_environment_container.this` (expected, since it was removed from state) plus the `started` flag flip — no other resources should show a diff
- [ ] After merge/apply, verify SSH key auth and console root password both work on the recreated container