### PR TITLE
feat(cloudflared): add scrape annotations for the existing metrics server

### DIFF
--- a/clusters/kubenuc/apps/cloudflare/manifests/cloudflared.yml
+++ b/clusters/kubenuc/apps/cloudflare/manifests/cloudflared.yml
@@ -27,6 +27,9 @@ spec:
         # pods. Generic (not secret-scoped) since the trigger here is the
         # tunnel-token Secret, not a ConfigMap.
         reloader.stakater.com/auto: "true"
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "2000"
+        prometheus.io/path: /metrics
     spec:
       tolerations:
       - key: node-role.kubernetes.io/control-plane


### PR DESCRIPTION
## Summary
- Adds `prometheus.io/scrape`/`port`/`path` annotations to the `cloudflared` DaemonSet's pod template on kubenuc — the tunnel client already runs with `--metrics 0.0.0.0:2000` (confirmed live via the existing `/ready` livenessProbe on the same port). No NetworkPolicy exists for the `cloudflare` namespace, so nothing restricts scraping. Purely a missing-annotation gap.
- Second app of Wave 2's two-step land process (annotation-only PR, merge, wait for reconcile + scrape interval, then a separate PR adds a dashboard builder once real metric names are confirmed live).
- Est. cardinality cost: ~20-40 series (per plan).

## Test plan
- [x] Confirmed `--metrics 0.0.0.0:2000` is genuinely in the container's args list and matches the existing livenessProbe port.
- [x] Confirmed no NetworkPolicy manifest exists anywhere under `clusters/kubenuc/apps/cloudflare/` (only `cloudflared.yml` in `manifests/`).
- [x] Confirmed `hostNetwork` is not set — standard pod-IP addressing, reachable from grafana-alloy's namespace over the pod network.
- [x] Dual review (independent Claude/fable subagent + codex-rescue) — both re-read the full manifest, confirmed no bugs.
- [ ] After merge + Flux reconcile, confirm via `list_prometheus_metric_names` that cloudflared's Prometheus metrics arrive with sane values.
- [ ] Re-check `grafanacloud_instance_active_series` delta against the ~20-40 estimate.