### PR TITLE
feat(k8s-vms-daniele,terraform): add external-dns to awx-test

### DIFF
--- a/clusters/k8s-vms-daniele/apps/awx-test/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/awx-test/manifests/release.yml
@@ -66,15 +66,19 @@ spec:
         init_container_image: ghcr.io/ctrliq/ascender-ee
         init_container_image_version: "25.5.1"
         control_plane_ee_image: ghcr.io/ctrliq/ascender-ee:25.5.1
-        # Traefik ingress, reachable on the cluster's own network via
-        # AWX_TEST_HOST (cluster-vars.sops.yaml) — deliberately a distinct
-        # hostname from prod awx's AWX_HOST, not reused, to avoid a Traefik
-        # routing collision between the two Ingress resources. No
-        # external-dns/Cloudflare Tunnel annotations (unlike prod awx): this
-        # stays LAN-reachable only, not internet-exposed.
+        # Traefik ingress via AWX_TEST_HOST (cluster-vars.sops.yaml) —
+        # deliberately a distinct hostname from prod awx's AWX_HOST, not
+        # reused, to avoid a Traefik routing collision between the two
+        # Ingress resources. Same external-dns/Cloudflare Tunnel wiring as
+        # prod awx (see terraform/cloudflare-tunnel/main.tf's prod_k3s
+        # module) — this instance is internet-reachable, same as prod.
         ingress_type: ingress
         ingress_class_name: traefik
         hostname: ${AWX_TEST_HOST}
+        ingress_annotations: |
+          external-dns.alpha.kubernetes.io/managed-by: external-dns
+          external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
+          external-dns.alpha.kubernetes.io/target: ${CLOUDFLARE_TUNNEL_TARGET}
         extra_settings:
           - setting: CSRF_TRUSTED_ORIGINS
             value:

--- a/terraform/cloudflare-tunnel/main.tf
+++ b/terraform/cloudflare-tunnel/main.tf
@@ -111,6 +111,13 @@ module "prod_k3s" {
       }
     },
     {
+      hostname = local.cf.prod_k3s.awx_test_host
+      service  = "http://traefik.kube-system.svc.cluster.local"
+      origin_request = {
+        origin_server_name = local.cf.prod_k3s.awx_test_host
+      }
+    },
+    {
       hostname = local.cf.prod_k3s.flux_webhook_host
       service  = "http://traefik.kube-system.svc.cluster.local"
       origin_request = {

--- a/terraform/cloudflare-tunnel/secrets.sops.yaml
+++ b/terraform/cloudflare-tunnel/secrets.sops.yaml
@@ -1,36 +1,37 @@
-account_id: ENC[AES256_GCM,data:7optnwysNI8vwBD0WUuixMwGlsYLvv4MsSiSjmIjMR4=,iv:xt90gVlCQDhjLrR7UNYN1YD/BB+gL3GgcNanGKweI/4=,tag:/+R5+mIGSKsPBC5CWYNuuA==,type:str]
+account_id: ENC[AES256_GCM,data:OjkcZjL/tdBzsgzDHeuHGpDg2tJHrya3bd7Bv73kznM=,iv:BnQ5Pj8y6g6OlI6U+rJeBnXHTOaWyPIvDqAN72cf5BA=,tag:1s9FqxrkLFQRBkWozGz5dQ==,type:str]
 kubenuc:
-    tunnel_id: ENC[AES256_GCM,data:P8GJV9tihwCQ+5X702ysrEEs4B56sSUpFnEOLRokZqaTkm74,iv:SGYVqZIbO2BBAggfyzSIiVUR1NVrZab+1fjSxXzXKFI=,tag:1tLBuj474ciA6dfD0ZgCew==,type:str]
-    kubenuc_host: ENC[AES256_GCM,data:/7VxlZkZM5yQDeFtCtq6zgM=,iv:pi+i08fu+ZogKJiGZ6WrHAK9gsLJIch2dhuK7gBZzyk=,tag:qo+6njFdnY8g9rw2lC+bjQ==,type:str]
-    nextcloud_host: ENC[AES256_GCM,data:2coI4NZN8GYst4EGxt4g,iv:libhAvCKbGYZQ7Z4wNWgVArG0elTz+24EvYmbWfOddU=,tag:NSJd+1qjHAAWBq4EPwIjwQ==,type:str]
-    harbor_host: ENC[AES256_GCM,data:1+Lgs+ISbVarm3/RIiC75w==,iv:C7PBRSsXbe3j/YxcDSw8lTtnHiBIXLQCM7YiGW/gY3g=,tag:7Oi2CaJemmX8emRdPfJezg==,type:str]
-    portainer_host: ENC[AES256_GCM,data:ePl74dH+MzS0LmtheMaqr6JpZw==,iv:JVTDMdxzjCb2RAb5AXLNE5V0piPYa0/4TFuS+OhVD0I=,tag:e937vGvYexpe8ARyTs7dkw==,type:str]
-    photos_host: ENC[AES256_GCM,data:JVenZkJjai/vktlWKBdNCg==,iv:EchTho5pnXbiTli2RK/4YndQuy9vU/hdCQ0lOkCJsgY=,tag:MxdG+hD7HRmOPz9AxMe68A==,type:str]
-    jenkins_host: ENC[AES256_GCM,data:VEHlHBvik9zVa155lm47LQA=,iv:80faL5CzEf+S1NGECog+NhOtNsTp6iH+hd89ZgEK760=,tag:JBmi+K42T9sBAgv/Jm5tjQ==,type:str]
-    sso_authentik_host: ENC[AES256_GCM,data:SNWCLMudUQKiQjPkPg==,iv:FYMW0EqejJNAtmKGbXQwfl14M9XydfpYPCc8aRZ8vDc=,tag:uszk82oEY8hqmFyFXpzSNQ==,type:str]
-    sso_host: ENC[AES256_GCM,data:jsm3uVJ101rrhZaMX5UQ74Op,iv:dzzhg+LsBCcyagurKuEFBNBMV1nh6M+oy7jiFIaljrI=,tag:VmL5JjJocjSzgLPEmbc1RQ==,type:str]
-    s3_api_host: ENC[AES256_GCM,data:ZeGkJUg/xHRJrd6cqEXAzw==,iv:U0H/cBbsWCHW743m9BgD6cTY/21DI71A7yVbPmrdYII=,tag:jMY9FM2wbrHcB6+w5TY1XQ==,type:str]
-    s3_host: ENC[AES256_GCM,data:S4FCNGTHPNBBVdYT,iv:NDNInjKL/OYHTdy2gfj+/+YhrFIkf9uyvl9YWL/wLEs=,tag:t3SqR1bm1iLFTcPV5Os82Q==,type:str]
-    artifactory_host: ENC[AES256_GCM,data:M5c25KF4TejlM0jguKeB4ll0JyI8,iv:jeoY1cAV6pQAzK2fPDoXzzF1hM5nVVAPCzC14nE0ots=,tag:C9/tGiBhPdeGjdDvwr6jMw==,type:str]
-    flux_webhook_host: ENC[AES256_GCM,data:xINMbbUEZxFznMJ/9TQo7gfNNEHw1oYgJKCrF0pe,iv:CrISP6Zq7Nhp6Dk0eJu9tLZSZ6vfneNUF9RuR2P4vZ4=,tag:bCiFBFQWLVjYmWE3Kn0hzQ==,type:str]
-    forgejo_host: ENC[AES256_GCM,data:dSiP2z1VoEnFabb8c9g=,iv:l3T4L8wuEwQeINib+QIODA/fBctGQI8+whGT8YZrohA=,tag:Uu838Xmm4Va1jwXz/R48PQ==,type:str]
+    tunnel_id: ENC[AES256_GCM,data:q4Gw6VBMKuDUDIpoCCk1U8j6NiaunaDULhvvS74rCXZrh3sl,iv:P3Btj4L+UN6DTQiwo1j7/3sFMXOIN3DihJJV4eh2cj8=,tag:q5W1Ypk9Ixsah12ykWTZKA==,type:str]
+    kubenuc_host: ENC[AES256_GCM,data:5DZ3mmSt5uC2zlYF3dTx8Jk=,iv:Wj4sVytbehgzBnSyH6ShFB6EmVaso5aNOMHrsrBp4Pk=,tag:X2XNYZtDdYf5/LeakMz+NQ==,type:str]
+    nextcloud_host: ENC[AES256_GCM,data:D0YPEqADBlCcSXLHcx3z,iv:nexox3RnuX31jRqd9RTyFxfPwWJxHyeiWD3UrYwOAj4=,tag:gePYW01v/ypIw80P+HXHiw==,type:str]
+    harbor_host: ENC[AES256_GCM,data:+Qc3svjjC9znTdXyWpAhIA==,iv:EtzPY2TsflMXuXLQtPtSfuTeP3IPUrU+zVKxDmjR1fI=,tag:+TBbY01dojiaUoYcVdtpuw==,type:str]
+    portainer_host: ENC[AES256_GCM,data:pryq6DGH193mjmvWJOFQ9EKImg==,iv:6Nf6coFUgx0O++qd1Mkk/ptsDYwBldblCbRGKqZICgo=,tag:uuloBZnxnK9osqy2wbgjTw==,type:str]
+    photos_host: ENC[AES256_GCM,data:yC3fWOmoW+b4GHea1atHWw==,iv:taG6WyjAK4Po5w7Q6NYaz1svbiMFsgMrTTsiQ9OxWJI=,tag:CIgzM14e+DgOxuTUCYe56Q==,type:str]
+    jenkins_host: ENC[AES256_GCM,data:hqKiQ3yusav/zyX8N54PV8g=,iv:RxRPpunLyM8UwvRoK2kv/2ptDL/Y9Ugw9EtbWTSDS7Q=,tag:UdMKIjfcBRIitWN3Mny85g==,type:str]
+    sso_authentik_host: ENC[AES256_GCM,data:eTB99IPTvJG3niXm+A==,iv:/+I/ya8DY6LOOmPQhg0WpRIuHZpjUwqR7lroSoTLs5M=,tag:PtMtVJWHugaaV4l/xWLG2A==,type:str]
+    sso_host: ENC[AES256_GCM,data:fpKF19+ZZfdZQgTsNnPnDD4D,iv:JZxn4gN8V384HaLjzk2PIq8rLw1XrjTnc8o1u937Kuk=,tag:tnccvVpmQxYgyTCvglbo8w==,type:str]
+    s3_api_host: ENC[AES256_GCM,data:dUyFkbfX6bt3KnHpWQFVyg==,iv:SMzGb7+TxyN0328iAYWZahdz49SOzwYlexvD7rW+wsU=,tag:buSFrSIyskMbYlVp6T9qgg==,type:str]
+    s3_host: ENC[AES256_GCM,data:3OJ/K87vlkXxM2Q2,iv:x129Jp3MQysa8rJbwpM6MmuXzDe6Z/xd2yPyGzTM8no=,tag:VmDtptWqSkpq/PNpj7zvZg==,type:str]
+    artifactory_host: ENC[AES256_GCM,data:jBfuBRXGSKUa7qHC2ZL1KfyO602q,iv:AxCJt5H8dnfTnUtmsLp0ap5bNYbI9Gjwx8WyahJNgiM=,tag:2ZdhcGQbhzJz5OJ6JP7ang==,type:str]
+    flux_webhook_host: ENC[AES256_GCM,data:hcyYP1s9EoYIXaOLk7Gfsc0OTwxGfPsPxOZpdo88,iv:ScwjGQ4u/pA/vLFjN+AAi6W4S+mf5Bl1NvQk1JiIJQA=,tag:+L3AKpYEKmXbzMFHZAAHCQ==,type:str]
+    forgejo_host: ENC[AES256_GCM,data:vxqOJqWRfF+KRiJ57VQ=,iv:PdfDC4aKwSOkJO5H7A/fv9rnhKtal4zhU5dO+BzDQtE=,tag:kjWO74c7JzEGwkxvOxde5g==,type:str]
 prod_k3s:
-    tunnel_id: ENC[AES256_GCM,data:9PdwOEyIHyKH9VQzEZM42akk9KZJPUK793Fss5JzCManmisw,iv:VzrvxKtHRNpwm481cf/PTv9N9mpDPdS5DJo17s/J2Ps=,tag:y4qVo+sDrSSrcJXVF8+LVw==,type:str]
-    semaphore_host: ENC[AES256_GCM,data:kbixWap9bEQVIzfTAFcNJcmWwt6jEHu5yA==,iv:6hZF5o0G4U70xImJKlzCUQ10TVrtB/Odkx2GO67Mra4=,tag:BmJAtIPm0cjEz3Se55kcDA==,type:str]
-    awx_host: ENC[AES256_GCM,data:q4QVa8XzsalH4vnI6sDq86RSBtFbyGU=,iv:4ki2SIo/cy6nHXa0YLy9G/gluCLkxckNWny6u1irNj8=,tag:XrgvxMC6U8yGN8tDN08lIg==,type:str]
-    flux_webhook_host: ENC[AES256_GCM,data:Dhep1fUgOVQrHmtZe7IoGsjQ4pX07kELqwg9sk/2WA==,iv:Dwb/k9DiVPQwCUP9Jlpr4BsJHH2Nmq28l6+Q48TkOJA=,tag:JQoOyT9/hzRlXkMTUa119A==,type:str]
+    tunnel_id: ENC[AES256_GCM,data:3AymfJDS4ZMtg/pUp6UPB77hlAZa50ZlnY8ePu2rC4TJzD30,iv:VatmubPKQmykHHCeRMe2RRKF6JgWBWqjeNzjxIM22u4=,tag:b86VtZ3KzWKLBnsB1KrVCQ==,type:str]
+    semaphore_host: ENC[AES256_GCM,data:wk6XuEl4pt2KsKFWtRygbNnU1UUDQ+Vnyw==,iv:STNNHXXLHPeXCW1kWoD3oguwHHYtRT211msIepAAN+4=,tag:Wn4x184xZDlClS8tV1+cDg==,type:str]
+    awx_host: ENC[AES256_GCM,data:RO1QDW5RfZCLexZimwZWD+vFgwRJtjQ=,iv:mXz6LzbE5q30S6wGv8Epic3BuPGyWBf4xnqFaV5Bq54=,tag:y0B0F9cjxNwe05+v+XP/BA==,type:str]
+    awx_test_host: ENC[AES256_GCM,data:Lpq/UFsxNimj0+xBe5cc8Oyf/Gkaf3Xl,iv:1S0LgcKjcaURZLBXZMOfPCFSvL96bCpsny46XK9vrvg=,tag:NwfJJlgyIXeC9P4EAOODGg==,type:str]
+    flux_webhook_host: ENC[AES256_GCM,data:Mz3qqUrP75Zy96aYLTvg6inx8w9mxnyr6Q40c0QLrg==,iv:Fnic/e88x31ww9pDDMiwqgcJQ/NdpzprTs3yltOpTOs=,tag:IR2GML3C1V9LjiE1lEiBwA==,type:str]
 sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvTVZod0UyRFV1L0FBK0Q4
-            c0N1Ri9RN1JEV2ZXWmQyY2daL2drWnJ3eGw0CkNDT0thNEg3dEVIZDdUa0hXOG5m
-            ZG1zbWNQU1VWalZkdjVFL2RjTTArc28KLS0tIHVMSXRMQUFUblI0ZGRVVnEzemc4
-            VElvd2lIaGF2R2w0cDNPTlgrSFZyYkEKxonUHZ5LYQs2CiPfcnF553IZAltWzeCF
-            9bKYVyCv9AR8tI5p2Mp+kv95X7q5NEo6VkArG+I12YtDkUQqoXQLUA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBuT1ZIaTNQcVdOdCtrK2JZ
+            Y0NLVzRlckZUQ0E2VnM5TWRXRFNmSWNlSUNnCkFXdmQ3cHV2SWhoNmo4VjE2U2Jp
+            UkYwOVJnVmR6UUNtczM5cWdHNGpoMGsKLS0tIE1JZGNjdVJlaWhjbUVUNVFXczEw
+            ZFVwWTMwalZxUllIMkh3dDBKVDZydEEKlDs2FfVUCctNyd/VovDvIRg0NrKn+Nli
+            LqVYUo3EwM5F/0twLvEDJPgYM036s8cnb0puAlOrd+P7LgWtv7XO4w==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1tce0mlehlddhnlsun7l2kd5mymuf5czk3dk8gs62u7vsxn76hfsq0ajkqv
-    lastmodified: "2026-08-04T19:39:59Z"
-    mac: ENC[AES256_GCM,data:/62K2xdx7f3X1n7nwh2J4JJnLPC1UlDcnA60vsOlvMSeo4iGdPtR7EezhV0TbNaPaOA2c/J/gF/B/cet+Ri4wUgFsWarBjEi0UrXYfcKNno2SQ0g3IIL+3m707DPCURhhKRnAGaLUmRH/UAv+Yx+5Xqf/vLS6dt6s9dr1YHf3Ek=,iv:4TOj4PTPz24bHHfhKoecExQFeHRtBE8Xa+MpVodEiWs=,tag:izsrVS8GiFfqtXReGZ8sYg==,type:str]
+    lastmodified: "2026-08-20T16:47:53Z"
+    mac: ENC[AES256_GCM,data:LsBH/QIYbhWSMviFBr+0ip6swFW2Bgfvocz0hoxy+ezjipl4gBig2qEod3ckw8QCmzqaJOhdayqE8g3Sj1zCR78nC4L04mTFTtkurUgvXy+Jsa4jYAFqY2znX1DkETW7lcNFT6G13vSqEuzM/w2/Hl2PFaU4OyhcOXe+pdtUoSg=,iv:uk240UgsxoQUr4nljG4az0erZYBdU5shxrJCcz3kxPE=,tag:BwVR5NQHTk5C/wbBlKsgEQ==,type:str]
     unencrypted_suffix: _unencrypted
-    version: 3.13.2
+    version: 3.13.3


### PR DESCRIPTION
## Summary
- Adds a new `prod_k3s.awx_test_host` entry to `terraform/cloudflare-tunnel/secrets.sops.yaml`, distinct from `awx_host`.
- Adds a matching Cloudflare Tunnel ingress rule in `main.tf` — same pattern as prod `awx`: routes to the cluster's shared Traefik service, `origin_server_name` set for SNI.
- Adds `ingress_annotations` to `awx-test`'s AWX CR (`external-dns.alpha.kubernetes.io/managed-by`, `cloudflare-proxied`, `target`) — opts its Ingress into the cluster's annotation-gated `external-dns` instance (confirmed cluster-wide scope, `fastnetserv.net` already in its `domainFilters`, no separate wiring needed there).
- Builds on #1866 (Traefik ingress + distinct `AWX_TEST_HOST` cluster-var, to avoid a hostname collision with prod `awx`).
- **Scope change from #1866**: `awx-test` is now internet-reachable via the same Cloudflare Tunnel as prod `awx`, on its own hostname — no longer LAN-only.
- Production `awx` is untouched.

## Test plan
- [x] CI static checks pass (including `terraform validate`/`fmt`, already run locally)
- [x] After merge, Terraform apply creates the new tunnel ingress rule
- [x] Confirm Flux reconciles the updated `awx-test` HelmRelease and the Ingress picks up the annotations
- [x] Confirm `external-dns` creates the DNS record for the new hostname (check its logs/the Cloudflare zone)
- [x] Confirm the AWX login page is reachable over the internet via the new hostname
- [x] Confirm prod `awx`'s tunnel ingress rule and DNS record are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)