### PR TITLE
fix(grafana-alloy): drop unused histogram bucket series to recover cardinality budget

### DIFF
--- a/clusters/k8s-vms-daniele/apps/grafana-alloy/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/grafana-alloy/manifests/release.yml
@@ -121,6 +121,14 @@ spec:
             regex         = "(controller_runtime_reconcile_time_seconds|workqueue_queue_duration_seconds|workqueue_work_duration_seconds)_bucket"
             action        = "drop"
           }
+          write_relabel_config {
+            // k3s built-in Traefik histogram buckets — no dashboard consumer
+            // today; _requests_total/_request_duration_seconds_sum retained
+            // for the Wave 1 Traefik dashboard.
+            source_labels = ["__name__"]
+            regex         = "traefik_(service|entrypoint)_request_duration_seconds_bucket"
+            action        = "drop"
+          }
       grafanaCloudLogs:
         type: loki
         url: ${GRAFANA_LOKI_URL}


### PR DESCRIPTION
## Summary
- Grafana Cloud active series is over the free-tier budget (10,474/10,000 confirmed live).
- Adds a write_relabel_config drop rule for k3s's built-in Traefik `_bucket` histogram series on k8s-vms-daniele — confirmed live at 345 + 165 = 510 series, zero dashboard/alert consumers (grepped terraform/grafana/ dashboards.tf, generate_dashboards.py, alerting.tf, dashboards/*.json). Note: the standalone `prometheus-node-exporter` chart's drop rule (a few lines above this one) is untouched — deliberately left alone.
- `_requests_total`/`_request_duration_seconds_sum` counters are untouched, kept for a planned request-rate dashboard.
- Second of two Wave 0 PRs (this repo's cardinality-reduction prerequisite before any further Grafana dashboard/scrape work); companion PR targets kubenuc's Velero/kopia buckets.

## Test plan
- [x] Dual review (independent Claude/fable subagent + codex-rescue) confirmed HCL/River syntax, regex exactness (full-name alternation, no prefix collision), correct placement within `metricProcessingRules`, and that the counter siblings exist live for these metrics.
- [ ] After merge + Flux reconcile (~25 min worst case for HelmRelease chart to reload), confirm `traefik_.*_bucket` series are gone via live Prometheus query.
- [ ] Re-check `grafanacloud_instance_active_series` shows the drop landing near the ~510 estimate for this cluster.