### PR TITLE
feat(nut): add scrape annotations for the existing NUT exporter

### DIFF
--- a/clusters/kubenuc/apps/nut/manifests/deployment.yaml
+++ b/clusters/kubenuc/apps/nut/manifests/deployment.yaml
@@ -14,6 +14,10 @@ spec:
     metadata:
       labels:
         app: nut-exporter
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9995"
+        prometheus.io/path: /metrics
     spec:
       containers:
       - image: hon95/prometheus-nut-exporter:stable@sha256:0ed2a78084a627c2290a90b8fad3d7bcb62620d87dab941badd0eb4678119a48


### PR DESCRIPTION
## Summary
- Adds `prometheus.io/scrape`/`port`/`path` annotations to the existing `nut-exporter` pod template on kubenuc — the exporter already runs and serves `/metrics` on port 9995, and the NetworkPolicy already permits scraping from `grafana-alloy` on that port. Purely a missing-annotation gap, no other config change needed.
- First step of Wave 2's two-step land process (annotation-only PR, merge, wait for Flux reconcile + one scrape interval, then a separate PR adds the `build_nut` dashboard builder once real `nut_*` metric names are confirmed live).
- Est. cardinality cost: ~15-30 series (per plan). Current headroom: 9,478/10,000 active series as of the last checkpoint after Wave 1.

## Test plan
- [x] Confirmed live via the running HelmRelease values that this cluster's Alloy `annotationAutodiscovery` config maps `prometheus.io/scrape`/`port`/`path` exactly as used here.
- [x] Confirmed port/path consistency across the container's `HTTP_PATH` env var, `containerPort: 9995`, the new annotation, and the existing NetworkPolicy's allowed port — all four already agreed before this diff.
- [x] Dual review (independent Claude/fable subagent + codex-rescue) — both re-read the full deployment.yaml and networkpolicy-allow-ingress.yml, confirmed no bugs.
- [ ] After merge + Flux reconcile, confirm via `list_prometheus_metric_names(matches=["nut_.*"])` that metrics arrive with sane values.
- [ ] Re-check `grafanacloud_instance_active_series` delta against the ~15-30 estimate.