### PR TITLE
fix(grafana-alloy): drop Authentik histogram bucket series to recover budget

### DIFF
--- a/clusters/kubenuc/apps/grafana-alloy/manifests/release.yml
+++ b/clusters/kubenuc/apps/grafana-alloy/manifests/release.yml
@@ -125,6 +125,17 @@ spec:
             regex         = "podVolume_pod_volume_operation_latency_seconds_bucket|kopia_blob_storage_latency_ms_bucket"
             action        = "drop"
           }
+          write_relabel_config {
+            // Authentik histogram buckets — confirmed live at ~549 series
+            // (authentik_tasks_duration_milliseconds_bucket alone was 399)
+            // with no dashboard consumer today; _sum/_count retained for
+            // rate/average queries. Landed as an expedited follow-up right
+            // after enabling Authentik metrics, since actual cardinality
+            // came in far above estimate.
+            source_labels = ["__name__"]
+            regex         = "authentik_(flows_(execution_stage|plan|stage)_time|policies_engine_time_total_seconds|property_mapping_execution_time|tasks_duration_milliseconds)_bucket"
+            action        = "drop"
+          }
       grafanaCloudLogs:
         type: loki
         url: ${GRAFANA_LOKI_URL}


### PR DESCRIPTION
## Summary
- **Urgent/expedited**: enabling Authentik metrics (previous PR) added 956 active series in practice, far above the plan's estimate — risking a breach of Grafana Cloud's hard 10,000-active-series cap (which drops ALL metrics org-wide if breached) once the account's lagging `active_series` gauge catches up.
- Adds a `write_relabel_config` drop rule for 6 histogram `_bucket` metrics confirmed live with zero dashboard consumers, recovering ~549 series: `authentik_tasks_duration_milliseconds_bucket` (399, the dominant contributor), `authentik_property_mapping_execution_time_bucket` (75), `authentik_policies_engine_time_total_seconds_bucket` (30), and the three `authentik_flows_*_time_bucket` metrics (15 each).
- `_sum`/`_count` are retained for rate/average queries — identical tradeoff to the existing Velero/kopia drop rule already in this file (Wave 0 precedent).

## Test plan
- [x] Regex verified via `re.fullmatch` (matching Prometheus's fully-anchored relabel semantics) against the complete live 32-name `authentik_*` metric list — exactly the 6 targets match, zero false positives/negatives.
- [x] Dual review (independent Claude/fable subagent + codex-rescue) — both independently re-derived the regex match table against the full live metric list, confirmed correct placement/syntax, confirmed no conflict with existing drop rules, confirmed the diff is a pure 11-line addition.
- [ ] After merge + Flux reconcile, confirm via `list_prometheus_metric_names` that the 6 target metrics are gone.
- [ ] Re-check `grafanacloud_instance_active_series` shows the ~549-series recovery.