### PR TITLE
feat(grafana): add Node Resources, CoreDNS, Flux, Velero, Traefik dashboards

### DIFF
--- a/.github/workflows/terraform-grafana.yml
+++ b/.github/workflows/terraform-grafana.yml
@@ -58,16 +58,38 @@ jobs:
 
       - name: Terraform Plan
         id: plan
-        run: terraform plan -no-color -var 'onepassword_token=${{ secrets.OP_TOKEN }}' -var 'onepassword_endpoint=${{ secrets.OP_ENDPOINT }}'
+        shell: bash
+        run: |
+          terraform plan -no-color -var 'onepassword_token=${{ secrets.OP_TOKEN }}' -var 'onepassword_endpoint=${{ secrets.OP_ENDPOINT }}' | tee plan_output.txt
         continue-on-error: true
 
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         if: github.event_name == 'pull_request'
-        env:
-          PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            // The plan can be large (a wave of new dashboards adds hundreds of
+            // JSON lines per resource). Read it from disk instead of an env
+            // var / ${{ }} interpolation — both go through the runner's
+            // process environment, which has a much lower size ceiling than
+            // a file and previously hit "Argument list too long" spawning
+            // node for this very step. GitHub comment bodies also cap out at
+            // 65536 characters, so truncate with headroom for the rest of
+            // the comment's markdown.
+            const fs = require('fs')
+            const path = require('path')
+            let planText
+            try {
+              planText = fs.readFileSync(path.join('terraform', 'grafana', 'plan_output.txt'), 'utf8')
+            } catch (e) {
+              planText = '(plan output file not found: ' + e.message + ')'
+            }
+            const MAX_PLAN_CHARS = 60000
+            if (planText.length > MAX_PLAN_CHARS) {
+              planText = planText.slice(-MAX_PLAN_CHARS) +
+                '\n\n... (plan truncated — showing the last ' + MAX_PLAN_CHARS + ' characters; see the workflow run logs for the full output)'
+            }
+
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -93,7 +115,7 @@ jobs:
             <details><summary>Show Plan</summary>
 
             \`\`\`\n
-            ${process.env.PLAN}
+            ${planText}
             \`\`\`
 
             </details>

--- a/.github/workflows/terraform-grafana.yml
+++ b/.github/workflows/terraform-grafana.yml
@@ -70,12 +70,11 @@ jobs:
           script: |
             // The plan can be large (a wave of new dashboards adds hundreds of
             // JSON lines per resource). Read it from disk instead of an env
-            // var / ${{ }} interpolation — both go through the runner's
-            // process environment, which has a much lower size ceiling than
-            // a file and previously hit "Argument list too long" spawning
-            // node for this very step. GitHub comment bodies also cap out at
-            // 65536 characters, so truncate with headroom for the rest of
-            // the comment's markdown.
+            // var, since that goes through the runner's process environment,
+            // which has a much lower size ceiling than a file and previously
+            // hit "Argument list too long" spawning node for this very step.
+            // GitHub comment bodies also cap out at 65536 characters, so
+            // truncate with headroom for the rest of the comment's markdown.
             const fs = require('fs')
             const path = require('path')
             let planText

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ decrypted-file.key
 # Ignored Terraform files
 *gitignore*.tf
 
+# terraform-grafana.yml's CI-only plan output capture (see PR that added it)
+terraform/grafana/plan_output.txt
+
 # Terraform variable files with sensitive values
 terraform/DNS/terraform.tfvars
 terraform/DNS/*.auto.tfvars

--- a/terraform/grafana/dashboards.tf
+++ b/terraform/grafana/dashboards.tf
@@ -17,6 +17,11 @@ resource "grafana_dashboard" "kubenuc_cloudflare" {
   config_json = file("${path.module}/dashboards/kubenuc/cloudflare.json")
 }
 
+resource "grafana_dashboard" "kubenuc_coredns" {
+  folder      = grafana_folder.kubenuc.uid
+  config_json = file("${path.module}/dashboards/kubenuc/coredns.json")
+}
+
 resource "grafana_dashboard" "kubenuc_falco" {
   folder      = grafana_folder.kubenuc.uid
   config_json = file("${path.module}/dashboards/kubenuc/falco.json")
@@ -25,6 +30,11 @@ resource "grafana_dashboard" "kubenuc_falco" {
 resource "grafana_dashboard" "kubenuc_film_tv_exporter" {
   folder      = grafana_folder.kubenuc.uid
   config_json = file("${path.module}/dashboards/kubenuc/film-tv-exporter.json")
+}
+
+resource "grafana_dashboard" "kubenuc_flux" {
+  folder      = grafana_folder.kubenuc.uid
+  config_json = file("${path.module}/dashboards/kubenuc/flux.json")
 }
 
 resource "grafana_dashboard" "kubenuc_grafana_alloy" {
@@ -62,6 +72,11 @@ resource "grafana_dashboard" "kubenuc_nextcloud" {
   config_json = file("${path.module}/dashboards/kubenuc/nextcloud.json")
 }
 
+resource "grafana_dashboard" "kubenuc_node_resources" {
+  folder      = grafana_folder.kubenuc.uid
+  config_json = file("${path.module}/dashboards/kubenuc/node-resources.json")
+}
+
 resource "grafana_dashboard" "kubenuc_nut" {
   folder      = grafana_folder.kubenuc.uid
   config_json = file("${path.module}/dashboards/kubenuc/nut.json")
@@ -90,6 +105,11 @@ resource "grafana_dashboard" "kubenuc_sso" {
 resource "grafana_dashboard" "kubenuc_system_upgrade_controller" {
   folder      = grafana_folder.kubenuc.uid
   config_json = file("${path.module}/dashboards/kubenuc/system-upgrade-controller.json")
+}
+
+resource "grafana_dashboard" "kubenuc_velero" {
+  folder      = grafana_folder.kubenuc.uid
+  config_json = file("${path.module}/dashboards/kubenuc/velero.json")
 }
 
 # proxmox
@@ -124,9 +144,19 @@ resource "grafana_dashboard" "k8s_vms_daniele_cloudflare" {
   config_json = file("${path.module}/dashboards/k8s-vms-daniele/cloudflare.json")
 }
 
+resource "grafana_dashboard" "k8s_vms_daniele_coredns" {
+  folder      = grafana_folder.k8s_vms_daniele.uid
+  config_json = file("${path.module}/dashboards/k8s-vms-daniele/coredns.json")
+}
+
 resource "grafana_dashboard" "k8s_vms_daniele_falco" {
   folder      = grafana_folder.k8s_vms_daniele.uid
   config_json = file("${path.module}/dashboards/k8s-vms-daniele/falco.json")
+}
+
+resource "grafana_dashboard" "k8s_vms_daniele_flux" {
+  folder      = grafana_folder.k8s_vms_daniele.uid
+  config_json = file("${path.module}/dashboards/k8s-vms-daniele/flux.json")
 }
 
 resource "grafana_dashboard" "k8s_vms_daniele_grafana_alloy" {
@@ -139,6 +169,11 @@ resource "grafana_dashboard" "k8s_vms_daniele_node_exporter" {
   config_json = file("${path.module}/dashboards/k8s-vms-daniele/node-exporter.json")
 }
 
+resource "grafana_dashboard" "k8s_vms_daniele_node_resources" {
+  folder      = grafana_folder.k8s_vms_daniele.uid
+  config_json = file("${path.module}/dashboards/k8s-vms-daniele/node-resources.json")
+}
+
 resource "grafana_dashboard" "k8s_vms_daniele_system_upgrade_controller" {
   folder      = grafana_folder.k8s_vms_daniele.uid
   config_json = file("${path.module}/dashboards/k8s-vms-daniele/system-upgrade-controller.json")
@@ -147,4 +182,9 @@ resource "grafana_dashboard" "k8s_vms_daniele_system_upgrade_controller" {
 resource "grafana_dashboard" "k8s_vms_daniele_teleport_agent" {
   folder      = grafana_folder.k8s_vms_daniele.uid
   config_json = file("${path.module}/dashboards/k8s-vms-daniele/teleport-agent.json")
+}
+
+resource "grafana_dashboard" "k8s_vms_daniele_traefik" {
+  folder      = grafana_folder.k8s_vms_daniele.uid
+  config_json = file("${path.module}/dashboards/k8s-vms-daniele/traefik.json")
 }

--- a/terraform/grafana/dashboards/k8s-vms-daniele/coredns.json
+++ b/terraform/grafana/dashboards/k8s-vms-daniele/coredns.json
@@ -1,10 +1,9 @@
 {
-  "title": "Falco \u2014 k8s-vms-daniele",
-  "uid": "kv-falco",
+  "title": "CoreDNS \u2014 k8s-vms-daniele",
+  "uid": "kv-coredns",
   "tags": [
     "k8s-vms-daniele",
-    "falco",
-    "security",
+    "coredns",
     "kubernetes"
   ],
   "timezone": "browser",
@@ -24,7 +23,7 @@
   "panels": [
     {
       "id": 1,
-      "title": "Security Events",
+      "title": "Status",
       "type": "row",
       "collapsed": false,
       "gridPos": {
@@ -37,7 +36,7 @@
     },
     {
       "id": 2,
-      "title": "Events (1h)",
+      "title": "Running Pods",
       "type": "stat",
       "datasource": {
         "uid": "grafanacloud-prom",
@@ -51,7 +50,7 @@
       },
       "targets": [
         {
-          "expr": "sum(increase(falcosecurity_falcosidekick_falco_events_total{cluster=\"k8s-vms-daniele\"}[1h]))",
+          "expr": "sum(kube_pod_status_phase{cluster=\"k8s-vms-daniele\",namespace=\"kube-system\",pod=~\"coredns.*\",phase=\"Running\"})",
           "legendFormat": "",
           "refId": "A"
         }
@@ -77,15 +76,11 @@
             "steps": [
               {
                 "value": null,
-                "color": "green"
-              },
-              {
-                "value": 10,
-                "color": "yellow"
-              },
-              {
-                "value": 100,
                 "color": "red"
+              },
+              {
+                "value": 1,
+                "color": "green"
               }
             ]
           },
@@ -99,7 +94,7 @@
     },
     {
       "id": 3,
-      "title": "Critical / Emergency (1h)",
+      "title": "Requests/s",
       "type": "stat",
       "datasource": {
         "uid": "grafanacloud-prom",
@@ -113,7 +108,7 @@
       },
       "targets": [
         {
-          "expr": "sum(increase(falcosecurity_falcosidekick_falco_events_total{cluster=\"k8s-vms-daniele\",priority_raw=~\"critical|emergency\"}[1h]))",
+          "expr": "sum(rate(coredns_dns_requests_total{cluster=\"k8s-vms-daniele\",job=\"kube-dns\"}[5m]))",
           "legendFormat": "",
           "refId": "A"
         }
@@ -133,17 +128,13 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "short",
+          "unit": "reqps",
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
                 "value": null,
                 "color": "green"
-              },
-              {
-                "value": 1,
-                "color": "red"
               }
             ]
           },
@@ -157,7 +148,7 @@
     },
     {
       "id": 4,
-      "title": "Running Pods",
+      "title": "SERVFAIL/s",
       "type": "stat",
       "datasource": {
         "uid": "grafanacloud-prom",
@@ -171,7 +162,7 @@
       },
       "targets": [
         {
-          "expr": "sum(kube_pod_status_phase{cluster=\"k8s-vms-daniele\",namespace=\"falco\",phase=\"Running\"})",
+          "expr": "sum(rate(coredns_dns_responses_total{cluster=\"k8s-vms-daniele\",job=\"kube-dns\",rcode=\"SERVFAIL\"}[5m]))",
           "legendFormat": "",
           "refId": "A"
         }
@@ -191,17 +182,21 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "short",
+          "unit": "reqps",
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
                 "value": null,
-                "color": "red"
+                "color": "green"
+              },
+              {
+                "value": 0.1,
+                "color": "yellow"
               },
               {
                 "value": 1,
-                "color": "green"
+                "color": "red"
               }
             ]
           },
@@ -215,7 +210,7 @@
     },
     {
       "id": 5,
-      "title": "Restarts (24h)",
+      "title": "Cache Hit Ratio",
       "type": "stat",
       "datasource": {
         "uid": "grafanacloud-prom",
@@ -229,7 +224,7 @@
       },
       "targets": [
         {
-          "expr": "sum(increase(kube_pod_container_status_restarts_total{cluster=\"k8s-vms-daniele\",namespace=\"falco\"}[24h]))",
+          "expr": "sum(rate(coredns_cache_hits_total{cluster=\"k8s-vms-daniele\",job=\"kube-dns\"}[5m])) / (sum(rate(coredns_cache_hits_total{cluster=\"k8s-vms-daniele\",job=\"kube-dns\"}[5m])) + sum(rate(coredns_cache_misses_total{cluster=\"k8s-vms-daniele\",job=\"kube-dns\"}[5m])))",
           "legendFormat": "",
           "refId": "A"
         }
@@ -249,21 +244,13 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "short",
+          "unit": "percentunit",
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
                 "value": null,
                 "color": "green"
-              },
-              {
-                "value": 1,
-                "color": "yellow"
-              },
-              {
-                "value": 5,
-                "color": "red"
               }
             ]
           },
@@ -277,7 +264,7 @@
     },
     {
       "id": 6,
-      "title": "Event Trends",
+      "title": "Queries",
       "type": "row",
       "collapsed": false,
       "gridPos": {
@@ -290,7 +277,7 @@
     },
     {
       "id": 7,
-      "title": "Events by Priority",
+      "title": "Requests/s by Server",
       "type": "timeseries",
       "datasource": {
         "uid": "grafanacloud-prom",
@@ -304,8 +291,8 @@
       },
       "targets": [
         {
-          "expr": "sum by (priority_raw) (rate(falcosecurity_falcosidekick_falco_events_total{cluster=\"k8s-vms-daniele\"}[5m]))",
-          "legendFormat": "{{priority_raw}}",
+          "expr": "sum by (server) (rate(coredns_dns_requests_total{cluster=\"k8s-vms-daniele\",job=\"kube-dns\"}[5m]))",
+          "legendFormat": "{{server}}",
           "refId": "A"
         }
       ],
@@ -325,7 +312,7 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "cps",
+          "unit": "reqps",
           "custom": {
             "lineWidth": 1,
             "fillOpacity": 10,
@@ -338,7 +325,7 @@
     },
     {
       "id": 8,
-      "title": "Top 10 Rules",
+      "title": "Responses/s by Code",
       "type": "timeseries",
       "datasource": {
         "uid": "grafanacloud-prom",
@@ -352,8 +339,8 @@
       },
       "targets": [
         {
-          "expr": "topk(10, sum by (rule) (rate(falcosecurity_falcosidekick_falco_events_total{cluster=\"k8s-vms-daniele\"}[5m])))",
-          "legendFormat": "{{rule}}",
+          "expr": "sum by (rcode) (rate(coredns_dns_responses_total{cluster=\"k8s-vms-daniele\",job=\"kube-dns\"}[5m]))",
+          "legendFormat": "{{rcode}}",
           "refId": "A"
         }
       ],
@@ -373,7 +360,7 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "cps",
+          "unit": "reqps",
           "custom": {
             "lineWidth": 1,
             "fillOpacity": 10,
@@ -386,7 +373,7 @@
     },
     {
       "id": 9,
-      "title": "Resources",
+      "title": "Cache & Forwarding",
       "type": "row",
       "collapsed": false,
       "gridPos": {
@@ -399,7 +386,7 @@
     },
     {
       "id": 10,
-      "title": "CPU Usage",
+      "title": "Cache Hits vs Misses",
       "type": "timeseries",
       "datasource": {
         "uid": "grafanacloud-prom",
@@ -413,9 +400,14 @@
       },
       "targets": [
         {
-          "expr": "sum by (pod) (rate(container_cpu_usage_seconds_total{cluster=\"k8s-vms-daniele\",namespace=\"falco\",container!=\"\",container!=\"POD\"}[5m]))",
-          "legendFormat": "{{pod}}",
+          "expr": "sum(rate(coredns_cache_hits_total{cluster=\"k8s-vms-daniele\",job=\"kube-dns\"}[5m]))",
+          "legendFormat": "hits",
           "refId": "A"
+        },
+        {
+          "expr": "sum(rate(coredns_cache_misses_total{cluster=\"k8s-vms-daniele\",job=\"kube-dns\"}[5m]))",
+          "legendFormat": "misses",
+          "refId": "B"
         }
       ],
       "options": {
@@ -434,7 +426,7 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "short",
+          "unit": "ops",
           "custom": {
             "lineWidth": 1,
             "fillOpacity": 10,
@@ -447,7 +439,7 @@
     },
     {
       "id": 11,
-      "title": "Memory Usage",
+      "title": "Proxy (Forward) Latency (avg)",
       "type": "timeseries",
       "datasource": {
         "uid": "grafanacloud-prom",
@@ -461,8 +453,8 @@
       },
       "targets": [
         {
-          "expr": "sum by (pod) (container_memory_working_set_bytes{cluster=\"k8s-vms-daniele\",namespace=\"falco\",container!=\"\",container!=\"POD\"})",
-          "legendFormat": "{{pod}}",
+          "expr": "sum(rate(coredns_proxy_request_duration_seconds_sum{cluster=\"k8s-vms-daniele\",job=\"kube-dns\"}[5m])) / sum(rate(coredns_proxy_request_duration_seconds_count{cluster=\"k8s-vms-daniele\",job=\"kube-dns\"}[5m]))",
+          "legendFormat": "avg latency",
           "refId": "A"
         }
       ],
@@ -482,7 +474,7 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "bytes",
+          "unit": "s",
           "custom": {
             "lineWidth": 1,
             "fillOpacity": 10,
@@ -522,7 +514,7 @@
       },
       "targets": [
         {
-          "expr": "{cluster=\"k8s-vms-daniele\",namespace=\"falco\"}",
+          "expr": "{cluster=\"k8s-vms-daniele\",namespace=\"kube-system\"} | pod=~\"coredns.*\"",
           "refId": "A",
           "queryType": "range"
         }

--- a/terraform/grafana/dashboards/k8s-vms-daniele/flux.json
+++ b/terraform/grafana/dashboards/k8s-vms-daniele/flux.json
@@ -1,10 +1,10 @@
 {
-  "title": "Falco \u2014 k8s-vms-daniele",
-  "uid": "kv-falco",
+  "title": "Flux \u2014 k8s-vms-daniele",
+  "uid": "kv-flux",
   "tags": [
     "k8s-vms-daniele",
-    "falco",
-    "security",
+    "flux",
+    "gitops",
     "kubernetes"
   ],
   "timezone": "browser",
@@ -24,7 +24,7 @@
   "panels": [
     {
       "id": 1,
-      "title": "Security Events",
+      "title": "Status",
       "type": "row",
       "collapsed": false,
       "gridPos": {
@@ -37,7 +37,7 @@
     },
     {
       "id": 2,
-      "title": "Events (1h)",
+      "title": "Running Pods",
       "type": "stat",
       "datasource": {
         "uid": "grafanacloud-prom",
@@ -51,7 +51,7 @@
       },
       "targets": [
         {
-          "expr": "sum(increase(falcosecurity_falcosidekick_falco_events_total{cluster=\"k8s-vms-daniele\"}[1h]))",
+          "expr": "sum(kube_pod_status_phase{cluster=\"k8s-vms-daniele\",namespace=\"flux-system\",phase=\"Running\"})",
           "legendFormat": "",
           "refId": "A"
         }
@@ -77,15 +77,11 @@
             "steps": [
               {
                 "value": null,
-                "color": "green"
-              },
-              {
-                "value": 10,
-                "color": "yellow"
-              },
-              {
-                "value": 100,
                 "color": "red"
+              },
+              {
+                "value": 1,
+                "color": "green"
               }
             ]
           },
@@ -99,7 +95,7 @@
     },
     {
       "id": 3,
-      "title": "Critical / Emergency (1h)",
+      "title": "Reconciles/s (all controllers)",
       "type": "stat",
       "datasource": {
         "uid": "grafanacloud-prom",
@@ -113,7 +109,7 @@
       },
       "targets": [
         {
-          "expr": "sum(increase(falcosecurity_falcosidekick_falco_events_total{cluster=\"k8s-vms-daniele\",priority_raw=~\"critical|emergency\"}[1h]))",
+          "expr": "sum(rate(controller_runtime_reconcile_time_seconds_count{cluster=\"k8s-vms-daniele\",job=~\"flux-operator|kustomize-controller|helm-controller|source-controller|notification-controller\"}[5m]))",
           "legendFormat": "",
           "refId": "A"
         }
@@ -133,17 +129,13 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "short",
+          "unit": "ops",
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
                 "value": null,
                 "color": "green"
-              },
-              {
-                "value": 1,
-                "color": "red"
               }
             ]
           },
@@ -157,7 +149,7 @@
     },
     {
       "id": 4,
-      "title": "Running Pods",
+      "title": "Total Workqueue Depth",
       "type": "stat",
       "datasource": {
         "uid": "grafanacloud-prom",
@@ -171,7 +163,7 @@
       },
       "targets": [
         {
-          "expr": "sum(kube_pod_status_phase{cluster=\"k8s-vms-daniele\",namespace=\"falco\",phase=\"Running\"})",
+          "expr": "sum(workqueue_depth{cluster=\"k8s-vms-daniele\",job=~\"flux-operator|kustomize-controller|helm-controller|source-controller|notification-controller\"})",
           "legendFormat": "",
           "refId": "A"
         }
@@ -197,11 +189,15 @@
             "steps": [
               {
                 "value": null,
-                "color": "red"
+                "color": "green"
               },
               {
-                "value": 1,
-                "color": "green"
+                "value": 20,
+                "color": "yellow"
+              },
+              {
+                "value": 100,
+                "color": "red"
               }
             ]
           },
@@ -229,7 +225,7 @@
       },
       "targets": [
         {
-          "expr": "sum(increase(kube_pod_container_status_restarts_total{cluster=\"k8s-vms-daniele\",namespace=\"falco\"}[24h]))",
+          "expr": "sum(increase(kube_pod_container_status_restarts_total{cluster=\"k8s-vms-daniele\",namespace=\"flux-system\"}[24h]))",
           "legendFormat": "",
           "refId": "A"
         }
@@ -277,7 +273,7 @@
     },
     {
       "id": 6,
-      "title": "Event Trends",
+      "title": "Reconciliation",
       "type": "row",
       "collapsed": false,
       "gridPos": {
@@ -290,7 +286,7 @@
     },
     {
       "id": 7,
-      "title": "Events by Priority",
+      "title": "Reconciles/s by Controller",
       "type": "timeseries",
       "datasource": {
         "uid": "grafanacloud-prom",
@@ -304,8 +300,8 @@
       },
       "targets": [
         {
-          "expr": "sum by (priority_raw) (rate(falcosecurity_falcosidekick_falco_events_total{cluster=\"k8s-vms-daniele\"}[5m]))",
-          "legendFormat": "{{priority_raw}}",
+          "expr": "sum by (job) (rate(controller_runtime_reconcile_time_seconds_count{cluster=\"k8s-vms-daniele\",job=~\"flux-operator|kustomize-controller|helm-controller|source-controller|notification-controller\"}[5m]))",
+          "legendFormat": "{{job}}",
           "refId": "A"
         }
       ],
@@ -325,7 +321,7 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "cps",
+          "unit": "ops",
           "custom": {
             "lineWidth": 1,
             "fillOpacity": 10,
@@ -338,7 +334,7 @@
     },
     {
       "id": 8,
-      "title": "Top 10 Rules",
+      "title": "Avg Reconcile Duration by Controller",
       "type": "timeseries",
       "datasource": {
         "uid": "grafanacloud-prom",
@@ -352,8 +348,8 @@
       },
       "targets": [
         {
-          "expr": "topk(10, sum by (rule) (rate(falcosecurity_falcosidekick_falco_events_total{cluster=\"k8s-vms-daniele\"}[5m])))",
-          "legendFormat": "{{rule}}",
+          "expr": "sum by (job) (rate(controller_runtime_reconcile_time_seconds_sum{cluster=\"k8s-vms-daniele\",job=~\"flux-operator|kustomize-controller|helm-controller|source-controller|notification-controller\"}[5m])) / sum by (job) (rate(controller_runtime_reconcile_time_seconds_count{cluster=\"k8s-vms-daniele\",job=~\"flux-operator|kustomize-controller|helm-controller|source-controller|notification-controller\"}[5m]))",
+          "legendFormat": "{{job}}",
           "refId": "A"
         }
       ],
@@ -373,7 +369,7 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "cps",
+          "unit": "s",
           "custom": {
             "lineWidth": 1,
             "fillOpacity": 10,
@@ -386,7 +382,7 @@
     },
     {
       "id": 9,
-      "title": "Resources",
+      "title": "Controller Health",
       "type": "row",
       "collapsed": false,
       "gridPos": {
@@ -399,7 +395,7 @@
     },
     {
       "id": 10,
-      "title": "CPU Usage",
+      "title": "Workqueue Depth by Controller",
       "type": "timeseries",
       "datasource": {
         "uid": "grafanacloud-prom",
@@ -413,8 +409,8 @@
       },
       "targets": [
         {
-          "expr": "sum by (pod) (rate(container_cpu_usage_seconds_total{cluster=\"k8s-vms-daniele\",namespace=\"falco\",container!=\"\",container!=\"POD\"}[5m]))",
-          "legendFormat": "{{pod}}",
+          "expr": "workqueue_depth{cluster=\"k8s-vms-daniele\",job=~\"flux-operator|kustomize-controller|helm-controller|source-controller|notification-controller\"}",
+          "legendFormat": "{{job}}",
           "refId": "A"
         }
       ],
@@ -447,7 +443,7 @@
     },
     {
       "id": 11,
-      "title": "Memory Usage",
+      "title": "Leader Election Status by Controller",
       "type": "timeseries",
       "datasource": {
         "uid": "grafanacloud-prom",
@@ -461,8 +457,8 @@
       },
       "targets": [
         {
-          "expr": "sum by (pod) (container_memory_working_set_bytes{cluster=\"k8s-vms-daniele\",namespace=\"falco\",container!=\"\",container!=\"POD\"})",
-          "legendFormat": "{{pod}}",
+          "expr": "leader_election_master_status{cluster=\"k8s-vms-daniele\",job=~\"flux-operator|kustomize-controller|helm-controller|source-controller|notification-controller\"}",
+          "legendFormat": "{{job}}",
           "refId": "A"
         }
       ],
@@ -482,7 +478,7 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "bytes",
+          "unit": "short",
           "custom": {
             "lineWidth": 1,
             "fillOpacity": 10,
@@ -522,7 +518,7 @@
       },
       "targets": [
         {
-          "expr": "{cluster=\"k8s-vms-daniele\",namespace=\"falco\"}",
+          "expr": "{cluster=\"k8s-vms-daniele\",namespace=\"flux-system\"}",
           "refId": "A",
           "queryType": "range"
         }

--- a/terraform/grafana/dashboards/k8s-vms-daniele/node-resources.json
+++ b/terraform/grafana/dashboards/k8s-vms-daniele/node-resources.json
@@ -1,0 +1,258 @@
+{
+  "title": "Node Resources \u2014 k8s-vms-daniele",
+  "uid": "kv-node-resources",
+  "tags": [
+    "k8s-vms-daniele",
+    "node-resources",
+    "kubernetes"
+  ],
+  "timezone": "browser",
+  "refresh": "1m",
+  "schemaVersion": 38,
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "templating": {
+    "list": []
+  },
+  "annotations": {
+    "list": []
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "CPU",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 2,
+      "title": "CPU Usage by Node",
+      "type": "timeseries",
+      "datasource": {
+        "uid": "grafanacloud-prom",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 1,
+        "w": 24,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum by (instance) (rate(node_cpu_usage_seconds_total{cluster=\"k8s-vms-daniele\",job=\"integrations/kubernetes/resources\"}[5m]))",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 3,
+      "title": "Memory",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 9,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 4,
+      "title": "Memory Working Set by Node",
+      "type": "timeseries",
+      "datasource": {
+        "uid": "grafanacloud-prom",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 10,
+        "w": 24,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "node_memory_working_set_bytes{cluster=\"k8s-vms-daniele\",job=\"integrations/kubernetes/resources\"}",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 5,
+      "title": "Network",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 18,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 6,
+      "title": "Network Receive by Node",
+      "type": "timeseries",
+      "datasource": {
+        "uid": "grafanacloud-prom",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 19,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "rate(node_network_receive_bytes_total{cluster=\"k8s-vms-daniele\",job=\"integrations/kubernetes/resources\"}[5m])",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 7,
+      "title": "Network Transmit by Node",
+      "type": "timeseries",
+      "datasource": {
+        "uid": "grafanacloud-prom",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 19,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "rate(node_network_transmit_bytes_total{cluster=\"k8s-vms-daniele\",job=\"integrations/kubernetes/resources\"}[5m])",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      }
+    }
+  ],
+  "version": 1,
+  "editable": true
+}

--- a/terraform/grafana/dashboards/k8s-vms-daniele/traefik.json
+++ b/terraform/grafana/dashboards/k8s-vms-daniele/traefik.json
@@ -1,10 +1,10 @@
 {
-  "title": "Falco \u2014 k8s-vms-daniele",
-  "uid": "kv-falco",
+  "title": "Traefik \u2014 k8s-vms-daniele",
+  "uid": "kv-traefik",
   "tags": [
     "k8s-vms-daniele",
-    "falco",
-    "security",
+    "traefik",
+    "ingress",
     "kubernetes"
   ],
   "timezone": "browser",
@@ -24,7 +24,7 @@
   "panels": [
     {
       "id": 1,
-      "title": "Security Events",
+      "title": "Status",
       "type": "row",
       "collapsed": false,
       "gridPos": {
@@ -37,7 +37,7 @@
     },
     {
       "id": 2,
-      "title": "Events (1h)",
+      "title": "Running Pods",
       "type": "stat",
       "datasource": {
         "uid": "grafanacloud-prom",
@@ -51,7 +51,7 @@
       },
       "targets": [
         {
-          "expr": "sum(increase(falcosecurity_falcosidekick_falco_events_total{cluster=\"k8s-vms-daniele\"}[1h]))",
+          "expr": "sum(kube_pod_status_phase{cluster=\"k8s-vms-daniele\",namespace=\"kube-system\",pod=~\"traefik.*\",phase=\"Running\"})",
           "legendFormat": "",
           "refId": "A"
         }
@@ -77,15 +77,11 @@
             "steps": [
               {
                 "value": null,
-                "color": "green"
-              },
-              {
-                "value": 10,
-                "color": "yellow"
-              },
-              {
-                "value": 100,
                 "color": "red"
+              },
+              {
+                "value": 1,
+                "color": "green"
               }
             ]
           },
@@ -99,7 +95,7 @@
     },
     {
       "id": 3,
-      "title": "Critical / Emergency (1h)",
+      "title": "Requests/s (all entrypoints)",
       "type": "stat",
       "datasource": {
         "uid": "grafanacloud-prom",
@@ -113,7 +109,7 @@
       },
       "targets": [
         {
-          "expr": "sum(increase(falcosecurity_falcosidekick_falco_events_total{cluster=\"k8s-vms-daniele\",priority_raw=~\"critical|emergency\"}[1h]))",
+          "expr": "sum(rate(traefik_entrypoint_requests_total{cluster=\"k8s-vms-daniele\",job=\"traefik\"}[5m]))",
           "legendFormat": "",
           "refId": "A"
         }
@@ -133,17 +129,13 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "short",
+          "unit": "reqps",
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
                 "value": null,
                 "color": "green"
-              },
-              {
-                "value": 1,
-                "color": "red"
               }
             ]
           },
@@ -157,7 +149,7 @@
     },
     {
       "id": 4,
-      "title": "Running Pods",
+      "title": "5xx/s",
       "type": "stat",
       "datasource": {
         "uid": "grafanacloud-prom",
@@ -171,7 +163,7 @@
       },
       "targets": [
         {
-          "expr": "sum(kube_pod_status_phase{cluster=\"k8s-vms-daniele\",namespace=\"falco\",phase=\"Running\"})",
+          "expr": "sum(rate(traefik_entrypoint_requests_total{cluster=\"k8s-vms-daniele\",job=\"traefik\",code=~\"5..\"}[5m]))",
           "legendFormat": "",
           "refId": "A"
         }
@@ -191,17 +183,21 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "short",
+          "unit": "reqps",
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
                 "value": null,
-                "color": "red"
+                "color": "green"
+              },
+              {
+                "value": 0.1,
+                "color": "yellow"
               },
               {
                 "value": 1,
-                "color": "green"
+                "color": "red"
               }
             ]
           },
@@ -229,7 +225,7 @@
       },
       "targets": [
         {
-          "expr": "sum(increase(kube_pod_container_status_restarts_total{cluster=\"k8s-vms-daniele\",namespace=\"falco\"}[24h]))",
+          "expr": "sum(increase(kube_pod_container_status_restarts_total{cluster=\"k8s-vms-daniele\",namespace=\"kube-system\",pod=~\"traefik.*\"}[24h]))",
           "legendFormat": "",
           "refId": "A"
         }
@@ -277,7 +273,7 @@
     },
     {
       "id": 6,
-      "title": "Event Trends",
+      "title": "Requests",
       "type": "row",
       "collapsed": false,
       "gridPos": {
@@ -290,7 +286,7 @@
     },
     {
       "id": 7,
-      "title": "Events by Priority",
+      "title": "Requests/s by Entrypoint",
       "type": "timeseries",
       "datasource": {
         "uid": "grafanacloud-prom",
@@ -304,8 +300,8 @@
       },
       "targets": [
         {
-          "expr": "sum by (priority_raw) (rate(falcosecurity_falcosidekick_falco_events_total{cluster=\"k8s-vms-daniele\"}[5m]))",
-          "legendFormat": "{{priority_raw}}",
+          "expr": "sum by (entrypoint) (rate(traefik_entrypoint_requests_total{cluster=\"k8s-vms-daniele\",job=\"traefik\"}[5m]))",
+          "legendFormat": "{{entrypoint}}",
           "refId": "A"
         }
       ],
@@ -325,7 +321,7 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "cps",
+          "unit": "reqps",
           "custom": {
             "lineWidth": 1,
             "fillOpacity": 10,
@@ -338,7 +334,7 @@
     },
     {
       "id": 8,
-      "title": "Top 10 Rules",
+      "title": "Requests/s by Service",
       "type": "timeseries",
       "datasource": {
         "uid": "grafanacloud-prom",
@@ -352,8 +348,8 @@
       },
       "targets": [
         {
-          "expr": "topk(10, sum by (rule) (rate(falcosecurity_falcosidekick_falco_events_total{cluster=\"k8s-vms-daniele\"}[5m])))",
-          "legendFormat": "{{rule}}",
+          "expr": "sum by (service) (rate(traefik_service_requests_total{cluster=\"k8s-vms-daniele\",job=\"traefik\"}[5m]))",
+          "legendFormat": "{{service}}",
           "refId": "A"
         }
       ],
@@ -373,7 +369,7 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "cps",
+          "unit": "reqps",
           "custom": {
             "lineWidth": 1,
             "fillOpacity": 10,
@@ -386,7 +382,7 @@
     },
     {
       "id": 9,
-      "title": "Resources",
+      "title": "Errors",
       "type": "row",
       "collapsed": false,
       "gridPos": {
@@ -399,7 +395,7 @@
     },
     {
       "id": 10,
-      "title": "CPU Usage",
+      "title": "Requests/s by Status Code",
       "type": "timeseries",
       "datasource": {
         "uid": "grafanacloud-prom",
@@ -408,13 +404,13 @@
       "gridPos": {
         "x": 0,
         "y": 15,
-        "w": 12,
+        "w": 24,
         "h": 8
       },
       "targets": [
         {
-          "expr": "sum by (pod) (rate(container_cpu_usage_seconds_total{cluster=\"k8s-vms-daniele\",namespace=\"falco\",container!=\"\",container!=\"POD\"}[5m]))",
-          "legendFormat": "{{pod}}",
+          "expr": "sum by (code) (rate(traefik_entrypoint_requests_total{cluster=\"k8s-vms-daniele\",job=\"traefik\"}[5m]))",
+          "legendFormat": "{{code}}",
           "refId": "A"
         }
       ],
@@ -434,7 +430,7 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "short",
+          "unit": "reqps",
           "custom": {
             "lineWidth": 1,
             "fillOpacity": 10,
@@ -447,54 +443,6 @@
     },
     {
       "id": 11,
-      "title": "Memory Usage",
-      "type": "timeseries",
-      "datasource": {
-        "uid": "grafanacloud-prom",
-        "type": "prometheus"
-      },
-      "gridPos": {
-        "x": 12,
-        "y": 15,
-        "w": 12,
-        "h": 8
-      },
-      "targets": [
-        {
-          "expr": "sum by (pod) (container_memory_working_set_bytes{cluster=\"k8s-vms-daniele\",namespace=\"falco\",container!=\"\",container!=\"POD\"})",
-          "legendFormat": "{{pod}}",
-          "refId": "A"
-        }
-      ],
-      "options": {
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        },
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "calcs": [
-            "lastNotNull",
-            "max"
-          ]
-        }
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "bytes",
-          "custom": {
-            "lineWidth": 1,
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "spanNulls": false
-          }
-        },
-        "overrides": []
-      }
-    },
-    {
-      "id": 12,
       "title": "Logs",
       "type": "row",
       "collapsed": false,
@@ -507,7 +455,7 @@
       "panels": []
     },
     {
-      "id": 13,
+      "id": 12,
       "title": "Pod Logs",
       "type": "logs",
       "datasource": {
@@ -522,7 +470,7 @@
       },
       "targets": [
         {
-          "expr": "{cluster=\"k8s-vms-daniele\",namespace=\"falco\"}",
+          "expr": "{cluster=\"k8s-vms-daniele\",namespace=\"kube-system\"} | pod=~\"traefik.*\"",
           "refId": "A",
           "queryType": "range"
         }

--- a/terraform/grafana/dashboards/kubenuc/coredns.json
+++ b/terraform/grafana/dashboards/kubenuc/coredns.json
@@ -1,10 +1,9 @@
 {
-  "title": "Falco \u2014 k8s-vms-daniele",
-  "uid": "kv-falco",
+  "title": "CoreDNS \u2014 kubenuc",
+  "uid": "kn-coredns",
   "tags": [
-    "k8s-vms-daniele",
-    "falco",
-    "security",
+    "kubenuc",
+    "coredns",
     "kubernetes"
   ],
   "timezone": "browser",
@@ -24,7 +23,7 @@
   "panels": [
     {
       "id": 1,
-      "title": "Security Events",
+      "title": "Status",
       "type": "row",
       "collapsed": false,
       "gridPos": {
@@ -37,7 +36,7 @@
     },
     {
       "id": 2,
-      "title": "Events (1h)",
+      "title": "Running Pods",
       "type": "stat",
       "datasource": {
         "uid": "grafanacloud-prom",
@@ -51,7 +50,7 @@
       },
       "targets": [
         {
-          "expr": "sum(increase(falcosecurity_falcosidekick_falco_events_total{cluster=\"k8s-vms-daniele\"}[1h]))",
+          "expr": "sum(kube_pod_status_phase{cluster=\"kubenuc\",namespace=\"kube-system\",pod=~\"coredns.*\",phase=\"Running\"})",
           "legendFormat": "",
           "refId": "A"
         }
@@ -77,15 +76,11 @@
             "steps": [
               {
                 "value": null,
-                "color": "green"
-              },
-              {
-                "value": 10,
-                "color": "yellow"
-              },
-              {
-                "value": 100,
                 "color": "red"
+              },
+              {
+                "value": 1,
+                "color": "green"
               }
             ]
           },
@@ -99,7 +94,7 @@
     },
     {
       "id": 3,
-      "title": "Critical / Emergency (1h)",
+      "title": "Requests/s",
       "type": "stat",
       "datasource": {
         "uid": "grafanacloud-prom",
@@ -113,7 +108,7 @@
       },
       "targets": [
         {
-          "expr": "sum(increase(falcosecurity_falcosidekick_falco_events_total{cluster=\"k8s-vms-daniele\",priority_raw=~\"critical|emergency\"}[1h]))",
+          "expr": "sum(rate(coredns_dns_requests_total{cluster=\"kubenuc\",job=\"kube-dns\"}[5m]))",
           "legendFormat": "",
           "refId": "A"
         }
@@ -133,17 +128,13 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "short",
+          "unit": "reqps",
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
                 "value": null,
                 "color": "green"
-              },
-              {
-                "value": 1,
-                "color": "red"
               }
             ]
           },
@@ -157,7 +148,7 @@
     },
     {
       "id": 4,
-      "title": "Running Pods",
+      "title": "SERVFAIL/s",
       "type": "stat",
       "datasource": {
         "uid": "grafanacloud-prom",
@@ -171,7 +162,7 @@
       },
       "targets": [
         {
-          "expr": "sum(kube_pod_status_phase{cluster=\"k8s-vms-daniele\",namespace=\"falco\",phase=\"Running\"})",
+          "expr": "sum(rate(coredns_dns_responses_total{cluster=\"kubenuc\",job=\"kube-dns\",rcode=\"SERVFAIL\"}[5m]))",
           "legendFormat": "",
           "refId": "A"
         }
@@ -191,17 +182,21 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "short",
+          "unit": "reqps",
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
                 "value": null,
-                "color": "red"
+                "color": "green"
+              },
+              {
+                "value": 0.1,
+                "color": "yellow"
               },
               {
                 "value": 1,
-                "color": "green"
+                "color": "red"
               }
             ]
           },
@@ -215,7 +210,7 @@
     },
     {
       "id": 5,
-      "title": "Restarts (24h)",
+      "title": "Cache Hit Ratio",
       "type": "stat",
       "datasource": {
         "uid": "grafanacloud-prom",
@@ -229,7 +224,7 @@
       },
       "targets": [
         {
-          "expr": "sum(increase(kube_pod_container_status_restarts_total{cluster=\"k8s-vms-daniele\",namespace=\"falco\"}[24h]))",
+          "expr": "sum(rate(coredns_cache_hits_total{cluster=\"kubenuc\",job=\"kube-dns\"}[5m])) / (sum(rate(coredns_cache_hits_total{cluster=\"kubenuc\",job=\"kube-dns\"}[5m])) + sum(rate(coredns_cache_misses_total{cluster=\"kubenuc\",job=\"kube-dns\"}[5m])))",
           "legendFormat": "",
           "refId": "A"
         }
@@ -249,21 +244,13 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "short",
+          "unit": "percentunit",
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
                 "value": null,
                 "color": "green"
-              },
-              {
-                "value": 1,
-                "color": "yellow"
-              },
-              {
-                "value": 5,
-                "color": "red"
               }
             ]
           },
@@ -277,7 +264,7 @@
     },
     {
       "id": 6,
-      "title": "Event Trends",
+      "title": "Queries",
       "type": "row",
       "collapsed": false,
       "gridPos": {
@@ -290,7 +277,7 @@
     },
     {
       "id": 7,
-      "title": "Events by Priority",
+      "title": "Requests/s by Server",
       "type": "timeseries",
       "datasource": {
         "uid": "grafanacloud-prom",
@@ -304,8 +291,8 @@
       },
       "targets": [
         {
-          "expr": "sum by (priority_raw) (rate(falcosecurity_falcosidekick_falco_events_total{cluster=\"k8s-vms-daniele\"}[5m]))",
-          "legendFormat": "{{priority_raw}}",
+          "expr": "sum by (server) (rate(coredns_dns_requests_total{cluster=\"kubenuc\",job=\"kube-dns\"}[5m]))",
+          "legendFormat": "{{server}}",
           "refId": "A"
         }
       ],
@@ -325,7 +312,7 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "cps",
+          "unit": "reqps",
           "custom": {
             "lineWidth": 1,
             "fillOpacity": 10,
@@ -338,7 +325,7 @@
     },
     {
       "id": 8,
-      "title": "Top 10 Rules",
+      "title": "Responses/s by Code",
       "type": "timeseries",
       "datasource": {
         "uid": "grafanacloud-prom",
@@ -352,8 +339,8 @@
       },
       "targets": [
         {
-          "expr": "topk(10, sum by (rule) (rate(falcosecurity_falcosidekick_falco_events_total{cluster=\"k8s-vms-daniele\"}[5m])))",
-          "legendFormat": "{{rule}}",
+          "expr": "sum by (rcode) (rate(coredns_dns_responses_total{cluster=\"kubenuc\",job=\"kube-dns\"}[5m]))",
+          "legendFormat": "{{rcode}}",
           "refId": "A"
         }
       ],
@@ -373,7 +360,7 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "cps",
+          "unit": "reqps",
           "custom": {
             "lineWidth": 1,
             "fillOpacity": 10,
@@ -386,7 +373,7 @@
     },
     {
       "id": 9,
-      "title": "Resources",
+      "title": "Cache & Forwarding",
       "type": "row",
       "collapsed": false,
       "gridPos": {
@@ -399,7 +386,7 @@
     },
     {
       "id": 10,
-      "title": "CPU Usage",
+      "title": "Cache Hits vs Misses",
       "type": "timeseries",
       "datasource": {
         "uid": "grafanacloud-prom",
@@ -413,9 +400,14 @@
       },
       "targets": [
         {
-          "expr": "sum by (pod) (rate(container_cpu_usage_seconds_total{cluster=\"k8s-vms-daniele\",namespace=\"falco\",container!=\"\",container!=\"POD\"}[5m]))",
-          "legendFormat": "{{pod}}",
+          "expr": "sum(rate(coredns_cache_hits_total{cluster=\"kubenuc\",job=\"kube-dns\"}[5m]))",
+          "legendFormat": "hits",
           "refId": "A"
+        },
+        {
+          "expr": "sum(rate(coredns_cache_misses_total{cluster=\"kubenuc\",job=\"kube-dns\"}[5m]))",
+          "legendFormat": "misses",
+          "refId": "B"
         }
       ],
       "options": {
@@ -434,7 +426,7 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "short",
+          "unit": "ops",
           "custom": {
             "lineWidth": 1,
             "fillOpacity": 10,
@@ -447,7 +439,7 @@
     },
     {
       "id": 11,
-      "title": "Memory Usage",
+      "title": "Proxy (Forward) Latency (avg)",
       "type": "timeseries",
       "datasource": {
         "uid": "grafanacloud-prom",
@@ -461,8 +453,8 @@
       },
       "targets": [
         {
-          "expr": "sum by (pod) (container_memory_working_set_bytes{cluster=\"k8s-vms-daniele\",namespace=\"falco\",container!=\"\",container!=\"POD\"})",
-          "legendFormat": "{{pod}}",
+          "expr": "sum(rate(coredns_proxy_request_duration_seconds_sum{cluster=\"kubenuc\",job=\"kube-dns\"}[5m])) / sum(rate(coredns_proxy_request_duration_seconds_count{cluster=\"kubenuc\",job=\"kube-dns\"}[5m]))",
+          "legendFormat": "avg latency",
           "refId": "A"
         }
       ],
@@ -482,7 +474,7 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "bytes",
+          "unit": "s",
           "custom": {
             "lineWidth": 1,
             "fillOpacity": 10,
@@ -522,7 +514,7 @@
       },
       "targets": [
         {
-          "expr": "{cluster=\"k8s-vms-daniele\",namespace=\"falco\"}",
+          "expr": "{cluster=\"kubenuc\",namespace=\"kube-system\"} | pod=~\"coredns.*\"",
           "refId": "A",
           "queryType": "range"
         }

--- a/terraform/grafana/dashboards/kubenuc/falco.json
+++ b/terraform/grafana/dashboards/kubenuc/falco.json
@@ -113,7 +113,7 @@
       },
       "targets": [
         {
-          "expr": "sum(increase(falcosecurity_falcosidekick_falco_events_total{cluster=\"kubenuc\",priority=~\"Critical|Emergency\"}[1h]))",
+          "expr": "sum(increase(falcosecurity_falcosidekick_falco_events_total{cluster=\"kubenuc\",priority_raw=~\"critical|emergency\"}[1h]))",
           "legendFormat": "",
           "refId": "A"
         }
@@ -304,8 +304,8 @@
       },
       "targets": [
         {
-          "expr": "sum by (priority) (rate(falcosecurity_falcosidekick_falco_events_total{cluster=\"kubenuc\"}[5m]))",
-          "legendFormat": "{{priority}}",
+          "expr": "sum by (priority_raw) (rate(falcosecurity_falcosidekick_falco_events_total{cluster=\"kubenuc\"}[5m]))",
+          "legendFormat": "{{priority_raw}}",
           "refId": "A"
         }
       ],

--- a/terraform/grafana/dashboards/kubenuc/flux.json
+++ b/terraform/grafana/dashboards/kubenuc/flux.json
@@ -1,10 +1,10 @@
 {
-  "title": "Falco \u2014 k8s-vms-daniele",
-  "uid": "kv-falco",
+  "title": "Flux \u2014 kubenuc",
+  "uid": "kn-flux",
   "tags": [
-    "k8s-vms-daniele",
-    "falco",
-    "security",
+    "kubenuc",
+    "flux",
+    "gitops",
     "kubernetes"
   ],
   "timezone": "browser",
@@ -24,7 +24,7 @@
   "panels": [
     {
       "id": 1,
-      "title": "Security Events",
+      "title": "Status",
       "type": "row",
       "collapsed": false,
       "gridPos": {
@@ -37,7 +37,7 @@
     },
     {
       "id": 2,
-      "title": "Events (1h)",
+      "title": "Running Pods",
       "type": "stat",
       "datasource": {
         "uid": "grafanacloud-prom",
@@ -51,7 +51,7 @@
       },
       "targets": [
         {
-          "expr": "sum(increase(falcosecurity_falcosidekick_falco_events_total{cluster=\"k8s-vms-daniele\"}[1h]))",
+          "expr": "sum(kube_pod_status_phase{cluster=\"kubenuc\",namespace=\"flux-system\",phase=\"Running\"})",
           "legendFormat": "",
           "refId": "A"
         }
@@ -77,15 +77,11 @@
             "steps": [
               {
                 "value": null,
-                "color": "green"
-              },
-              {
-                "value": 10,
-                "color": "yellow"
-              },
-              {
-                "value": 100,
                 "color": "red"
+              },
+              {
+                "value": 1,
+                "color": "green"
               }
             ]
           },
@@ -99,7 +95,7 @@
     },
     {
       "id": 3,
-      "title": "Critical / Emergency (1h)",
+      "title": "Reconciles/s (all controllers)",
       "type": "stat",
       "datasource": {
         "uid": "grafanacloud-prom",
@@ -113,7 +109,7 @@
       },
       "targets": [
         {
-          "expr": "sum(increase(falcosecurity_falcosidekick_falco_events_total{cluster=\"k8s-vms-daniele\",priority_raw=~\"critical|emergency\"}[1h]))",
+          "expr": "sum(rate(controller_runtime_reconcile_time_seconds_count{cluster=\"kubenuc\",job=~\"flux-operator|kustomize-controller|helm-controller|source-controller|notification-controller\"}[5m]))",
           "legendFormat": "",
           "refId": "A"
         }
@@ -133,17 +129,13 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "short",
+          "unit": "ops",
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
                 "value": null,
                 "color": "green"
-              },
-              {
-                "value": 1,
-                "color": "red"
               }
             ]
           },
@@ -157,7 +149,7 @@
     },
     {
       "id": 4,
-      "title": "Running Pods",
+      "title": "Total Workqueue Depth",
       "type": "stat",
       "datasource": {
         "uid": "grafanacloud-prom",
@@ -171,7 +163,7 @@
       },
       "targets": [
         {
-          "expr": "sum(kube_pod_status_phase{cluster=\"k8s-vms-daniele\",namespace=\"falco\",phase=\"Running\"})",
+          "expr": "sum(workqueue_depth{cluster=\"kubenuc\",job=~\"flux-operator|kustomize-controller|helm-controller|source-controller|notification-controller\"})",
           "legendFormat": "",
           "refId": "A"
         }
@@ -197,11 +189,15 @@
             "steps": [
               {
                 "value": null,
-                "color": "red"
+                "color": "green"
               },
               {
-                "value": 1,
-                "color": "green"
+                "value": 20,
+                "color": "yellow"
+              },
+              {
+                "value": 100,
+                "color": "red"
               }
             ]
           },
@@ -229,7 +225,7 @@
       },
       "targets": [
         {
-          "expr": "sum(increase(kube_pod_container_status_restarts_total{cluster=\"k8s-vms-daniele\",namespace=\"falco\"}[24h]))",
+          "expr": "sum(increase(kube_pod_container_status_restarts_total{cluster=\"kubenuc\",namespace=\"flux-system\"}[24h]))",
           "legendFormat": "",
           "refId": "A"
         }
@@ -277,7 +273,7 @@
     },
     {
       "id": 6,
-      "title": "Event Trends",
+      "title": "Reconciliation",
       "type": "row",
       "collapsed": false,
       "gridPos": {
@@ -290,7 +286,7 @@
     },
     {
       "id": 7,
-      "title": "Events by Priority",
+      "title": "Reconciles/s by Controller",
       "type": "timeseries",
       "datasource": {
         "uid": "grafanacloud-prom",
@@ -304,8 +300,8 @@
       },
       "targets": [
         {
-          "expr": "sum by (priority_raw) (rate(falcosecurity_falcosidekick_falco_events_total{cluster=\"k8s-vms-daniele\"}[5m]))",
-          "legendFormat": "{{priority_raw}}",
+          "expr": "sum by (job) (rate(controller_runtime_reconcile_time_seconds_count{cluster=\"kubenuc\",job=~\"flux-operator|kustomize-controller|helm-controller|source-controller|notification-controller\"}[5m]))",
+          "legendFormat": "{{job}}",
           "refId": "A"
         }
       ],
@@ -325,7 +321,7 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "cps",
+          "unit": "ops",
           "custom": {
             "lineWidth": 1,
             "fillOpacity": 10,
@@ -338,7 +334,7 @@
     },
     {
       "id": 8,
-      "title": "Top 10 Rules",
+      "title": "Avg Reconcile Duration by Controller",
       "type": "timeseries",
       "datasource": {
         "uid": "grafanacloud-prom",
@@ -352,8 +348,8 @@
       },
       "targets": [
         {
-          "expr": "topk(10, sum by (rule) (rate(falcosecurity_falcosidekick_falco_events_total{cluster=\"k8s-vms-daniele\"}[5m])))",
-          "legendFormat": "{{rule}}",
+          "expr": "sum by (job) (rate(controller_runtime_reconcile_time_seconds_sum{cluster=\"kubenuc\",job=~\"flux-operator|kustomize-controller|helm-controller|source-controller|notification-controller\"}[5m])) / sum by (job) (rate(controller_runtime_reconcile_time_seconds_count{cluster=\"kubenuc\",job=~\"flux-operator|kustomize-controller|helm-controller|source-controller|notification-controller\"}[5m]))",
+          "legendFormat": "{{job}}",
           "refId": "A"
         }
       ],
@@ -373,7 +369,7 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "cps",
+          "unit": "s",
           "custom": {
             "lineWidth": 1,
             "fillOpacity": 10,
@@ -386,7 +382,7 @@
     },
     {
       "id": 9,
-      "title": "Resources",
+      "title": "Controller Health",
       "type": "row",
       "collapsed": false,
       "gridPos": {
@@ -399,7 +395,7 @@
     },
     {
       "id": 10,
-      "title": "CPU Usage",
+      "title": "Workqueue Depth by Controller",
       "type": "timeseries",
       "datasource": {
         "uid": "grafanacloud-prom",
@@ -413,8 +409,8 @@
       },
       "targets": [
         {
-          "expr": "sum by (pod) (rate(container_cpu_usage_seconds_total{cluster=\"k8s-vms-daniele\",namespace=\"falco\",container!=\"\",container!=\"POD\"}[5m]))",
-          "legendFormat": "{{pod}}",
+          "expr": "workqueue_depth{cluster=\"kubenuc\",job=~\"flux-operator|kustomize-controller|helm-controller|source-controller|notification-controller\"}",
+          "legendFormat": "{{job}}",
           "refId": "A"
         }
       ],
@@ -447,7 +443,7 @@
     },
     {
       "id": 11,
-      "title": "Memory Usage",
+      "title": "Leader Election Status by Controller",
       "type": "timeseries",
       "datasource": {
         "uid": "grafanacloud-prom",
@@ -461,8 +457,8 @@
       },
       "targets": [
         {
-          "expr": "sum by (pod) (container_memory_working_set_bytes{cluster=\"k8s-vms-daniele\",namespace=\"falco\",container!=\"\",container!=\"POD\"})",
-          "legendFormat": "{{pod}}",
+          "expr": "leader_election_master_status{cluster=\"kubenuc\",job=~\"flux-operator|kustomize-controller|helm-controller|source-controller|notification-controller\"}",
+          "legendFormat": "{{job}}",
           "refId": "A"
         }
       ],
@@ -482,7 +478,7 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "bytes",
+          "unit": "short",
           "custom": {
             "lineWidth": 1,
             "fillOpacity": 10,
@@ -522,7 +518,7 @@
       },
       "targets": [
         {
-          "expr": "{cluster=\"k8s-vms-daniele\",namespace=\"falco\"}",
+          "expr": "{cluster=\"kubenuc\",namespace=\"flux-system\"}",
           "refId": "A",
           "queryType": "range"
         }

--- a/terraform/grafana/dashboards/kubenuc/node-resources.json
+++ b/terraform/grafana/dashboards/kubenuc/node-resources.json
@@ -1,0 +1,258 @@
+{
+  "title": "Node Resources \u2014 kubenuc",
+  "uid": "kn-node-resources",
+  "tags": [
+    "kubenuc",
+    "node-resources",
+    "kubernetes"
+  ],
+  "timezone": "browser",
+  "refresh": "1m",
+  "schemaVersion": 38,
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "templating": {
+    "list": []
+  },
+  "annotations": {
+    "list": []
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "CPU",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 2,
+      "title": "CPU Usage by Node",
+      "type": "timeseries",
+      "datasource": {
+        "uid": "grafanacloud-prom",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 1,
+        "w": 24,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum by (instance) (rate(node_cpu_usage_seconds_total{cluster=\"kubenuc\",job=\"integrations/kubernetes/resources\"}[5m]))",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 3,
+      "title": "Memory",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 9,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 4,
+      "title": "Memory Working Set by Node",
+      "type": "timeseries",
+      "datasource": {
+        "uid": "grafanacloud-prom",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 10,
+        "w": 24,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "node_memory_working_set_bytes{cluster=\"kubenuc\",job=\"integrations/kubernetes/resources\"}",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 5,
+      "title": "Network",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 18,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 6,
+      "title": "Network Receive by Node",
+      "type": "timeseries",
+      "datasource": {
+        "uid": "grafanacloud-prom",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 19,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "rate(node_network_receive_bytes_total{cluster=\"kubenuc\",job=\"integrations/kubernetes/resources\"}[5m])",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 7,
+      "title": "Network Transmit by Node",
+      "type": "timeseries",
+      "datasource": {
+        "uid": "grafanacloud-prom",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 19,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "rate(node_network_transmit_bytes_total{cluster=\"kubenuc\",job=\"integrations/kubernetes/resources\"}[5m])",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      }
+    }
+  ],
+  "version": 1,
+  "editable": true
+}

--- a/terraform/grafana/dashboards/kubenuc/velero.json
+++ b/terraform/grafana/dashboards/kubenuc/velero.json
@@ -1,0 +1,958 @@
+{
+  "title": "Velero \u2014 kubenuc",
+  "uid": "kn-velero",
+  "tags": [
+    "kubenuc",
+    "velero",
+    "backup",
+    "kubernetes"
+  ],
+  "timezone": "browser",
+  "refresh": "1m",
+  "schemaVersion": 38,
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "templating": {
+    "list": []
+  },
+  "annotations": {
+    "list": []
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Status",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 2,
+      "title": "Running Pods",
+      "type": "stat",
+      "datasource": {
+        "uid": "grafanacloud-prom",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 1,
+        "w": 6,
+        "h": 4
+      },
+      "targets": [
+        {
+          "expr": "sum(kube_pod_status_phase{cluster=\"kubenuc\",namespace=\"velero\",phase=\"Running\"})",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "red"
+              },
+              {
+                "value": 1,
+                "color": "green"
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": []
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 3,
+      "title": "Ready Containers",
+      "type": "stat",
+      "datasource": {
+        "uid": "grafanacloud-prom",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 6,
+        "y": 1,
+        "w": 6,
+        "h": 4
+      },
+      "targets": [
+        {
+          "expr": "sum(kube_pod_container_status_ready{cluster=\"kubenuc\",namespace=\"velero\"})",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "red"
+              },
+              {
+                "value": 1,
+                "color": "green"
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": []
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 4,
+      "title": "Restarts (24h)",
+      "type": "stat",
+      "datasource": {
+        "uid": "grafanacloud-prom",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 1,
+        "w": 6,
+        "h": 4
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(kube_pod_container_status_restarts_total{cluster=\"kubenuc\",namespace=\"velero\"}[24h]))",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "green"
+              },
+              {
+                "value": 1,
+                "color": "yellow"
+              },
+              {
+                "value": 5,
+                "color": "red"
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": []
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 5,
+      "title": "Replicas (Available / Desired)",
+      "type": "stat",
+      "datasource": {
+        "uid": "grafanacloud-prom",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 18,
+        "y": 1,
+        "w": 6,
+        "h": 4
+      },
+      "targets": [
+        {
+          "expr": "sum(kube_deployment_status_replicas_available{cluster=\"kubenuc\",namespace=\"velero\"})",
+          "legendFormat": "Available",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(kube_deployment_spec_replicas{cluster=\"kubenuc\",namespace=\"velero\"})",
+          "legendFormat": "Desired",
+          "refId": "B"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "textMode": "value_and_name",
+        "colorMode": "value",
+        "graphMode": "none"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": []
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 6,
+      "title": "Backups",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 5,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 7,
+      "title": "Successful (24h)",
+      "type": "stat",
+      "datasource": {
+        "uid": "grafanacloud-prom",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 6,
+        "w": 6,
+        "h": 4
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(velero_backup_success_total{cluster=\"kubenuc\"}[24h]))",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "red"
+              },
+              {
+                "value": 1,
+                "color": "green"
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": []
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 8,
+      "title": "Failed (24h)",
+      "type": "stat",
+      "datasource": {
+        "uid": "grafanacloud-prom",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 6,
+        "y": 6,
+        "w": 6,
+        "h": 4
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(velero_backup_failure_total{cluster=\"kubenuc\"}[24h]))",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "green"
+              },
+              {
+                "value": 1,
+                "color": "red"
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": []
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 9,
+      "title": "Partial Failures (24h)",
+      "type": "stat",
+      "datasource": {
+        "uid": "grafanacloud-prom",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 6,
+        "w": 6,
+        "h": 4
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(velero_backup_partial_failure_total{cluster=\"kubenuc\"}[24h]))",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "green"
+              },
+              {
+                "value": 1,
+                "color": "yellow"
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": []
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 10,
+      "title": "Time Since Last Success",
+      "type": "stat",
+      "datasource": {
+        "uid": "grafanacloud-prom",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 18,
+        "y": 6,
+        "w": 6,
+        "h": 4
+      },
+      "targets": [
+        {
+          "expr": "time() - max(velero_backup_last_successful_timestamp{cluster=\"kubenuc\"})",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "green"
+              },
+              {
+                "value": 172800,
+                "color": "yellow"
+              },
+              {
+                "value": 259200,
+                "color": "red"
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": []
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 11,
+      "title": "Backup Detail",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 10,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 12,
+      "title": "Backup Attempts/s by Result",
+      "type": "timeseries",
+      "datasource": {
+        "uid": "grafanacloud-prom",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 11,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(velero_backup_success_total{cluster=\"kubenuc\"}[1h]))",
+          "legendFormat": "success",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(velero_backup_failure_total{cluster=\"kubenuc\"}[1h]))",
+          "legendFormat": "failure",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(rate(velero_backup_partial_failure_total{cluster=\"kubenuc\"}[1h]))",
+          "legendFormat": "partial failure",
+          "refId": "C"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 13,
+      "title": "Avg Backup Duration",
+      "type": "timeseries",
+      "datasource": {
+        "uid": "grafanacloud-prom",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 11,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(velero_backup_duration_seconds_sum{cluster=\"kubenuc\"}[1h])) / sum(rate(velero_backup_duration_seconds_count{cluster=\"kubenuc\"}[1h]))",
+          "legendFormat": "avg duration",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 14,
+      "title": "Items Backed Up / Errors",
+      "type": "timeseries",
+      "datasource": {
+        "uid": "grafanacloud-prom",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 19,
+        "w": 24,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(velero_backup_items_total{cluster=\"kubenuc\"}[1h]))",
+          "legendFormat": "items",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(velero_backup_items_errors{cluster=\"kubenuc\"}[1h]))",
+          "legendFormat": "errors",
+          "refId": "B"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 15,
+      "title": "Resources",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 27,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 16,
+      "title": "CPU Usage by Pod",
+      "type": "timeseries",
+      "datasource": {
+        "uid": "grafanacloud-prom",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 28,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum by (pod) (rate(container_cpu_usage_seconds_total{cluster=\"kubenuc\",namespace=\"velero\",container!=\"\",container!=\"POD\"}[5m]))",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 17,
+      "title": "Memory Usage by Pod",
+      "type": "timeseries",
+      "datasource": {
+        "uid": "grafanacloud-prom",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 28,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum by (pod) (container_memory_working_set_bytes{cluster=\"kubenuc\",namespace=\"velero\",container!=\"\",container!=\"POD\"})",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 18,
+      "title": "Reliability",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 36,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 19,
+      "title": "Container Restarts",
+      "type": "timeseries",
+      "datasource": {
+        "uid": "grafanacloud-prom",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 37,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum by (pod, container) (rate(kube_pod_container_status_restarts_total{cluster=\"kubenuc\",namespace=\"velero\"}[5m]))",
+          "legendFormat": "{{pod}}/{{container}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 20,
+      "title": "Network I/O",
+      "type": "timeseries",
+      "datasource": {
+        "uid": "grafanacloud-prom",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 37,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(container_network_receive_bytes_total{cluster=\"kubenuc\",namespace=\"velero\"}[5m]))",
+          "legendFormat": "Receive",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(container_network_transmit_bytes_total{cluster=\"kubenuc\",namespace=\"velero\"}[5m]))",
+          "legendFormat": "Transmit",
+          "refId": "B"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 21,
+      "title": "Logs",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 45,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 22,
+      "title": "Pod Logs",
+      "type": "logs",
+      "datasource": {
+        "uid": "grafanacloud-logs",
+        "type": "loki"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 46,
+        "w": 24,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "{cluster=\"kubenuc\",namespace=\"velero\"}",
+          "refId": "A",
+          "queryType": "range"
+        }
+      ],
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": false
+      }
+    }
+  ],
+  "version": 1,
+  "editable": true
+}

--- a/terraform/grafana/generate_dashboards.py
+++ b/terraform/grafana/generate_dashboards.py
@@ -327,7 +327,7 @@ def build_falco(cluster, namespace, uid_str):
         0, y, thresholds=[{"value": None, "color": "green"}, {"value": 10, "color": "yellow"}, {"value": 100, "color": "red"}]
     )); pid += 1
     panels.append(p_stat(pid, "Critical / Emergency (1h)",
-        f'sum(increase(falcosecurity_falcosidekick_falco_events_total{{cluster="{c}",priority=~"Critical|Emergency"}}[1h]))',
+        f'sum(increase(falcosecurity_falcosidekick_falco_events_total{{cluster="{c}",priority_raw=~"critical|emergency"}}[1h]))',
         6, y, thresholds=[{"value": None, "color": "green"}, {"value": 1, "color": "red"}]
     )); pid += 1
     panels.append(p_stat(pid, "Running Pods",
@@ -341,7 +341,7 @@ def build_falco(cluster, namespace, uid_str):
 
     panels.append(p_row(pid, "Event Trends", y)); pid += 1; y += 1
     panels.append(p_ts(pid, "Events by Priority",
-        [{"expr": f'sum by (priority) (rate(falcosecurity_falcosidekick_falco_events_total{{cluster="{c}"}}[5m]))', "legend": "{{priority}}"}],
+        [{"expr": f'sum by (priority_raw) (rate(falcosecurity_falcosidekick_falco_events_total{{cluster="{c}"}}[5m]))', "legend": "{{priority_raw}}"}],
         0, y, w=12, unit="cps"
     )); pid += 1
     panels.append(p_ts(pid, "Top 10 Rules",
@@ -662,6 +662,278 @@ def build_rabbit_netbw(uid_str):
     )
 
 
+def build_node_resources(cluster, uid_str):
+    """Node-scoped resource dashboard using the k8s-monitoring chart's built-in
+    low-cardinality resource collector (job=integrations/kubernetes/resources),
+    distinct from the standalone prometheus-node-exporter chart on
+    k8s-vms-daniele (job=prometheus-node-exporter, deliberately dropped
+    upstream — do not use that job here). No namespace filter: node-scoped.
+    """
+    c = cluster
+    jf = ',job="integrations/kubernetes/resources"'
+    panels = []
+    pid, y = 1, 0
+
+    panels.append(p_row(pid, "CPU", y)); pid += 1; y += 1
+    panels.append(p_ts(pid, "CPU Usage by Node",
+        [{"expr": f'sum by (instance) (rate(node_cpu_usage_seconds_total{{cluster="{c}"{jf}}}[5m]))', "legend": "{{instance}}"}],
+        0, y, w=24, unit="short"
+    )); pid += 1; y += 8
+
+    panels.append(p_row(pid, "Memory", y)); pid += 1; y += 1
+    panels.append(p_ts(pid, "Memory Working Set by Node",
+        [{"expr": f'node_memory_working_set_bytes{{cluster="{c}"{jf}}}', "legend": "{{instance}}"}],
+        0, y, w=24, unit="bytes"
+    )); pid += 1; y += 8
+
+    panels.append(p_row(pid, "Network", y)); pid += 1; y += 1
+    panels.append(p_ts(pid, "Network Receive by Node",
+        [{"expr": f'rate(node_network_receive_bytes_total{{cluster="{c}"{jf}}}[5m])', "legend": "{{instance}}"}],
+        0, y, w=12, unit="Bps"
+    )); pid += 1
+    panels.append(p_ts(pid, "Network Transmit by Node",
+        [{"expr": f'rate(node_network_transmit_bytes_total{{cluster="{c}"{jf}}}[5m])', "legend": "{{instance}}"}],
+        12, y, w=12, unit="Bps"
+    )); pid += 1
+
+    return make_dashboard(f"Node Resources — {cluster}", uid_str, [cluster, "node-resources", "kubernetes"], panels)
+
+
+def build_coredns(cluster, uid_str):
+    """job=kube-dns, namespace=kube-system on both clusters (confirmed live).
+    Latency comes from the proxy plugin (coredns_proxy_request_duration_seconds_*),
+    not a "forward_*" latency metric — CoreDNS has no such metric; only
+    coredns_forward_healthcheck_broken_total/coredns_forward_max_concurrent_rejects_total
+    exist under the forward_ prefix, both event counters, not latency.
+    """
+    c, n = cluster, "kube-system"
+    jf = ',job="kube-dns"'
+    panels = []
+    pid, y = 1, 0
+
+    panels.append(p_row(pid, "Status", y)); pid += 1; y += 1
+    panels.append(p_stat(pid, "Running Pods",
+        f'sum(kube_pod_status_phase{{cluster="{c}",namespace="{n}",pod=~"coredns.*",phase="Running"}})',
+        0, y, thresholds=[{"value": None, "color": "red"}, {"value": 1, "color": "green"}]
+    )); pid += 1
+    panels.append(p_stat(pid, "Requests/s",
+        f'sum(rate(coredns_dns_requests_total{{cluster="{c}"{jf}}}[5m]))',
+        6, y, unit="reqps"
+    )); pid += 1
+    panels.append(p_stat(pid, "SERVFAIL/s",
+        f'sum(rate(coredns_dns_responses_total{{cluster="{c}"{jf},rcode="SERVFAIL"}}[5m]))',
+        12, y, unit="reqps",
+        thresholds=[{"value": None, "color": "green"}, {"value": 0.1, "color": "yellow"}, {"value": 1, "color": "red"}]
+    )); pid += 1
+    panels.append(p_stat(pid, "Cache Hit Ratio",
+        f'sum(rate(coredns_cache_hits_total{{cluster="{c}"{jf}}}[5m])) / '
+        f'(sum(rate(coredns_cache_hits_total{{cluster="{c}"{jf}}}[5m])) + sum(rate(coredns_cache_misses_total{{cluster="{c}"{jf}}}[5m])))',
+        18, y, unit="percentunit"
+    )); pid += 1; y += 4
+
+    panels.append(p_row(pid, "Queries", y)); pid += 1; y += 1
+    panels.append(p_ts(pid, "Requests/s by Server",
+        [{"expr": f'sum by (server) (rate(coredns_dns_requests_total{{cluster="{c}"{jf}}}[5m]))', "legend": "{{server}}"}],
+        0, y, w=12, unit="reqps"
+    )); pid += 1
+    panels.append(p_ts(pid, "Responses/s by Code",
+        [{"expr": f'sum by (rcode) (rate(coredns_dns_responses_total{{cluster="{c}"{jf}}}[5m]))', "legend": "{{rcode}}"}],
+        12, y, w=12, unit="reqps"
+    )); pid += 1; y += 8
+
+    panels.append(p_row(pid, "Cache & Forwarding", y)); pid += 1; y += 1
+    panels.append(p_ts(pid, "Cache Hits vs Misses",
+        [
+            {"expr": f'sum(rate(coredns_cache_hits_total{{cluster="{c}"{jf}}}[5m]))', "legend": "hits"},
+            {"expr": f'sum(rate(coredns_cache_misses_total{{cluster="{c}"{jf}}}[5m]))', "legend": "misses"},
+        ],
+        0, y, w=12, unit="ops"
+    )); pid += 1
+    panels.append(p_ts(pid, "Proxy (Forward) Latency (avg)",
+        [{"expr": f'sum(rate(coredns_proxy_request_duration_seconds_sum{{cluster="{c}"{jf}}}[5m])) / '
+                  f'sum(rate(coredns_proxy_request_duration_seconds_count{{cluster="{c}"{jf}}}[5m]))', "legend": "avg latency"}],
+        12, y, w=12, unit="s"
+    )); pid += 1; y += 8
+
+    panels.append(p_row(pid, "Logs", y)); pid += 1; y += 1
+    panels.append(p_logs(pid, c, n, y, extra_filter=' | pod=~"coredns.*"'))
+
+    return make_dashboard(f"CoreDNS — {cluster}", uid_str, [cluster, "coredns", "kubernetes"], panels)
+
+
+FLUX_JOBS = "flux-operator|kustomize-controller|helm-controller|source-controller|notification-controller"
+
+
+def build_flux(cluster, uid_str):
+    """namespace=flux-system, jobs=FLUX_JOBS on both clusters (confirmed live).
+    No per-resource-kind reconcile success/failure panel: the classic
+    gotk_reconcile_* metrics are dropped before remote-write by the
+    "gotk" alternative in the first write_relabel_config rule in this
+    cluster's grafana-alloy release.yml (self-diagnostics cleanup) — that
+    data never reaches Grafana Cloud today. Built instead from what's
+    actually live: controller-runtime reconcile latency (_sum/_count,
+    not _bucket — already dropped by an existing rule), workqueue depth,
+    and leader-election status, all confirmed live per controller.
+    """
+    c, n = cluster, "flux-system"
+    jf = f',job=~"{FLUX_JOBS}"'
+    panels = []
+    pid, y = 1, 0
+
+    panels.append(p_row(pid, "Status", y)); pid += 1; y += 1
+    panels.append(p_stat(pid, "Running Pods",
+        f'sum(kube_pod_status_phase{{cluster="{c}",namespace="{n}",phase="Running"}})',
+        0, y, thresholds=[{"value": None, "color": "red"}, {"value": 1, "color": "green"}]
+    )); pid += 1
+    panels.append(p_stat(pid, "Reconciles/s (all controllers)",
+        f'sum(rate(controller_runtime_reconcile_time_seconds_count{{cluster="{c}"{jf}}}[5m]))',
+        6, y, unit="ops"
+    )); pid += 1
+    panels.append(p_stat(pid, "Total Workqueue Depth",
+        f'sum(workqueue_depth{{cluster="{c}"{jf}}})',
+        12, y, thresholds=[{"value": None, "color": "green"}, {"value": 20, "color": "yellow"}, {"value": 100, "color": "red"}]
+    )); pid += 1
+    panels.append(p_stat(pid, "Restarts (24h)",
+        f'sum(increase(kube_pod_container_status_restarts_total{{cluster="{c}",namespace="{n}"}}[24h]))',
+        18, y, thresholds=[{"value": None, "color": "green"}, {"value": 1, "color": "yellow"}, {"value": 5, "color": "red"}]
+    )); pid += 1; y += 4
+
+    panels.append(p_row(pid, "Reconciliation", y)); pid += 1; y += 1
+    panels.append(p_ts(pid, "Reconciles/s by Controller",
+        [{"expr": f'sum by (job) (rate(controller_runtime_reconcile_time_seconds_count{{cluster="{c}"{jf}}}[5m]))', "legend": "{{job}}"}],
+        0, y, w=12, unit="ops"
+    )); pid += 1
+    panels.append(p_ts(pid, "Avg Reconcile Duration by Controller",
+        [{"expr": f'sum by (job) (rate(controller_runtime_reconcile_time_seconds_sum{{cluster="{c}"{jf}}}[5m])) / '
+                  f'sum by (job) (rate(controller_runtime_reconcile_time_seconds_count{{cluster="{c}"{jf}}}[5m]))', "legend": "{{job}}"}],
+        12, y, w=12, unit="s"
+    )); pid += 1; y += 8
+
+    panels.append(p_row(pid, "Controller Health", y)); pid += 1; y += 1
+    panels.append(p_ts(pid, "Workqueue Depth by Controller",
+        [{"expr": f'workqueue_depth{{cluster="{c}"{jf}}}', "legend": "{{job}}"}],
+        0, y, w=12, unit="short"
+    )); pid += 1
+    panels.append(p_ts(pid, "Leader Election Status by Controller",
+        [{"expr": f'leader_election_master_status{{cluster="{c}"{jf}}}', "legend": "{{job}}"}],
+        12, y, w=12, unit="short"
+    )); pid += 1; y += 8
+
+    panels.append(p_row(pid, "Logs", y)); pid += 1; y += 1
+    panels.append(p_logs(pid, c, n, y))
+
+    return make_dashboard(f"Flux — {cluster}", uid_str, [cluster, "flux", "gitops", "kubernetes"], panels)
+
+
+def build_velero(uid_str):
+    """kubenuc only. namespace=velero, job=velero (confirmed live)."""
+    c, n = "kubenuc", "velero"
+    panels, pid, y = status_row(1, 0, c, n)
+
+    panels.append(p_row(pid, "Backups", y)); pid += 1; y += 1
+    panels.append(p_stat(pid, "Successful (24h)",
+        f'sum(increase(velero_backup_success_total{{cluster="{c}"}}[24h]))',
+        0, y, w=6, thresholds=[{"value": None, "color": "red"}, {"value": 1, "color": "green"}]
+    )); pid += 1
+    panels.append(p_stat(pid, "Failed (24h)",
+        f'sum(increase(velero_backup_failure_total{{cluster="{c}"}}[24h]))',
+        6, y, w=6, thresholds=[{"value": None, "color": "green"}, {"value": 1, "color": "red"}]
+    )); pid += 1
+    panels.append(p_stat(pid, "Partial Failures (24h)",
+        f'sum(increase(velero_backup_partial_failure_total{{cluster="{c}"}}[24h]))',
+        12, y, w=6, thresholds=[{"value": None, "color": "green"}, {"value": 1, "color": "yellow"}]
+    )); pid += 1
+    panels.append(p_stat(pid, "Time Since Last Success",
+        f'time() - max(velero_backup_last_successful_timestamp{{cluster="{c}"}})',
+        18, y, w=6, unit="s", instant=True,
+        thresholds=[{"value": None, "color": "green"}, {"value": 172800, "color": "yellow"}, {"value": 259200, "color": "red"}]
+    )); pid += 1; y += 4
+
+    panels.append(p_row(pid, "Backup Detail", y)); pid += 1; y += 1
+    panels.append(p_ts(pid, "Backup Attempts/s by Result",
+        [
+            {"expr": f'sum(rate(velero_backup_success_total{{cluster="{c}"}}[1h]))', "legend": "success"},
+            {"expr": f'sum(rate(velero_backup_failure_total{{cluster="{c}"}}[1h]))', "legend": "failure"},
+            {"expr": f'sum(rate(velero_backup_partial_failure_total{{cluster="{c}"}}[1h]))', "legend": "partial failure"},
+        ],
+        0, y, w=12, unit="ops"
+    )); pid += 1
+    panels.append(p_ts(pid, "Avg Backup Duration",
+        [{"expr": f'sum(rate(velero_backup_duration_seconds_sum{{cluster="{c}"}}[1h])) / '
+                  f'sum(rate(velero_backup_duration_seconds_count{{cluster="{c}"}}[1h]))', "legend": "avg duration"}],
+        12, y, w=12, unit="s"
+    )); pid += 1; y += 8
+
+    panels.append(p_ts(pid, "Items Backed Up / Errors",
+        [
+            {"expr": f'sum(rate(velero_backup_items_total{{cluster="{c}"}}[1h]))', "legend": "items"},
+            {"expr": f'sum(rate(velero_backup_items_errors{{cluster="{c}"}}[1h]))', "legend": "errors"},
+        ],
+        0, y, w=24, unit="ops"
+    )); pid += 1; y += 8
+
+    rp, pid, y = resource_row(pid, y, c, n)
+    panels += rp
+    rp, pid, y = reliability_row(pid, y, c, n)
+    panels += rp
+
+    panels.append(p_row(pid, "Logs", y)); pid += 1; y += 1
+    panels.append(p_logs(pid, c, n, y))
+
+    return make_dashboard(f"Velero — {c}", uid_str, [c, "velero", "backup", "kubernetes"], panels)
+
+
+def build_traefik(uid_str):
+    """k8s-vms-daniele only. k3s's built-in Traefik, namespace=kube-system,
+    job=traefik (confirmed live). Uses the *_requests_total counters, not the
+    *_request_duration_seconds_bucket histograms (dropped in Wave 0).
+    """
+    c, n = "k8s-vms-daniele", "kube-system"
+    jf = ',job="traefik"'
+    panels = []
+    pid, y = 1, 0
+
+    panels.append(p_row(pid, "Status", y)); pid += 1; y += 1
+    panels.append(p_stat(pid, "Running Pods",
+        f'sum(kube_pod_status_phase{{cluster="{c}",namespace="{n}",pod=~"traefik.*",phase="Running"}})',
+        0, y, thresholds=[{"value": None, "color": "red"}, {"value": 1, "color": "green"}]
+    )); pid += 1
+    panels.append(p_stat(pid, "Requests/s (all entrypoints)",
+        f'sum(rate(traefik_entrypoint_requests_total{{cluster="{c}"{jf}}}[5m]))',
+        6, y, unit="reqps"
+    )); pid += 1
+    panels.append(p_stat(pid, "5xx/s",
+        f'sum(rate(traefik_entrypoint_requests_total{{cluster="{c}"{jf},code=~"5.."}}[5m]))',
+        12, y, unit="reqps",
+        thresholds=[{"value": None, "color": "green"}, {"value": 0.1, "color": "yellow"}, {"value": 1, "color": "red"}]
+    )); pid += 1
+    panels.append(p_stat(pid, "Restarts (24h)",
+        f'sum(increase(kube_pod_container_status_restarts_total{{cluster="{c}",namespace="{n}",pod=~"traefik.*"}}[24h]))',
+        18, y, thresholds=[{"value": None, "color": "green"}, {"value": 1, "color": "yellow"}, {"value": 5, "color": "red"}]
+    )); pid += 1; y += 4
+
+    panels.append(p_row(pid, "Requests", y)); pid += 1; y += 1
+    panels.append(p_ts(pid, "Requests/s by Entrypoint",
+        [{"expr": f'sum by (entrypoint) (rate(traefik_entrypoint_requests_total{{cluster="{c}"{jf}}}[5m]))', "legend": "{{entrypoint}}"}],
+        0, y, w=12, unit="reqps"
+    )); pid += 1
+    panels.append(p_ts(pid, "Requests/s by Service",
+        [{"expr": f'sum by (service) (rate(traefik_service_requests_total{{cluster="{c}"{jf}}}[5m]))', "legend": "{{service}}"}],
+        12, y, w=12, unit="reqps"
+    )); pid += 1; y += 8
+
+    panels.append(p_row(pid, "Errors", y)); pid += 1; y += 1
+    panels.append(p_ts(pid, "Requests/s by Status Code",
+        [{"expr": f'sum by (code) (rate(traefik_entrypoint_requests_total{{cluster="{c}"{jf}}}[5m]))', "legend": "{{code}}"}],
+        0, y, w=24, unit="reqps"
+    )); pid += 1; y += 8
+
+    panels.append(p_row(pid, "Logs", y)); pid += 1; y += 1
+    panels.append(p_logs(pid, c, n, y, extra_filter=' | pod=~"traefik.*"'))
+
+    return make_dashboard(f"Traefik — {c}", uid_str, [c, "traefik", "ingress", "kubernetes"], panels)
+
+
 # ---------------------------------------------------------------------------
 # App registry
 # ---------------------------------------------------------------------------
@@ -672,8 +944,10 @@ APPS = {
         ("1password",                "1password",             "1Password",                    "standard"),
         ("cert-manager",             "cert-manager",          "cert-manager",                  "cert-manager"),
         ("cloudflare",               "cloudflare",            "Cloudflare Tunnel",             "standard"),
+        ("coredns",                  "kube-system",           "CoreDNS",                       "coredns"),
         ("falco",                    "falco",                 "Falco",                         "falco"),
         ("film-tv-exporter",         "film-tv",               "Film/TV Exporter",              "no-container"),
+        ("flux",                     "flux-system",           "Flux",                          "flux"),
         ("grafana-alloy",            "grafana-alloy",         "Grafana Alloy",                 "standard"),
         ("haproxy-ingress",          "haproxy-ingress",       "HAProxy Ingress",               "standard"),
         ("harbor",                   "harbor",                "Harbor Registry",               "harbor"),
@@ -681,12 +955,14 @@ APPS = {
         ("jenkins",                  "jenkins",               "Jenkins",                       "standard"),
         ("net-mon",                  "net-mon",               "Net-Mon",                       "standard"),
         ("nextcloud",                "nextcloud-fastnetserv", "Nextcloud",                     "nextcloud"),
+        ("node-resources",           None,                    "Node Resources",                "node-resources"),
         ("nut",                      "nut",                   "NUT Exporter",                  "standard"),
         ("openebs",                  "openebs",               "OpenEBS",                       "standard"),
         ("postgresql",               "databases",             "PostgreSQL (Zalando)",          "postgresql"),
         ("s3",                       "nextcloud-fastnetserv", "S3 / SeaweedFS",               "s3"),
         ("sso",                      "sso",                   "SSO (Keycloak)",                "standard"),
         ("system-upgrade-controller","system-upgrade",        "System Upgrade Controller",     "standard"),
+        ("velero",                   "velero",                "Velero",                        "velero"),
     ],
     "k8s-vms-daniele": [
         ("1password",                "1password",             "1Password",                    "standard"),
@@ -694,11 +970,15 @@ APPS = {
         ("blackbox",                 "monitoring",            "Blackbox Exporter",             "standard"),
         ("cert-manager",             "cert-manager",          "cert-manager",                  "cert-manager"),
         ("cloudflare",               "cloudflare",            "Cloudflare Tunnel",             "standard"),
+        ("coredns",                  "kube-system",           "CoreDNS",                       "coredns"),
         ("falco",                    "falco",                 "Falco",                         "falco"),
+        ("flux",                     "flux-system",           "Flux",                          "flux"),
         ("grafana-alloy",            "grafana-alloy",         "Grafana Alloy",                 "standard"),
         ("node-exporter",            "node-exporter",         "Node Exporter",                 "standard"),
+        ("node-resources",           None,                    "Node Resources",                "node-resources"),
         ("system-upgrade-controller","system-upgrade",        "System Upgrade Controller",     "standard"),
         ("teleport-agent",           "teleport-agent",        "Teleport Agent",                "standard"),
+        ("traefik",                  "kube-system",           "Traefik",                       "traefik"),
     ],
     "proxmox": [
         ("rabbit-netbw", None, "rabbit-01-psp Network Bandwidth", "rabbit-netbw"),
@@ -727,6 +1007,11 @@ def main():
                 "nextcloud":    lambda c, fn, ns, d, u: build_nextcloud(c, ns, u),
                 "s3":           lambda c, fn, ns, d, u: build_s3(c, ns, u),
                 "rabbit-netbw": lambda c, fn, ns, d, u: build_rabbit_netbw(u),
+                "node-resources": lambda c, fn, ns, d, u: build_node_resources(c, u),
+                "coredns":      lambda c, fn, ns, d, u: build_coredns(c, u),
+                "flux":         lambda c, fn, ns, d, u: build_flux(c, u),
+                "velero":       lambda c, fn, ns, d, u: build_velero(u),
+                "traefik":      lambda c, fn, ns, d, u: build_traefik(u),
             }
 
             dash = builders[app_type](cluster, file_name, namespace, display, uid_str)


### PR DESCRIPTION
## Summary
- Adds 5 new zero-new-cardinality dashboards: Node Resources (both clusters), CoreDNS (both clusters), Flux (both clusters), Velero (kubenuc only), Traefik (k8s-vms-daniele only). Every panel query uses a metric confirmed live via `list_prometheus_metric_names`/`query_prometheus` before being written — no new scrape targets, no new series.
- Fixes two silent-empty-result bugs in the existing Falco dashboard: the "Critical/Emergency" stat and "Events by Priority" panel filtered/grouped on the `priority` label, which holds opaque numeric strings (`"-100"/"0"/"3"/"4"/"6"`) — `priority=~"Critical|Emergency"` could never match. Fixed to use `priority_raw`, the label that actually carries `"notice"/"warning"/"critical"` etc.
- Deliberate scope note on the Flux dashboard: it has no per-resource-kind reconciliation success/failure panel. Confirmed live that the classic `gotk_reconcile_*` metrics never reach Grafana Cloud — a pre-existing `write_relabel_config` rule in this cluster's grafana-alloy `release.yml` already drops every `gotk_*` metric before remote-write (unrelated to this PR, not touched). Built instead from what's actually live: controller-runtime reconcile rate/latency, workqueue depth, leader-election status per controller.
- Wave 1 (items 1a–1f) of the Grafana Dashboard Overhaul plan, following #1884 (dashboard deletions).

## Test plan
- [x] Every new metric/label name cross-checked against a live Prometheus query immediately before being written into a panel (job filters, rcode values, priority_raw values, traefik code/entrypoint/service labels, velero metric names — all confirmed live, not guessed).
- [x] `python3 generate_dashboards.py && git diff --exit-code dashboards/` — deterministic regeneration, zero stray diff on any of the 29 pre-existing dashboards; exactly 8 new + 2 modified (falco).
- [x] `terraform fmt -diff` and `terraform validate` both clean.
- [x] Dual review (independent Claude/fable subagent + codex-rescue), each given the full live-metric evidence to cross-check the PromQL against, both independently re-ran the generator and `terraform fmt`/`validate` — no bugs found by either.
- [ ] After merge, confirm CI drift-guard + `terraform plan` (`terraform-grafana.yml`) shows exactly 8 adds, 2 changes, 0 destroys.
- [ ] `get_dashboard_by_uid`/`get_panel_image` on each new dashboard's UID post-apply — confirm real, non-empty rendering.