### PR TITLE
docs(kubenuc): remove hardcoded domain from cloudflare-api-token.yml comment

### DIFF
--- a/clusters/kubenuc/apps/external-dns/secrets/cloudflare-api-token.yml
+++ b/clusters/kubenuc/apps/external-dns/secrets/cloudflare-api-token.yml
@@ -6,6 +6,6 @@ metadata:
 spec:
   # Create this item in 1Password with a field:
   #   api-token - Cloudflare API token scoped to Zone:Read + DNS:Edit on
-  #               ddlns.net (the zone this cluster's app Ingress hosts
-  #               live in)
+  #               this cluster's managed zone (see domainFilters in
+  #               manifests/release.yml for the exact value)
   itemPath: "vaults/k8s_secrets/items/Cloudflare_kubenuc"


### PR DESCRIPTION
## Summary
- Missed sibling of the k8s-vms-daniele fix in #1826 — same `OnePasswordItem` comment pattern in `clusters/kubenuc/apps/external-dns/secrets/cloudflare-api-token.yml` hardcoded the domain, just not caught by the original scan.
- Comment-only, zero runtime effect.

## Test plan
- [x] YAML validated