### PR TITLE
feat(k8s-vms-daniele): swap awx-test images to Ascender for feasibility check

### DIFF
--- a/clusters/k8s-vms-daniele/apps/awx-test/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/awx-test/manifests/release.yml
@@ -42,11 +42,17 @@ spec:
       enabled: true
       name: awx-test
       spec:
-        # Pinned so this disposable instance stays representative of the
-        # live production AWX (confirmed 24.6.1) that the awx_migrate_ascender
-        # rehearsal is meant to mirror, regardless of what AWX version the
-        # unpinned awx-operator chart would otherwise default to.
-        image_version: "24.6.1"
+        # Ascender image swap (feasibility check, see Confluence memo) — same
+        # AWX CRD, different application images. postgres/redis intentionally
+        # left on AWX's own defaults to isolate the variable under test. No
+        # verified CIQ compatibility statement exists for a 24.6.1->25.5.1
+        # schema upgrade under AWX's own operator — that's the open question
+        # this test is designed to answer; a failure here is a valid result.
+        image: ghcr.io/ctrliq/ascender
+        image_version: "25.5.1"
+        init_container_image: ghcr.io/ctrliq/ascender-ee
+        init_container_image_version: "25.5.1"
+        control_plane_ee_image: ghcr.io/ctrliq/ascender-ee:25.5.1
         # Internal-only: no Ingress, no Cloudflare Tunnel hostname, never
         # internet-reachable. Reach it via kubectl port-forward.
         ingress_type: none


### PR DESCRIPTION
## Summary
- Swaps the disposable, internal-only `awx-test` instance's AWX CR images from stock AWX 24.6.1 to CIQ's Ascender fork (`ghcr.io/ctrliq/ascender`, `ghcr.io/ctrliq/ascender-ee`, both `25.5.1`), per the field mapping in CIQ's own `ascender-install` installer template (`additional-spec.yml`).
- Purely a feasibility check: does the existing `awx-operator` chart (unmodified, 3.2.1) reconcile successfully when pointed at Ascender's application/init/EE images instead of AWX's own — not a data migration rehearsal.
- `postgres_image`/`redis_image` are deliberately left untouched (stay on the operator's own AWX defaults) to isolate the variable under test.
- Production `awx` (separate app directory, same cluster) is completely untouched by this change.
- Reviewed by an independent codex pass before implementation: field mapping confirmed complete/correct against the installed AWX CRD; confirmed no verified CIQ compatibility statement exists for a 24.6.1→25.5.1 schema upgrade under AWX's own (not Ascender's) operator — that's the open question this test is designed to answer, and a failure here is a valid, useful result, not something to avoid.

## Test plan
- [x] CI static checks (YAML validation, kustomize build, KubeLinter/checkov) pass
- [ ] After merge, Flux reconciles `awx-test`'s HelmRelease and the AWX operator picks up the new image fields
- [ ] Confirm via cluster access that pods in the `awx-test` namespace actually reference `ghcr.io/ctrliq/ascender*` images — not just that the manifest parses
- [ ] Check the AWX CR status and operator logs directly (not just Flux/HelmRelease "Ready" status) — this app's Kustomization has no AWX-level healthCheck wired up (pre-existing gap, same as prod's `awx`, out of scope here), so Flux could report healthy while the AWX CR/pods are still failing
- [ ] Confirm `awx-manage` initialization tasks (createsuperuser/update_password/register_default_execution_environments) complete without error in the operator's logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)