### PR TITLE
feat(k8s-vms-daniele): add Traefik ingress to awx-test

### DIFF
--- a/.github/fixtures/cluster-vars-ci.yaml
+++ b/.github/fixtures/cluster-vars-ci.yaml
@@ -19,6 +19,7 @@ stringData:
   AUTHENTIK_POSTGRESQL__HOST: authentik-postgresql.ci.invalid
   AUTHENTIK_POSTGRESQL__PASSWORD: ci-placeholder-password
   AWX_HOST: awx.ci.invalid
+  AWX_TEST_HOST: awx-test.ci.invalid
   CLOUDFLARE_DOMAIN: ci.invalid
   CLOUDFLARE_TUNNEL_TARGET: ci-placeholder-tunnel.cfargotunnel.com
   FASTNETSERV_DOMAIN: ci.invalid

--- a/clusters/k8s-vms-daniele/apps/awx-test/deploy.yaml
+++ b/clusters/k8s-vms-daniele/apps/awx-test/deploy.yaml
@@ -19,6 +19,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
+    - name: cluster-vars
     - name: awx-test-secrets
   interval: 5m
   sourceRef:
@@ -26,3 +27,7 @@ spec:
     name: flux-system
   path: ./clusters/k8s-vms-daniele/apps/awx-test/manifests
   prune: true
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-vars

--- a/clusters/k8s-vms-daniele/apps/awx-test/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/awx-test/manifests/release.yml
@@ -66,9 +66,20 @@ spec:
         init_container_image: ghcr.io/ctrliq/ascender-ee
         init_container_image_version: "25.5.1"
         control_plane_ee_image: ghcr.io/ctrliq/ascender-ee:25.5.1
-        # Internal-only: no Ingress, no Cloudflare Tunnel hostname, never
-        # internet-reachable. Reach it via kubectl port-forward.
-        ingress_type: none
+        # Traefik ingress, reachable on the cluster's own network via
+        # AWX_TEST_HOST (cluster-vars.sops.yaml) — deliberately a distinct
+        # hostname from prod awx's AWX_HOST, not reused, to avoid a Traefik
+        # routing collision between the two Ingress resources. No
+        # external-dns/Cloudflare Tunnel annotations (unlike prod awx): this
+        # stays LAN-reachable only, not internet-exposed.
+        ingress_type: ingress
+        ingress_class_name: traefik
+        hostname: ${AWX_TEST_HOST}
+        extra_settings:
+          - setting: CSRF_TRUSTED_ORIGINS
+            value:
+              - https://localhost:3001
+              - https://${AWX_TEST_HOST}
         secret_key_secret: custom-awx-test-secret-key
         projects_persistence: true
         projects_storage_class: local-path

--- a/clusters/k8s-vms-daniele/vars/cluster-vars.sops.yaml
+++ b/clusters/k8s-vms-daniele/vars/cluster-vars.sops.yaml
@@ -1,43 +1,44 @@
-#ENC[AES256_GCM,data:1Ytb7xjgsqWZn6K6oe+sald3RBT6B+NDAtfDf2Fo1FEBru2DxyJKR7MC8n4seylmTUULEsupIlY1,iv:CKZYCOX6hZDy5HoDI0TkeRT4A7tfoYIREWpEwqpcJZg=,tag:kZrE6yazEtn+tDuOVd8WkQ==,type:comment]
-#ENC[AES256_GCM,data:KB8lVP7FfU8F3onVWrvEGSjIMnt6Gs56F2V9Wud3g/pDBrynvO9Kv1O1hMktqPFarJQyVN76AeGHj0GoJD5YqF3Tnrk43s98UUwHJeVzWEH7tK7B,iv:kVz9uWbhG0ysCyLAMgzoAbhOIgfrSSqsLwjCPtu3Ltk=,tag:oHfpfUgLfu98OMn3mcSZWg==,type:comment]
+#ENC[AES256_GCM,data:sAnW+BB8ceVFdo4DWhqO7bg4HdvUxVZH9hUfeCvHBKxn/JXLHsDeUXjDs+bU13MZBiOdo7hlprpG,iv:94nwyma9CqBuEhE2WButOVRp0cCs+KPuTsnhsJwSG3I=,tag:kqG9O85x3x1Tk3bSjXUVfQ==,type:comment]
+#ENC[AES256_GCM,data:55HekLDd1N8kNjSnAUUy2TnDUHNOKF2Qs6ASJ4aBWb2t9FixaFRhI6WBATqLxHnQaz4/IV35Xgkh29QI2keHhJ0tchIJ0AgGOpqqb519mjJkdsjT,iv:U7XmpRAnX21doumirUrz+N11DOv+XgvMOh+glU5yULs=,tag:V17I01nL4Ccj46Fl9lK7ZA==,type:comment]
 #
-#ENC[AES256_GCM,data:43Uh3t7nzkP2Oiw8u5j0KsUze2uevCA7fatTZ8ogW7Z3u1Uay2ADQQ==,iv:BtM2j65doPT6VqzXPTY605XPJ9g4JRaNHgkH0jtjcjM=,tag:vejExq0Wxj2Up6wetfMrpw==,type:comment]
-#ENC[AES256_GCM,data:KeeLAz2ZOjg6SM3gG9Kl42dWm+Hn4XQz79GC0mo/ufMehw==,iv:ogsjtES/FmfeTr8iJkNX01XsDsDmFh0G2WF8Ib5zQDI=,tag:h88hrFTwJn41mwIC8jPtVg==,type:comment]
-#ENC[AES256_GCM,data:oHZ1fZf54AENAXA6dFVqDbt4n+GnvF16oJLyGp3fILikRx9TokABFSXCmw==,iv:qGuXDD6br0RKI3jYl3NWV1ht8WtCTl7f+3j6LuBam1g=,tag:niVUz/xFUJ8z2WlsBKEQFQ==,type:comment]
-#ENC[AES256_GCM,data:Ajo7IvKHHqnRAZYDxB5GMeFvB3oQFNkmkYdFlwjd,iv:5y1AZso8wAv0WTZGgRrhm5o3YMr0IWGiFntircs7ebI=,tag:Cw9H2/uBbo8MuQfslj8baA==,type:comment]
-#ENC[AES256_GCM,data:JOG1Jmz0qGsHrwiTPvfgAM2vbsTvrKiRDItbM4AgQgpVGwrwDI6f3sI7b/JScic=,iv:0utjs3rZe+YtA9SvWyFWEFGJ+A1tGFs/ZabneBUDV60=,tag:KU0DPy2vLpaqVeJN/Sdk9w==,type:comment]
-#ENC[AES256_GCM,data:4iDhHN6W4agobLMi9oG/y252jOK2CqjfeUxyickfOgH0WcqQJsL9zg==,iv:wjXMjGmV1BE+o3Yu5ykIW17pgrCjWEvK7Wcn1/EVhBM=,tag:RUT3LXvIeyz2ibWlYGXypw==,type:comment]
-#ENC[AES256_GCM,data:nndKzfMAXnQJJrszLigMc0phZkC+2FYhYb+OxeQL1Om8A/Ha5FKmZFsdMWEU8TH6gRycOd3q/zQKqBnHQNwTYSMq2w==,iv:VJHBdiTeIqSqHJw5MeQRAOJwj4vY+lzXERqv//s9MTk=,tag:ThJksQ89ZSFtzFC5mhtNuw==,type:comment]
-#ENC[AES256_GCM,data:598RoMntegM+kxT0RIT++75lADknL3ZGMx5XTs+HNVy1Ve6+2GDOvsPcfMim0vcCItwIryMLfYCMsA==,iv:gKYmyDViZkOZu2H283YgyfxjXNde02nHKKQ18+N2jm8=,tag:v4Ro4eaFzYHskSbw9W1wJg==,type:comment]
-apiVersion: ENC[AES256_GCM,data:/ts=,iv:OQcnCgAig843hPzSj7ftj+yOB+oegG4hxvLdFuDQuEQ=,tag:Rv5N9ENEiM6SfIpk4ESBpw==,type:str]
-kind: ENC[AES256_GCM,data:3MFKOpIp,iv:oh3YkHlb43UJNkU3GZsBCwnepiUZ/aRZxhWVCAUO5HQ=,tag:RAiTy0AN/32gBZvB8alVrw==,type:str]
+#ENC[AES256_GCM,data:ybZWyzH5TzIzIkd+GRyw9wZt00+bkW/fljta72ke8fQhYgYxXD6kLw==,iv:zZL0rh9fnEiwxxPQ8p+Eoy0QWHuA7u0G+n55IE0PUmM=,tag:BkoU/j3/TIEEdY+5iguQ5Q==,type:comment]
+#ENC[AES256_GCM,data:4Wp5ie9W8R0H/77MngKCnCklrhzsHxfPj/We34ea0UjOuw==,iv:iuh7m53CcTQi+yKZ6mEbJmzLRAfeflPnGaP0hyweHJQ=,tag:+j3UT9pR7tVN9fjtwPQiaA==,type:comment]
+#ENC[AES256_GCM,data:H34X1+dmbWJBt+qHHDiEPjbey2AlTjeYS4ybOSxEApWkJwDcaIA0mNGR8w==,iv:Q6AI/5i+c2xerCGoj/V8YB8hWyJRPhH0dOCmkSE1puk=,tag:loxereevyDtcMtgmgnwTKg==,type:comment]
+#ENC[AES256_GCM,data:e/z5YkGtsnN1B168tu3ygNbDTh9AJ1d3V5VKBK7i,iv:vKOQSndq9vPYSZFQ46VZ3QyJFylMI2XF4XPLvbdOkt0=,tag:bf6vYAeBrFK3J6hl+fPM9w==,type:comment]
+#ENC[AES256_GCM,data:lcv90Fw+8H4g4SI1ZiLdYZsXAOIjNKd8FAd0lmV6jgq0bjZIR1LzxHxktNKbEq8=,iv:yQOnbz5oScpJ4AUFfwH0HSmWk8eRGJkAERXagZtxhcI=,tag:GVX0hOQhV7y8I/BMbdPutQ==,type:comment]
+#ENC[AES256_GCM,data:FEI3FpvhaWKgp2Om5aVPN53vDA/GmnGEVsCqyipoblSQK42vnXGylA==,iv:3pknlnWW7zw6MzJteOO1o9B63Z8M4LUWHhPEpqHyRWM=,tag:2/Ow3+/REN2TSM+gHyubqg==,type:comment]
+#ENC[AES256_GCM,data:4Z2lG7aUoCS7RMi4ouiBmoFtW0MT3izYZDxIinJIxafiZP4rMPrFcodLb/y8i1f6cnClxc95CoAixG0rZOmrxZrjLg==,iv:e5TH/5uYsJjcUpAi1Ty+TR0cwtO3wUaov/9UGlT8lH8=,tag:UutBW6HqTjBYFItFZIAL0Q==,type:comment]
+#ENC[AES256_GCM,data:b0RbYnCCbPcd6hh9Kb2KyDXutU8yIXDzyWeijqlenzQTxWQe/Bm/vEExfqq7f8rCDD7DSWeXgPPxeQ==,iv:+NBUxnSQAMYzYK2mdSAg4TjrMy8sMCztV7/XXFCzBng=,tag:nkT8sjmwHlgQ6JDqgl4C/A==,type:comment]
+apiVersion: ENC[AES256_GCM,data:h9g=,iv:afh5PbyLr/3GxlERfhqAViQVjNUJxxmNWOnacjKD+Yo=,tag:9AWa/FV/EPnxj2gg7X6nKA==,type:str]
+kind: ENC[AES256_GCM,data:ubdtkqy4,iv:gNmB8c44asnRmDSiez6hcuigodEO1nnVJ9K4+/D2xCk=,tag:n4+jp960iUd+50/PdFfx+g==,type:str]
 metadata:
-    name: ENC[AES256_GCM,data:o6RZ3QpQ0YBfMhqR,iv:jcgpS5VL5yr+R7O26KpguXpfMNMZIWYubqpFb8NkzxQ=,tag:hKpM5FuaMMMPMUcGPsedYg==,type:str]
-    namespace: ENC[AES256_GCM,data:4GpjEfOizwHzN1s=,iv:K1SXhyZ5RsyqBNwjdkIyxUMqkoCBqzAsGdCILlCNass=,tag:kOmrjh5OmWwsR7YzCDHRRQ==,type:str]
+    name: ENC[AES256_GCM,data:QodxmAi3MLMy666T,iv:Izz2kG17TRr09DMKOL8wbjhnjkiOrZeotGNy2SjwL9g=,tag:cYCykac71FiwxsvVYPgI2Q==,type:str]
+    namespace: ENC[AES256_GCM,data:pRLfh6pU9mCNOaE=,iv:x0jgZt/jOc0PwNWYFv575MKIpBnCcoLQ0PtxY+l/AJ4=,tag:Jkf1JmJe66tG1Qe5RCWSbw==,type:str]
 stringData:
-    SEMAPHORE_HOST: ENC[AES256_GCM,data:3LdqRpP7RtsIBvqQwbUCr6hI1PtQVHe7Qw==,iv:lXoTN06LNoHYfVxIyqLS40g72Mrhzpf4LsBbYYrUITU=,tag:/ilAQ8g62Cg3g+TwfsqFpA==,type:str]
-    GRAFANA_PROMETHEUS_URL: ENC[AES256_GCM,data:iy2AO7c494KWTTh0FyfiCGm5LoRUiXa3PIdPzOuYJxa2UO2EfrL3HdxT7Nj9MUwCNW2cYdL/jXD8TKn62j4YUQXXI7sWyQ==,iv:zljWumiV4mgd5knukeZF+VuTDhxAITaddm0SyeDPJvQ=,tag:zCb8/GCHajxcBGfjbfE+GQ==,type:str]
-    GRAFANA_LOKI_URL: ENC[AES256_GCM,data:sbYb5gMTs4Kaowkhtsk4MeYfqZtQQj+NcJmYmnr8YSMT88oHqfDQunmNCcq2iTyNhms=,iv:C9g16SFTsUW4J2U5MHf9jq9mqO6MeCuwQP02mix/bkg=,tag:47acXMgvU35nmP9eT1HBwA==,type:str]
-    GRAFANA_LOKI_HOST: ENC[AES256_GCM,data:CzL+48r3TM3Xo+Mzk8Ni3h9v8v57RhXvqsh2ugY54x3v,iv:PbvcYyfpiCzdHYZGuXd9QVRHWMv1qEPUUJqlLBw5kfo=,tag:+QseyvouNNOs2+/zQMAILQ==,type:str]
-    AWX_HOST: ENC[AES256_GCM,data:Qx0yjzrc46w4VeH0jifX6/FAdTboAGA=,iv:2EUjIBhCYHuIscJ4Kr8v48yPxyFyX6yRPbIhua2TR2k=,tag:reihUTDIC/ZUIgutHnem1w==,type:str]
-    TELEPORT_HOST: ENC[AES256_GCM,data:MQXemWHJv7bhb18AnoLDXiiI,iv:A7JGe2U1pdqzd6G+BkePSbe83l3Apt4ZYWlEFs5Xp1U=,tag:9e21va8upvhsxkMbkJ/Dyg==,type:str]
-    CLOUDFLARE_DOMAIN: ENC[AES256_GCM,data:ud/jFrVAd600,iv:Xkbzfy03QzU6DElTfl0GNh8Vy50SpfTtBnwzcYFZtEk=,tag:W7Bjgv2sI+xoB9/dQGVv4A==,type:str]
-    FASTNETSERV_DOMAIN: ENC[AES256_GCM,data:cOrqlHvCLoz+MXEslg3I,iv:ghz41K1V016owlYmQpENSpDCk6q66ciwGOEQJ5AZul4=,tag:acmS+ENhGgOBmvoThHb3PQ==,type:str]
-    ACME_EMAIL: ENC[AES256_GCM,data:VkjrB4GJeFiUWzTETfS+f4lqWxfhHFulDt24lXpGZUCM,iv:+xqcU+gv+TdqQVIaxaCvhwy6CXRStH3i3xzXzQqsNSc=,tag:hK1sT8O+4StcjKEq1Voejg==,type:str]
-    CLOUDFLARE_TUNNEL_TARGET: ENC[AES256_GCM,data:WrjKIw4kTL5NWLz+hJ0NOiaz4fQ9YOJm2mGS+RRSKDLXrDmlpliNGe4VZAdVDzDRGZ5yWL0=,iv:K6b5E9dimvJEY//RX95hBurkYylzcH+b3FtpTbRuJCs=,tag:FlSVfoUupJs6yQUbm6HBIA==,type:str]
-    FLUX_WEBHOOK_HOST: ENC[AES256_GCM,data:nVF+DR3OuG2k0RvvJE4hZvoCBtU5F6EPaJ98WcQLAQ==,iv:O9vjZJ/F99bUXU2oMT6aNm2KDCfzCUhPF58EZyQbgKY=,tag:zbM2CZ/MG5gjI3kn5g01sA==,type:str]
+    SEMAPHORE_HOST: ENC[AES256_GCM,data:hHIV9LesG2ty0pPjcBuCc53bkl3+5Y30yw==,iv:23EEl5NGlF3xljxJqjkQLAnhwap7Q/IHb2D9xnNjF4w=,tag:RMBTwhX4iEF+0YmZtOwmaQ==,type:str]
+    GRAFANA_PROMETHEUS_URL: ENC[AES256_GCM,data:PHj12syD4AoB8IPEor3Pnrz1gNvDk6B72F+Brl7nM7UgnpvdNdMkuo7bC/QywYF8yc4ajkNJgROsd7QbLKTNheDT8y3XlQ==,iv:UBtVETycVoDe56wpt5rM8Jh65DZqKrGmnvd38OmNv8k=,tag:b8lTV6RcJCE82d5VL5jiww==,type:str]
+    GRAFANA_LOKI_URL: ENC[AES256_GCM,data:1YGia13chowo7VHYP4A1YtqJAKMrIbED5z9KGb3/7hOvg1FD1btS3EntuqmvBCqrXTo=,iv:KPcZXoBQLGm62u4SA/0BE+6U8p/9zXKNXNZgpI1TwLc=,tag:+4VrjlJ8bNNNxMtuoTcWcw==,type:str]
+    GRAFANA_LOKI_HOST: ENC[AES256_GCM,data:YnOUGJIGjm9MAfTH8PtEK6/Fw7Rm3bM7YqkxE7b9ko8v,iv:qFTegt6QzVVGK/j1JL4jgJowpNtRpA2pNydivu9jIyo=,tag:oEl+z/iWt6i/igjm0CpEHA==,type:str]
+    AWX_HOST: ENC[AES256_GCM,data:zdCujaqes5Gow5qcpVtk9tUdDY9TDDE=,iv:CrheH1yxenIYRlw7VQdUGiEZIPfLFTRDTXJvMEYUoqQ=,tag:3L4gnTb0vM0yZj5mrD6liw==,type:str]
+    AWX_TEST_HOST: ENC[AES256_GCM,data:qsN+tOSEjULXzVMsW5nahw9i7wVRA+1G,iv:xJQT8amsAYJ0UEH1CJkzfKirQ6rFhsJA3+wlGsFK1KI=,tag:rn4cWK1XvIKMQpBXRdEApQ==,type:str]
+    TELEPORT_HOST: ENC[AES256_GCM,data:zd8Xe3qRX7qYiCFsvBjCvmrz,iv:q/ooC9GlXOPzOlu3Y6MYncaSGtkWP8YkO/QwdZG0TTI=,tag:MyG6yP/p8XG/Cdhf4WNWnQ==,type:str]
+    CLOUDFLARE_DOMAIN: ENC[AES256_GCM,data:uWun8v3o9T5x,iv:rZq1In58kI0xYADaPmfJ2TRZ2GilKaFjZNgID5f4dHU=,tag:L7ivfUXnLbTybARz8IbFhA==,type:str]
+    FASTNETSERV_DOMAIN: ENC[AES256_GCM,data:bePCRVcERk4WiYZWDtAG,iv:ulXy+0KWuux6hFAkZ9ZzoJkWpIXNdy+7OuVHkGw9qy0=,tag:c41KLnJYFPms8uK2kx/LSw==,type:str]
+    ACME_EMAIL: ENC[AES256_GCM,data:e0CcQ7loO2sAx6KTY1sBuYT8mKWSXCP1n3GhpbPyUFzQ,iv:BO4yF4u3lcOpRskgZ553KRn5AxIYEwd3Db2G0TSg/84=,tag:mo0OogtrQcdQJzxFSaAcyQ==,type:str]
+    CLOUDFLARE_TUNNEL_TARGET: ENC[AES256_GCM,data:uKAN3JTCYAaCPen7+jVXmWtQ0YPp3Sn45+6s4VYHFa6ISpKgN48U5EV8LSY07aAmMy/EL0I=,iv:2N/bp4XJwcej1z3Uxc3c+BN7R2imvOcxwmxrtuhTSeM=,tag:xrdJ+v8xy5Wn+KBYDH3sVw==,type:str]
+    FLUX_WEBHOOK_HOST: ENC[AES256_GCM,data:9ye3HedwZv/dlg++R/OcvrWwwKOoF1WYXHGEjN1lfQ==,iv:NvQu8rSETTE0QP+u5LjawLGg/bTvzCdC8MnyLyWF0l4=,tag:8/Y2ic634fIOUgR0NTEWvw==,type:str]
 sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGaGZmcit2ak5oZzI5VDRQ
-            Rytha0M1MklXV1FYTjZYZ000UnZaSkQvekF3CmZQQUVYb2hyRXBzSGsvSkdlcjl2
-            bzBVYmhBR09nNDA1ZVkyUS9EZ2xlMlkKLS0tIDhmQU9IOUpYUkFWWWxER2tXekRV
-            YmpPSllRZGJnTnhmZjlqdnRZUnpHd00KDDeWN4NLDKtXT0dPFE0phvXEl2koJ+I4
-            d47T9O/Yuty1XD9I7Rd1rxsbzIFFF/VzJwS98n+HaMQHwB7HR/CE3g==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBiQTBIejRnUXhPK1pUcWJt
+            dzcwUFFjNGFhMWZ2RjhxeW5FVjdaZmY3WjJFCmRJQUlmUmpSNlUxcDdtUlI5QkNV
+            dFVNN0RWOTZRYnltbVFqdHRRelpjNTgKLS0tIEtKMlNId0RrZnY2TzJja0s5dm8v
+            RjJwUDdPTDVTQnRZMDdIa0lFclh4eEkKdsry6Kli8C0QvUqV8pjfwYHfhCNZrwrk
+            ubXyX5TScTXA2LxB3PWXKrTwbtEpOSNTjB4wpf7zLMAIP6FLLR+M5w==
             -----END AGE ENCRYPTED FILE-----
           recipient: age10zqzjdvku9q2qpq34pqjvss9jarc86wyqxe07x6f0qd8c2w9tvss03awl3
-    lastmodified: "2026-08-09T08:01:47Z"
-    mac: ENC[AES256_GCM,data:5c4Ty/AIR6lbLAm/kFc4quTLJrLNxOoBDs2j7cT5g+EZzSstYzLZvzDwX8NUe2NC/hcFpU2V9ejvMz8I64kAnlr8FUjZuxKMANTzHSXMNcHRj633BRb3I4qaImnf5v9qk8rqw5zQ4jYcGqK7WRUL2gCig6MxHJlC0aGxbcTFFMQ=,iv:CswrmNKWN7efw7xSnWbYQUEYjjk5WXmZ9+v1DYKPzxY=,tag:0AbTQ+XDNpHHoRaRT25NbA==,type:str]
+    lastmodified: "2026-08-19T19:50:24Z"
+    mac: ENC[AES256_GCM,data:FrNbOKN6ayyMiF+mMoSAH9cV3/nnzs920QA1+79/wV1IH5BE1l6AjG76WEJE57NmLaeFEoiVNWXmI+NZjCyOHnjh0Zg9XMSexee9LEjXqKd0JsY13qedDzlTqPGww9BdJo+zAC9iddW5KF2RhvINJ3A+gm27iQhzT1r/lmbnuFA=,iv:YZXLGt3rw9S9IJzkJbe0OJrctz+cOLvDDfzDZxHFEHY=,tag:ZcHnRViFHExOplEHRmJJfQ==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.3


### PR DESCRIPTION
## Summary
- Adds a new `AWX_TEST_HOST` key to `clusters/k8s-vms-daniele/vars/cluster-vars.sops.yaml`, distinct from prod `awx`'s `AWX_HOST` — deliberately not reused, to avoid a Traefik routing collision between the two Ingress resources on the same cluster.
- Wires `awx-test`'s HelmRelease to a Traefik `Ingress` (`ingress_type: ingress`, `ingress_class_name: traefik`, `hostname: ${AWX_TEST_HOST}`), with matching `CSRF_TRUSTED_ORIGINS` (`extra_settings`).
- `deploy.yaml`'s `awx-test` Kustomization now `dependsOn` the `cluster-vars` Kustomization and substitutes it via `postBuild.substituteFrom`, same pattern as prod `awx`'s `deploy.yaml`.
- Scope is deliberately narrower than prod `awx`: no `external-dns`/Cloudflare Tunnel `ingress_annotations`, so this stays reachable only via the cluster's own Traefik controller (LAN), not exposed to the public internet.
- Production `awx` is untouched.

## Test plan
- [ ] CI static checks pass
- [ ] After merge, Flux reconciles `cluster-vars`/`awx-test`, the Ingress resource is created with the substituted hostname, and Traefik doesn't report a routing conflict with prod `awx`'s Ingress
- [ ] Confirm the AWX login page is reachable via the new hostname on the cluster's network
- [ ] Confirm prod `awx`'s Ingress/hostname is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)