### PR TITLE
fix(terraform,grafana): port postgresql.json's 8 hand-added panels into build_postgresql()

### DIFF
--- a/terraform/grafana/generate_dashboards.py
+++ b/terraform/grafana/generate_dashboards.py
@@ -388,7 +388,79 @@ def build_postgresql(cluster, namespace, uid_str):
     panels += rp
 
     panels.append(p_row(pid, "Logs", y)); pid += 1; y += 1
-    panels.append(p_logs(pid, c, n, y))
+    panels.append(p_logs(pid, c, n, y)); pid += 1; y += 8
+
+    # pg_* metrics here are exporter-native (no namespace label), unlike the
+    # kube_*/container_* metrics above.
+    panels.append(p_row(pid, "Database", y)); pid += 1; y += 1
+
+    panels.append(p_stat(pid, "Database Up",
+        f'pg_up{{cluster="{c}"}}',
+        0, y, w=4, legend="{{pod}}",
+        thresholds=[{"value": None, "color": "red"}, {"value": 1, "color": "green"}]
+    )); pid += 1
+
+    panels.append({
+        "id": pid, "title": "Uptime", "type": "stat", "datasource": PROM,
+        "gridPos": {"x": 4, "y": y, "w": 4, "h": 4},
+        "targets": [{"expr": f'time() - pg_postmaster_start_time_seconds{{cluster="{c}"}}', "legendFormat": "{{pod}}", "refId": "A"}],
+        "options": {
+            "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": False},
+            "orientation": "auto", "textMode": "auto",
+            "colorMode": "value", "graphMode": "none",
+        },
+        "fieldConfig": {
+            "defaults": {
+                "unit": "s",
+                "color": {"mode": "thresholds"},
+                "thresholds": {"mode": "absolute", "steps": [{"value": None, "color": "green"}]},
+                "mappings": [],
+            },
+            "overrides": [],
+        },
+    }); pid += 1
+
+    panels.append(p_ts(pid, "Connections vs Limit", [
+        {"expr": f'pg_stat_database_numbackends{{cluster="{c}"}}', "legend": "{{datname}} ({{pod}})"},
+        {"expr": f'pg_database_connection_limit{{cluster="{c}"}}', "legend": "limit {{datname}} ({{pod}})"},
+    ], 8, y, w=8, h=8)); pid += 1
+
+    panels.append({
+        "id": pid, "title": "Cache Hit Ratio", "type": "timeseries", "datasource": PROM,
+        "gridPos": {"x": 16, "y": y, "w": 8, "h": 8},
+        "targets": [{
+            "expr": f'pg_stat_database_blks_hit{{cluster="{c}"}} / (pg_stat_database_blks_hit{{cluster="{c}"}} + pg_stat_database_blks_read{{cluster="{c}"}})',
+            "legendFormat": "{{datname}} ({{pod}})", "refId": "A",
+        }],
+        "options": {
+            "tooltip": {"mode": "multi", "sort": "desc"},
+            "legend": {"displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "min"]},
+        },
+        "fieldConfig": {
+            "defaults": {
+                "unit": "percentunit", "min": 0, "max": 1,
+                "custom": {"lineWidth": 1, "fillOpacity": 10, "gradientMode": "none", "spanNulls": False},
+            },
+            "overrides": [],
+        },
+    }); pid += 1; y += 8
+
+    panels.append(p_ts(pid, "Transactions/s", [
+        {"expr": f'rate(pg_stat_database_xact_commit{{cluster="{c}"}}[5m])', "legend": "commit {{datname}} ({{pod}})"},
+        {"expr": f'rate(pg_stat_database_xact_rollback{{cluster="{c}"}}[5m])', "legend": "rollback {{datname}} ({{pod}})"},
+    ], 0, y, w=8, h=8, unit="ops")); pid += 1
+
+    panels.append(p_ts(pid, "Deadlocks", [
+        {"expr": f'rate(pg_stat_database_deadlocks{{cluster="{c}"}}[5m])', "legend": "{{datname}} ({{pod}})"},
+    ], 8, y, w=8, h=8, unit="ops")); pid += 1
+
+    panels.append(p_ts(pid, "Database Size", [
+        {"expr": f'pg_database_size_bytes{{cluster="{c}"}}', "legend": "{{datname}} ({{pod}})"},
+    ], 16, y, w=8, h=8, unit="bytes")); pid += 1; y += 8
+
+    panels.append(p_ts(pid, "Replication Lag", [
+        {"expr": f'pg_replication_lag_seconds{{cluster="{c}"}} and on(instance) (pg_replication_is_replica{{cluster="{c}"}} == 1)', "legend": "{{pod}}"},
+    ], 0, y, w=12, h=8, unit="s"))
 
     return make_dashboard(f"PostgreSQL — {cluster}", uid_str, [cluster, "postgresql", "database", "kubernetes"], panels)
 


### PR DESCRIPTION
## Summary

Closes #1837.

- `dashboards/kubenuc/postgresql.json` had 8 panels (Database Up, Uptime, Connections vs Limit, Cache Hit Ratio, Transactions/s, Deadlocks, Database Size, Replication Lag) that existed only in the committed JSON, never in `build_postgresql()` in `generate_dashboards.py` — the generator that's supposed to be this file's source of truth. Introduced by hand-editing the JSON directly in PR #1542, silently, and never ported back.
- `generate_dashboards.py`'s own header says these JSONs are "auto-generated — never hand-edit," but the drift meant anyone running the generator for an unrelated dashboard would silently clobber all 8 panels from this live, already-applied dashboard. Caught and worked around (not fixed) in #1836's rabbit-netbw dashboard fix via `git checkout --`.
- Ported all 8 panels into `build_postgresql()`. 6 reuse the existing `p_stat`/`p_ts` helpers. 2 (`Uptime`'s `colorMode="value"` + single green threshold, `Cache Hit Ratio`'s `min`/`max` fields + `"min"` legend calc instead of the helpers' hardcoded `"max"`) are one-off inline dicts rather than new `p_stat`/`p_ts` parameters — those helpers are shared across 30+ other dashboards, and adding one-off params to serve a single panel each risks reintroducing the exact class of silent drift this PR closes.

## Test plan

- [x] `python3 -m py_compile generate_dashboards.py` — compiles clean
- [x] Regenerated all 34 dashboards against current `main` (i.e. **after** #1836 merged, so `rabbit-netbw.json`'s `eth0` fix is included in the baseline) — `git status --short -- dashboards/` shows **zero diff** across all 34 files, including `postgresql.json`
- [x] `terraform fmt` / `terraform validate` clean (no `.tf` changes in this PR)
- [x] On this PR, confirm the `terraform-grafana.yml` plan comment shows **no change** for `grafana_dashboard.kubenuc_postgresql` (since the regenerated JSON is byte-identical to what's committed) — if it instead shows `~ update` on `config_json`, that indicates live Grafana has independently drifted from the committed JSON, which would be worth surfacing separately rather than merging past

🤖 Generated with [Claude Code](https://claude.com/claude-code)