### PR TITLE
feat(k8s-vms-daniele): swap awx-test operator to Ascender's own operator

### DIFF
--- a/clusters/k8s-vms-daniele/apps/awx-test/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/awx-test/manifests/release.yml
@@ -38,6 +38,19 @@ spec:
   driftDetection:
     mode: warn
   values:
+    # Swaps the operator controller's own image to CIQ's ascender-operator
+    # (paired release tag, per ctrliq/ascender-install's own
+    # ascender-operator/kustomization.j2 image override). AWX's stock
+    # awx-manager renders pod templates (redis sidecar name/socket path,
+    # etc.) that don't match what Ascender's app images expect at runtime
+    # (Ascender's own client code looks for /var/run/valkey/valkey.sock,
+    # not AWX's /var/run/redis/redis.sock) — confirmed live on this
+    # instance as a CrashLoopBackOff on awx-test-web. Using Ascender's own
+    # operator to reconcile the AWX CR should render templates matching
+    # what its own app images actually expect.
+    operator-controller-containers:
+      awx-manager:
+        image: ghcr.io/ctrliq/ascender-operator:25.5.1
     AWX:
       enabled: true
       name: awx-test


### PR DESCRIPTION
## Summary
- Overrides `awx-test`'s awx-operator chart's controller-manager container image to CIQ's own `ghcr.io/ctrliq/ascender-operator:25.5.1` (via the chart's `operator-controller-containers.awx-manager.image` override), instead of the stock `quay.io/ansible/awx-operator:2.19.1`.
- Version paired with the already-deployed `ascender`/`ascender-ee` 25.5.1 app images (PR #1864), matching CIQ's own `ascender-install`'s `ascender-operator/kustomization.j2` image-override convention.
- Root cause this addresses: live testing on `awx-test` (fresh install, no prior AWX data) found `awx-test-web` in a genuine CrashLoopBackOff — Ascender's app images hardcode their broker/channel-layer client to `/var/run/valkey/valkey.sock`, but the stock awx-operator renders the redis sidecar's socket at `/var/run/redis/redis.sock`. Using Ascender's own operator to reconcile the `AWX` CR should render pod templates matching what its own app images actually expect (Valkey-named paths), rather than patching around it.
- Production `awx` (separate app directory, same cluster) is untouched.
- Scope note: this is a bigger surface than the original pure-image-swap feasibility check — it now also swaps the operator controller itself, not just the AWX CR's application images. Still a values-only Helm override, no chart/CRD changes.

## Test plan
- [ ] CI static checks pass
- [ ] After merge, Flux reconciles the HelmRelease and the new `ascender-operator` controller-manager pod comes up
- [ ] Confirm the operator reconciles the `AWX` CR successfully and recreates `awx-test-web`/`awx-test-task` pods
- [ ] Confirm `awx-test-web` no longer crash-loops — check restart count stays flat across several minutes (not just a single snapshot), and check `awx.main.routing`/`daphne` logs for the Valkey socket connection succeeding
- [ ] Confirm `awx-test-task`'s `callback-receiver`/`broadcast_websocket` subsystems stop logging the `ConnectionError` for the Valkey socket

🤖 Generated with [Claude Code](https://claude.com/claude-code)