### PR TITLE
fix(grafana-alloy): drop unused histogram bucket series to recover cardinality budget

### DIFF
--- a/clusters/kubenuc/apps/grafana-alloy/manifests/release.yml
+++ b/clusters/kubenuc/apps/grafana-alloy/manifests/release.yml
@@ -118,6 +118,13 @@ spec:
             regex         = "(controller_runtime_reconcile_time_seconds|workqueue_queue_duration_seconds|workqueue_work_duration_seconds)_bucket"
             action        = "drop"
           }
+          write_relabel_config {
+            // Velero pod-volume-backup / kopia histogram buckets — no dashboard
+            // consumer today; _sum/_count retained for rate/average queries.
+            source_labels = ["__name__"]
+            regex         = "podVolume_pod_volume_operation_latency_seconds_bucket|kopia_blob_storage_latency_ms_bucket"
+            action        = "drop"
+          }
       grafanaCloudLogs:
         type: loki
         url: ${GRAFANA_LOKI_URL}


### PR DESCRIPTION
## Summary
- Grafana Cloud active series is over the free-tier budget (10,474/10,000 confirmed live).
- Adds a write_relabel_config drop rule for the Velero pod-volume-backup/kopia `_bucket` histogram series on kubenuc — confirmed live at 450 + 153 = 603 series, zero dashboard/alert consumers (grepped terraform/grafana/ dashboards.tf, generate_dashboards.py, alerting.tf, dashboards/*.json).
- `_sum`/`_count` siblings are untouched, so rate/average queries remain possible if a future dashboard needs them.
- First of two Wave 0 PRs (this repo's cardinality-reduction prerequisite before any further Grafana dashboard/scrape work); companion PR targets k8s-vms-daniele's Traefik buckets.

## Test plan
- [x] Dual review (independent Claude/fable subagent + codex-rescue) confirmed HCL/River syntax, regex exactness (full-name alternation, no prefix collision), correct placement within `metricProcessingRules`, and that `_sum`/`_count` siblings exist live for these metrics.
- [ ] After merge + Flux reconcile (~25 min worst case for HelmRelease chart to reload), confirm `podVolume_.*|kopia_.*` `_bucket` series are gone via live Prometheus query.
- [ ] Re-check `grafanacloud_instance_active_series` shows the drop landing near the ~603 estimate for this cluster.