### PR TITLE
fix(terraform): assign static IP and MAC to mon-bgy LXC container

### DIFF
--- a/terraform/proxmox/rabbit/lxc.tf
+++ b/terraform/proxmox/rabbit/lxc.tf
@@ -381,9 +381,11 @@ module "rabbit_mon_bgy_lxc" {
   os_type          = "ubuntu"
 
   network_bridge         = "vmbr1"
+  network_mac_address    = "BC:24:11:33:75:CB"
   network_interface_name = "eth0"
   ip_config = {
-    ipv4_address = "dhcp"
+    ipv4_address = "10.10.20.107/24"
+    ipv4_gateway = "10.10.20.1"
   }
 
   console = {}


### PR DESCRIPTION
## Summary
- Moves `rabbit_mon_bgy_lxc` (`terraform/proxmox/rabbit/lxc.tf`) from DHCP to a static IPv4 address + gateway, and pins the network MAC address — matching the convention already used by its sibling LXC blocks in this file.

## Context
Follow-up to #1824 (mon-bgy credential/start fix). This container's Terraform state is currently being removed and the live container manually deleted for a clean recreate; this PR's config will apply to the fresh container once that's done.

## Test plan
- [ ] CI plan (`terraform-psp.yml`) shows only `network_interface`/`initialization.ip_config` changes (or a full `create` if the state-rm/delete has already happened) for `module.rabbit_mon_bgy_lxc` — no other resources affected
- [ ] Hold merge until the manual state-rm + container delete is confirmed complete