### PR TITLE
fix(ansible): Alloy CLI flag + pip PEP 668 crash-loop in pve-host-netmon/pve-monitoring

### DIFF
--- a/ansible/CLAUDE.md
+++ b/ansible/CLAUDE.md
@@ -36,6 +36,8 @@ docker compose exec -w /workspace/ansible/{role-name} ansible-agent molecule tes
 
 **verify.yml**: Assert `UnitFileState == "enabled"` — do NOT assert `active` state for services that depend on external infra.
 
+Do NOT add `ignore_errors: true` to the start task based on this pattern. A genuinely bad config (wrong CLI flag, malformed file) also makes the start task fail in Molecule, and `ignore_errors: true` swallows that identically to an external-connectivity failure — this is exactly how `pve-host-netmon` shipped with Alloy crash-looping in production (`alloy run` was passed a nonexistent `--config.file` flag) undetected by Molecule. If a start task fails, check `journalctl -u <service>` for the real cause before assuming it's connectivity — Alloy's `remote_write`, in particular, does not block startup even fully offline.
+
 **`defaults/main.yml` doesn't auto-load without a real role**: Ansible only auto-loads a directory's `defaults/main.yml` when that directory is invoked as a role (`roles:`, `include_role`, `import_role`). Every role in this repo is wired into its `playbook.yml` via flat `ansible.builtin.import_tasks` on `tasks/main.yml`, not as a real role, so `defaults/main.yml` silently never loads on a real run — same bug class as the template-path gotcha above, where `import_tasks` drops role-relative magic Molecule's `converge.yml` can mask by loading the file explicitly via `vars_files`, staying green while the real playbook fails on the first undefined var. Non-secret vars belong in `group_vars/` (auto-loads for both the real playbook and Molecule from inventory group membership), never in a `defaults/main.yml`. Confirmed via repo-wide grep: no role under `ansible/` has a `defaults/` directory.
 
 ---

--- a/ansible/pve-host-netmon/molecule/default/verify.yml
+++ b/ansible/pve-host-netmon/molecule/default/verify.yml
@@ -93,10 +93,22 @@
     # /etc/default/alloy
     # -------------------------------------------------------------------------
 
-    - name: Check /etc/default/alloy has CUSTOM_ARGS line
+    - name: Check /etc/default/alloy has CONFIG_FILE line
       ansible.builtin.command:
-        cmd: grep -q "CUSTOM_ARGS=" /etc/default/alloy
+        cmd: grep -q "CONFIG_FILE=" /etc/default/alloy
       changed_when: false
+
+    - name: Check /etc/default/alloy does not pass --config.file via CUSTOM_ARGS
+      ansible.builtin.command:
+        cmd: grep -q -- "--config.file" /etc/default/alloy
+      register: alloy_bad_flag_check
+      changed_when: false
+      failed_when: false
+
+    - name: Assert --config.file flag is not present
+      ansible.builtin.assert:
+        that: alloy_bad_flag_check.rc != 0
+        fail_msg: "/etc/default/alloy still contains the invalid '--config.file' flag; alloy run has no such flag and will crash-loop"
 
     # -------------------------------------------------------------------------
     # Alloy service enabled
@@ -111,6 +123,11 @@
       ansible.builtin.assert:
         that: alloy_service_info.status.UnitFileState == "enabled"
         fail_msg: "alloy service is not enabled (state: {{ alloy_service_info.status.UnitFileState }})"
+
+    - name: Assert alloy service is active
+      ansible.builtin.assert:
+        that: alloy_service_info.status.ActiveState == "active"
+        fail_msg: "alloy is not active ({{ alloy_service_info.status.ActiveState }}) — check journalctl -u alloy"
 
     # -------------------------------------------------------------------------
     # Ensure pve-exporter was NOT installed by this role

--- a/ansible/pve-host-netmon/tasks/main.yml
+++ b/ansible/pve-host-netmon/tasks/main.yml
@@ -58,8 +58,17 @@
 - name: Configure Alloy to use custom config path
   ansible.builtin.lineinfile:
     path: /etc/default/alloy
+    regexp: '^CONFIG_FILE='
+    line: 'CONFIG_FILE="{{ alloy_config_dir }}/config.alloy"'
+    create: true
+    mode: "0644"
+  notify: Restart alloy
+
+- name: Reset Alloy CUSTOM_ARGS to package default
+  ansible.builtin.lineinfile:
+    path: /etc/default/alloy
     regexp: '^CUSTOM_ARGS='
-    line: 'CUSTOM_ARGS="--config.file {{ alloy_config_dir }}/config.alloy"'
+    line: 'CUSTOM_ARGS=""'
     create: true
     mode: "0644"
   notify: Restart alloy
@@ -75,4 +84,3 @@
     name: alloy
     state: started
   changed_when: false
-  ignore_errors: true

--- a/ansible/pve-monitoring/molecule/default/verify.yml
+++ b/ansible/pve-monitoring/molecule/default/verify.yml
@@ -52,6 +52,18 @@
       ansible.builtin.command: pip3 show prometheus-pve-exporter
       changed_when: false
 
+    - name: Check pve_exporter console-script landed at the path the systemd unit expects
+      ansible.builtin.stat:
+        path: /usr/local/bin/pve_exporter
+      register: pve_exporter_bin
+
+    - name: Assert pve_exporter binary is present and executable
+      ansible.builtin.assert:
+        that:
+          - pve_exporter_bin.stat.exists
+          - pve_exporter_bin.stat.executable
+        fail_msg: "/usr/local/bin/pve_exporter not found or not executable — pip3 show alone doesn't prove this"
+
     # -------------------------------------------------------------------------
     # Grafana Alloy
     # -------------------------------------------------------------------------
@@ -107,10 +119,22 @@
         that: alloy_url_check.rc == 0
         fail_msg: "Expected grafana_prometheus_url not found in /etc/alloy/config.alloy"
 
-    - name: Check /etc/default/alloy has CUSTOM_ARGS set
+    - name: Check /etc/default/alloy has CONFIG_FILE set
       ansible.builtin.command:
-        cmd: grep -q "CUSTOM_ARGS=" /etc/default/alloy
+        cmd: grep -q "CONFIG_FILE=" /etc/default/alloy
       changed_when: false
+
+    - name: Check /etc/default/alloy does not pass --config.file via CUSTOM_ARGS
+      ansible.builtin.command:
+        cmd: grep -q -- "--config.file" /etc/default/alloy
+      register: alloy_bad_flag_check
+      changed_when: false
+      failed_when: false
+
+    - name: Assert --config.file flag is not present
+      ansible.builtin.assert:
+        that: alloy_bad_flag_check.rc != 0
+        fail_msg: "/etc/default/alloy still contains the invalid '--config.file' flag; alloy run has no such flag and will crash-loop"
 
     - name: Check pve-exporter service is enabled
       ansible.builtin.systemd:
@@ -131,3 +155,8 @@
       ansible.builtin.assert:
         that: alloy_service_info.status.UnitFileState == "enabled"
         fail_msg: "alloy service is not enabled (state: {{ alloy_service_info.status.UnitFileState }})"
+
+    - name: Assert alloy service is active
+      ansible.builtin.assert:
+        that: alloy_service_info.status.ActiveState == "active"
+        fail_msg: "alloy is not active ({{ alloy_service_info.status.ActiveState }}) — check journalctl -u alloy"

--- a/ansible/pve-monitoring/tasks/main.yml
+++ b/ansible/pve-monitoring/tasks/main.yml
@@ -37,11 +37,15 @@
     group: "{{ pve_exporter_user }}"
     mode: "0750"
 
+# --break-system-packages: target LXCs run Ubuntu 24.04 (PEP 668-enforced
+# Python), and pve-exporter.service.j2's ExecStart hardcodes the console-script
+# path a system-wide install produces — no apt package or venv change needed.
 - name: Install prometheus-pve-exporter via pip
   ansible.builtin.pip:
     name: "prometheus-pve-exporter=={{ pve_exporter_version }}"
     executable: pip3
     state: present
+    extra_args: --break-system-packages
 
 - name: Deploy pve-exporter config
   ansible.builtin.template:
@@ -118,8 +122,17 @@
 - name: Configure Alloy to use custom config path
   ansible.builtin.lineinfile:
     path: /etc/default/alloy
+    regexp: '^CONFIG_FILE='
+    line: 'CONFIG_FILE="{{ alloy_config_dir }}/config.alloy"'
+    create: true
+    mode: "0644"
+  notify: Restart alloy
+
+- name: Reset Alloy CUSTOM_ARGS to package default
+  ansible.builtin.lineinfile:
+    path: /etc/default/alloy
     regexp: '^CUSTOM_ARGS='
-    line: 'CUSTOM_ARGS="--config.file {{ alloy_config_dir }}/config.alloy"'
+    line: 'CUSTOM_ARGS=""'
     create: true
     mode: "0644"
   notify: Restart alloy


### PR DESCRIPTION
## Summary
- `alloy run` has no `--config.file` flag — the config path is positional, sourced from the `$CONFIG_FILE` env var. Both `pve-host-netmon` and `pve-monitoring` were passing it via `CUSTOM_ARGS="--config.file ..."`, causing Alloy to crash-loop (`unknown flag: --config.file`, `start-limit-hit`) in production. Fixed both roles to set `CONFIG_FILE=` instead, and added a task to reset any stale `CUSTOM_ARGS` left behind by the old buggy config on already-converged hosts.
- Removed a stray `ignore_errors: true` on `pve-host-netmon`'s "Start Alloy service" task that was masking this exact crash under the mistaken assumption that Alloy always fails to start in network-isolated Molecule containers — it doesn't; `remote_write` failures don't block startup.
- Strengthened both roles' `molecule/default/verify.yml`: a negative check that `--config.file` never reappears, and an `ActiveState == "active"` assertion for the `alloy` service (previously only `UnitFileState == "enabled"` was checked, which is exactly why the crash-loop shipped undetected).
- Separately, `pve-monitoring`'s pip install of `prometheus-pve-exporter` was failing on PEP 668 ("externally-managed-environment") — the real target LXCs run Ubuntu 24.04, which enforces this by default, and there's no apt-packaged alternative. Fixed with `extra_args: --break-system-packages`, matching this repo's existing pattern for the same issue in `docker/agents/terraform/Dockerfile` and `docker/semaphore-runner/Dockerfile`. Added a `verify.yml` check that the `pve_exporter` console-script actually lands where the systemd unit's `ExecStart` expects it (not just that `pip3 show` succeeds).
- `ansible/CLAUDE.md` updated: don't add `ignore_errors: true` to a service-start task based on the "external deps crash in Molecule" pattern — check `journalctl` for the real cause first.

## Test plan
- [x] `ansible-lint` clean on all changed files
- [x] `pve-host-netmon`: full `molecule test` green (converge, idempotence, all verify assertions)
- [x] `pve-monitoring`: full `molecule test` green end-to-end for the first time this session (converge, idempotence, 29 verify assertions)
- [x] Manually simulated a previously-broken host's `/etc/default/alloy` (stale `CUSTOM_ARGS`) and re-converged — confirmed it self-heals to `active (running)`
- [x] Reviewed independently by both Codex and a second Claude reviewer across two rounds; all confirmed findings addressed
- [x] Re-run against the real production host(s) to confirm Alloy stays up and metrics land in Grafana Cloud

🤖 Generated with [Claude Code](https://claude.com/claude-code)