### PR TITLE
fix(terraform,grafana): fix rabbit-netbw iface name, add 25TB quota alert

### DIFF
--- a/terraform/grafana/alerting.tf
+++ b/terraform/grafana/alerting.tf
@@ -207,3 +207,100 @@ resource "grafana_rule_group" "backup_cronjob_guard" {
     }
   }
 }
+
+# ---------------------------------------------------------------------------
+# rabbit-01-psp is capped at 25 TB/month of physical-NIC bandwidth by its
+# housing provider (see ansible/pve-host-netmon/). Tracks a trailing 30-day
+# increase() (not calendar month-to-date — grafana_rule_group has no "now/M"
+# calendar-alignment primitive) against 90% of the cap, the same "orange"
+# tier used by the dashboard's gauge/stat panels. Evaluated hourly since a
+# 30d range query on a slow-moving counter doesn't need 5m granularity;
+# `for` is set to a few eval cycles so a single noisy evaluation can't fire
+# it. Rolling 30d, not calendar month — see plan doc / PR description for
+# why, and note it under-reads (fires late, not early) across any collector
+# gap since increase() can't count samples that were never scraped.
+# ---------------------------------------------------------------------------
+resource "grafana_rule_group" "rabbit_netbw_quota_guard" {
+  name             = "rabbit-netbw-quota-guard"
+  folder_uid       = grafana_folder.alerting.uid
+  interval_seconds = 3600
+
+  rule {
+    name           = "RabbitNetbwApproachingMonthlyQuota"
+    condition      = "B"
+    for            = "3h"
+    no_data_state  = "NoData"
+    exec_err_state = "Alerting"
+
+    data {
+      ref_id = "A"
+
+      relative_time_range {
+        from = 2592000 # 30d
+        to   = 0
+      }
+
+      datasource_uid = "grafanacloud-prom"
+      model = jsonencode({
+        refId         = "A"
+        expr          = "(sum(increase(node_network_receive_bytes_total{site=\"bgy\",device=\"eth0\",instance=\"rabbit-01-psp\"}[30d])) + sum(increase(node_network_transmit_bytes_total{site=\"bgy\",device=\"eth0\",instance=\"rabbit-01-psp\"}[30d]))) / 25000000000000.0 * 100"
+        instant       = true
+        range         = false
+        intervalMs    = 1000
+        maxDataPoints = 43200
+      })
+    }
+
+    data {
+      ref_id = "B"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "-100"
+      model = jsonencode({
+        refId = "B"
+        type  = "classic_conditions"
+        datasource = {
+          type = "__expr__"
+          uid  = "-100"
+        }
+        conditions = [
+          {
+            evaluator = {
+              type   = "gt"
+              params = [90]
+            }
+            operator = {
+              type = "and"
+            }
+            query = {
+              params = ["A"]
+            }
+            reducer = {
+              type   = "last"
+              params = []
+            }
+            type = "query"
+          }
+        ]
+      })
+    }
+
+    labels = {
+      severity = "warning"
+    }
+
+    annotations = {
+      summary     = "rabbit-01-psp is approaching its 25 TB/month bandwidth quota"
+      description = "Trailing 30-day rx+tx on eth0 (site=bgy, instance=rabbit-01-psp) is above 90% of the 25 TB housing cap. This is a rolling 30-day window, not calendar month-to-date, and under-reads across any collector gap - check the 'rabbit-01-psp — Network Bandwidth' dashboard (proxmox folder, uid pve-rabbit-netbw) for the exact month-to-date figure before deciding whether to throttle or contact the provider."
+    }
+
+    notification_settings {
+      contact_point = grafana_contact_point.infra_slack.name
+      group_by      = ["alertname"]
+    }
+  }
+}

--- a/terraform/grafana/dashboards/proxmox/rabbit-netbw.json
+++ b/terraform/grafana/dashboards/proxmox/rabbit-netbw.json
@@ -51,7 +51,7 @@
       },
       "targets": [
         {
-          "expr": "(sum(increase(node_network_receive_bytes_total{site=\"bgy\",device=\"eno1\"}[$__range])) + sum(increase(node_network_transmit_bytes_total{site=\"bgy\",device=\"eno1\"}[$__range]))) / 25000000000000.0 * 100",
+          "expr": "(sum(increase(node_network_receive_bytes_total{site=\"bgy\",device=\"eth0\",instance=\"rabbit-01-psp\"}[$__range])) + sum(increase(node_network_transmit_bytes_total{site=\"bgy\",device=\"eth0\",instance=\"rabbit-01-psp\"}[$__range]))) / 25000000000000.0 * 100",
           "legendFormat": "",
           "refId": "A",
           "instant": true
@@ -119,7 +119,7 @@
       },
       "targets": [
         {
-          "expr": "sum(increase(node_network_receive_bytes_total{site=\"bgy\",device=\"eno1\"}[$__range])) + sum(increase(node_network_transmit_bytes_total{site=\"bgy\",device=\"eno1\"}[$__range]))",
+          "expr": "sum(increase(node_network_receive_bytes_total{site=\"bgy\",device=\"eth0\",instance=\"rabbit-01-psp\"}[$__range])) + sum(increase(node_network_transmit_bytes_total{site=\"bgy\",device=\"eth0\",instance=\"rabbit-01-psp\"}[$__range]))",
           "legendFormat": "",
           "refId": "A",
           "instant": true
@@ -186,7 +186,7 @@
       },
       "targets": [
         {
-          "expr": "25000000000000.0 - (sum(increase(node_network_receive_bytes_total{site=\"bgy\",device=\"eno1\"}[$__range])) + sum(increase(node_network_transmit_bytes_total{site=\"bgy\",device=\"eno1\"}[$__range])))",
+          "expr": "25000000000000.0 - (sum(increase(node_network_receive_bytes_total{site=\"bgy\",device=\"eth0\",instance=\"rabbit-01-psp\"}[$__range])) + sum(increase(node_network_transmit_bytes_total{site=\"bgy\",device=\"eth0\",instance=\"rabbit-01-psp\"}[$__range])))",
           "legendFormat": "",
           "refId": "A",
           "instant": true
@@ -253,7 +253,7 @@
       },
       "targets": [
         {
-          "expr": "(sum(increase(node_network_receive_bytes_total{site=\"bgy\",device=\"eno1\"}[$__range])) + sum(increase(node_network_transmit_bytes_total{site=\"bgy\",device=\"eno1\"}[$__range]))) / ($__range_s / 86400)",
+          "expr": "(sum(increase(node_network_receive_bytes_total{site=\"bgy\",device=\"eth0\",instance=\"rabbit-01-psp\"}[$__range])) + sum(increase(node_network_transmit_bytes_total{site=\"bgy\",device=\"eth0\",instance=\"rabbit-01-psp\"}[$__range]))) / ($__range_s / 86400)",
           "legendFormat": "",
           "refId": "A",
           "instant": true
@@ -307,7 +307,7 @@
     },
     {
       "id": 7,
-      "title": "Inbound / Outbound Rate (eno1)",
+      "title": "Inbound / Outbound Rate (eth0)",
       "type": "timeseries",
       "datasource": {
         "uid": "grafanacloud-prom",
@@ -321,12 +321,12 @@
       },
       "targets": [
         {
-          "expr": "rate(node_network_receive_bytes_total{site=\"bgy\",device=\"eno1\"}[1h])",
+          "expr": "rate(node_network_receive_bytes_total{site=\"bgy\",device=\"eth0\",instance=\"rabbit-01-psp\"}[1h])",
           "legendFormat": "\u2193 rx",
           "refId": "A"
         },
         {
-          "expr": "rate(node_network_transmit_bytes_total{site=\"bgy\",device=\"eno1\"}[1h])",
+          "expr": "rate(node_network_transmit_bytes_total{site=\"bgy\",device=\"eth0\",instance=\"rabbit-01-psp\"}[1h])",
           "legendFormat": "\u2191 tx",
           "refId": "B"
         }

--- a/terraform/grafana/generate_dashboards.py
+++ b/terraform/grafana/generate_dashboards.py
@@ -500,9 +500,9 @@ def build_rabbit_netbw(uid_str):
     LIMIT = 25e12  # 25 TB in bytes
     site = "bgy"
 
-    iface = "eno1"
-    rx = f'node_network_receive_bytes_total{{site="{site}",device="{iface}"}}'
-    tx = f'node_network_transmit_bytes_total{{site="{site}",device="{iface}"}}'
+    iface = "eth0"
+    rx = f'node_network_receive_bytes_total{{site="{site}",device="{iface}",instance="rabbit-01-psp"}}'
+    tx = f'node_network_transmit_bytes_total{{site="{site}",device="{iface}",instance="rabbit-01-psp"}}'
     total_mtd = f"sum(increase({rx}[$__range])) + sum(increase({tx}[$__range]))"
 
     panels = []


### PR DESCRIPTION
## Summary

- **Fix 1**: `rabbit-netbw` dashboard was generated (in #1383) before any real metrics ever flowed to Grafana Cloud, so its interface-name assumption (`device="eno1"`) was never validated. Now that #1834/#1835 fixed the two crash-loop bugs blocking ingestion, live data confirms the physical NIC actually reports as `device="eth0"`. Also pins `instance="rabbit-01-psp"` on the dashboard query so a second BGY host ever emitting `eth0` can't silently get summed into this host's totals.
- **Fix 2**: Adds the alert PR #1383's test plan left unchecked — `grafana_rule_group.rabbit_netbw_quota_guard` pages via Slack when the trailing 30-day rx+tx on `eth0` crosses 90% of the 25 TB/month housing-provider bandwidth cap, following the same shape as `active_series_guard`/`backup_cronjob_guard`. Uses a rolling 30-day `increase()` rather than calendar month-to-date, since `grafana_rule_group` has no calendar-alignment primitive equivalent to the dashboard's `now/M` trick — documented in the rule's header comment, including the caveat that this under-reads (fires late, not early) across any collector gap.

## Side note (not part of this PR's diff)

Regenerating dashboards via `generate_dashboards.py` also reverted 8 hand-added panels in `dashboards/kubenuc/postgresql.json` that were never ported back into `build_postgresql()` (introduced in PR #1542). That drift-revert was discarded via `git checkout --` before staging — only `rabbit-netbw.json` and `alerting.tf`/`generate_dashboards.py` are in this PR. Filing a separate follow-up to port those 8 panels into the generator so the next unrelated regenerate doesn't hit the same trap.

## Documentation routing

Ran this through the `documentation` skill per top-level `CLAUDE.md` rule 11. Conclusion: no README/CLAUDE.md/Confluence update needed. `terraform/grafana/` has no README, and the alert's rationale (90% threshold choice, rolling-30-day-vs-calendar-month caveat, `NoData`/`exec_err_state` paging behavior) is already fully captured in `alerting.tf`'s inline comment block — matching this file's established convention (per PR #1638) of documenting alert-rule gotchas as comments above each `grafana_rule_group`, not in a separate doc. The original #1383 test-plan item that this closes out lived only in that PR's description, never checked into a repo doc, so there's no stale checklist elsewhere to update either.

## Test plan

- [x] `terraform fmt` / `terraform init` / `terraform validate` all clean
- [x] Regenerated dashboards, confirmed exactly 2 files changed (`rabbit-netbw.json`, `postgresql.json`), reverted the unrelated `postgresql.json` drift, confirmed diff scoped to `rabbit-netbw.json` only (7 `eno1`→`eth0` substitutions + `instance=` pin, matches expected diff)
- [x] Ran the new alert's exact PromQL expression against live `grafanacloud-prom` via `query_prometheus` — executes cleanly, returns a sane (near-zero, since metrics only started flowing today) result
- [x] Confirmed dashboard title (`rabbit-01-psp — Network Bandwidth`) matches the string referenced in the new alert's annotation
- [ ] On this PR, confirm the `terraform-grafana.yml` plan comment shows `+ create` for `grafana_dashboard.proxmox_rabbit_netbw` and `grafana_rule_group.rabbit_netbw_quota_guard`, and **no diff** on `grafana_dashboard.kubenuc_postgresql`
- [ ] After merge: confirm dashboard panels show real non-zero/non-"No data" values, and the new alert rule appears under the "alerting" folder and evaluates without `exec_err_state` firing falsely

🤖 Generated with [Claude Code](https://claude.com/claude-code)