### PR TITLE
feat(sso): enable Authentik server/worker metrics Services

### DIFF
--- a/clusters/kubenuc/apps/sso/manifests/release.yml
+++ b/clusters/kubenuc/apps/sso/manifests/release.yml
@@ -34,6 +34,13 @@ spec:
   values:
     server:
       replicas: 3
+      # Deploys a dedicated {fullname}-metrics Service (containerPorts.metrics
+      # 9300, already declared by the chart regardless of this flag) and
+      # annotates it via global.addPrometheusAnnotations below - scraped by
+      # grafana-alloy's service-role discovery, so cost is per-Service (one
+      # target), not multiplied by replicas.
+      metrics:
+        enabled: true
       containerSecurityContext:
         allowPrivilegeEscalation: false
         capabilities:
@@ -112,6 +119,10 @@ spec:
               - ${SSO_AUTHENTIK_HOST}
 
     global:
+      # Annotates the server/worker -metrics Services (prometheus.io/scrape,
+      # prometheus.io/port) - the chart's built-in alternative to a
+      # ServiceMonitor, matching this cluster's Alloy service-role discovery.
+      addPrometheusAnnotations: true
       podAnnotations:
         secret.reloader.stakater.com/auto: "true"
       volumes:
@@ -167,6 +178,8 @@ spec:
 
     worker:
       replicas: 3
+      metrics:
+        enabled: true
       containerSecurityContext:
         allowPrivilegeEscalation: false
         capabilities:


### PR DESCRIPTION
## Summary
- Enables Authentik's built-in metrics Services for both `server` and `worker` components on kubenuc (`server.metrics.enabled`/`worker.metrics.enabled` + `global.addPrometheusAnnotations`) — the chart's own alternative to a ServiceMonitor, confirmed against its templates: both flags together annotate a dedicated `{fullname}-metrics` Service (port 9300) with `prometheus.io/scrape`/`port`.
- This is Service-role scraping (not pod-role): cost is per-Service (2 targets total: server-metrics + worker-metrics), not multiplied by the 3 replicas each component runs.
- NetworkPolicy already allows unrestricted-port ingress from `grafana-alloy` in this namespace (comment: "port intentionally unrestricted since the exact scrape port wasn't confirmed") — no policy change needed.
- Note: this namespace also hosts Zitadel (unrelated, untouched by this diff).

## Test plan
- [x] Pulled the actual chart (`authentik@2026.8.0`) and confirmed both `metrics.enabled` (creates the Service) and `addPrometheusAnnotations` (annotates it) are independently required — set both.
- [x] `helm template` against the exact extracted `spec.values` renders successfully with both `-metrics` Services carrying the correct annotations and port.
- [x] Dual review (independent Claude/fable subagent + codex-rescue) — both confirmed the Service-vs-pod cardinality reasoning is standard Prometheus SD semantics, and codex-rescue additionally confirmed via Authentik's own docs (`AUTHENTIK_LISTEN__METRICS`) that the worker process genuinely serves metrics, not just a declared port.
- [ ] After merge + Flux reconcile, confirm via `list_prometheus_metric_names` that Authentik metrics arrive with sane values.
- [ ] Re-check `grafanacloud_instance_active_series` delta.