### PR TITLE
feat(teleport-agent): add scrape annotations for the always-on diag endpoint

### DIFF
--- a/clusters/k8s-vms-daniele/apps/teleport-agent/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/teleport-agent/manifests/release.yml
@@ -34,6 +34,16 @@ spec:
     joinTokenSecret:
       create: false
       name: "teleport-kube-agent-join-token"
+    # The chart always starts the agent with --diag-addr=0.0.0.0:3000
+    # unconditionally (not gated by any values flag) - already-live
+    # /healthz and /readyz probes on this port confirm it. Its diag HTTP
+    # server also serves /metrics; this was purely a missing-annotation
+    # gap, no NetworkPolicy restricts this namespace either.
+    annotations:
+      pod:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "3000"
+        prometheus.io/path: /metrics
     # Conservative documented estimate (not sized from live usage - no
     # Grafana access this session); a single agent proxying/holding a
     # persistent connection to the Teleport proxy, no local state.


### PR DESCRIPTION
## Summary
- Adds `annotations.pod` with `prometheus.io/scrape`/`port`/`path` to the `teleport-agent` HelmRelease on k8s-vms-daniele.
- Correction to the original task plan: the `teleport-kube-agent` chart (v18.10.7) already starts the agent with `--diag-addr=0.0.0.0:3000` unconditionally — confirmed against the chart's `statefulset.yaml` template, not gated by any values flag. Nothing needed "enabling"; the existing `/healthz`/`/readyz` liveness/readiness probes on that port already prove it's live in production.
- Confirmed against Teleport's own docs that the diag HTTP server also serves `/metrics` (Prometheus-compatible) on the same port.
- No NetworkPolicy restricts the `teleport-agent` namespace, so this was purely a missing-annotation gap.
- First step of Wave 2's two-step land process (annotation-only PR; a separate dashboard PR follows once metrics are confirmed live).

## Test plan
- [x] Pulled the actual chart and confirmed `--diag-addr=0.0.0.0:3000` is unconditional, and that `annotations.pod` is the chart's documented pod-annotation mechanism.
- [x] `helm template` against the exact extracted `spec.values` renders successfully (exit 0) with the annotations correctly on the StatefulSet's pod template.
- [x] Dual review (independent Claude/fable subagent + codex-rescue) — both independently confirmed the `/metrics` claim against Teleport's own docs, confirmed no NetworkPolicy exists, and confirmed the annotation's harmless spillover onto an unrelated delete-hook Job pod template (which never listens on port 3000).
- [ ] After merge + Flux reconcile, confirm via `list_prometheus_metric_names` that Teleport metrics arrive with sane values.
- [ ] Re-check `grafanacloud_instance_active_series` delta against the "low-moderate" estimate.