### PR TITLE
fix(proxmox,gh-runner): Increase disk size to 200Gb

### DIFF
--- a/terraform/proxmox/rabbit/vm.tf
+++ b/terraform/proxmox/rabbit/vm.tf
@@ -513,7 +513,7 @@ module "rabbit_runner_vm" {
     boot = {
       datastore_id = "data-ssd"
       interface    = "scsi0"
-      size         = 150
+      size         = 200
       ssd          = false
       discard      = "ignore"
     }


### PR DESCRIPTION
Bump GitHub Runner disk to 200Gb