### PR TITLE
feat(grafana): add Cloudflare Tunnel, Teleport Agent, Authentik dashboards

### DIFF
--- a/terraform/grafana/dashboards/k8s-vms-daniele/teleport-agent.json
+++ b/terraform/grafana/dashboards/k8s-vms-daniele/teleport-agent.json
@@ -3,7 +3,7 @@
   "uid": "kv-teleport-agent",
   "tags": [
     "k8s-vms-daniele",
-    "teleport-agent",
+    "teleport",
     "kubernetes"
   ],
   "timezone": "browser",
@@ -94,7 +94,7 @@
     },
     {
       "id": 3,
-      "title": "Ready Containers",
+      "title": "Kubernetes Resource Healthy",
       "type": "stat",
       "datasource": {
         "uid": "grafanacloud-prom",
@@ -108,7 +108,7 @@
       },
       "targets": [
         {
-          "expr": "sum(kube_pod_container_status_ready{cluster=\"k8s-vms-daniele\",namespace=\"teleport-agent\"})",
+          "expr": "min(teleport_resources_health_status_healthy{cluster=\"k8s-vms-daniele\",job=\"teleport-agent\",type=\"kubernetes\"})",
           "legendFormat": "",
           "refId": "A"
         }
@@ -152,7 +152,7 @@
     },
     {
       "id": 4,
-      "title": "Restarts (24h)",
+      "title": "Cache Healthy (kube)",
       "type": "stat",
       "datasource": {
         "uid": "grafanacloud-prom",
@@ -160,6 +160,64 @@
       },
       "gridPos": {
         "x": 12,
+        "y": 1,
+        "w": 6,
+        "h": 4
+      },
+      "targets": [
+        {
+          "expr": "min(teleport_cache_health{cluster=\"k8s-vms-daniele\",job=\"teleport-agent\",cache_component=\"kube\"})",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "red"
+              },
+              {
+                "value": 1,
+                "color": "green"
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": []
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 5,
+      "title": "Restarts (24h)",
+      "type": "stat",
+      "datasource": {
+        "uid": "grafanacloud-prom",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 18,
         "y": 1,
         "w": 6,
         "h": 4
@@ -213,58 +271,8 @@
       }
     },
     {
-      "id": 5,
-      "title": "Replicas (Available / Desired)",
-      "type": "stat",
-      "datasource": {
-        "uid": "grafanacloud-prom",
-        "type": "prometheus"
-      },
-      "gridPos": {
-        "x": 18,
-        "y": 1,
-        "w": 6,
-        "h": 4
-      },
-      "targets": [
-        {
-          "expr": "sum(kube_deployment_status_replicas_available{cluster=\"k8s-vms-daniele\",namespace=\"teleport-agent\"})",
-          "legendFormat": "Available",
-          "refId": "A"
-        },
-        {
-          "expr": "sum(kube_deployment_spec_replicas{cluster=\"k8s-vms-daniele\",namespace=\"teleport-agent\"})",
-          "legendFormat": "Desired",
-          "refId": "B"
-        }
-      ],
-      "options": {
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "orientation": "horizontal",
-        "textMode": "value_and_name",
-        "colorMode": "value",
-        "graphMode": "none"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": []
-        },
-        "overrides": []
-      }
-    },
-    {
       "id": 6,
-      "title": "Resources",
+      "title": "Connectivity",
       "type": "row",
       "collapsed": false,
       "gridPos": {
@@ -277,7 +285,7 @@
     },
     {
       "id": 7,
-      "title": "CPU Usage by Pod",
+      "title": "Connect-to-Node Attempts/s",
       "type": "timeseries",
       "datasource": {
         "uid": "grafanacloud-prom",
@@ -286,6 +294,120 @@
       "gridPos": {
         "x": 0,
         "y": 6,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(teleport_connect_to_node_attempts_total{cluster=\"k8s-vms-daniele\",job=\"teleport-agent\"}[5m]))",
+          "legendFormat": "attempts/s",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 8,
+      "title": "Resource Health Status by Type",
+      "type": "timeseries",
+      "datasource": {
+        "uid": "grafanacloud-prom",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 6,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum by (type) (teleport_resources_health_status_healthy{cluster=\"k8s-vms-daniele\",job=\"teleport-agent\"})",
+          "legendFormat": "{{type}} healthy",
+          "refId": "A"
+        },
+        {
+          "expr": "sum by (type) (teleport_resources_health_status_unknown{cluster=\"k8s-vms-daniele\",job=\"teleport-agent\"})",
+          "legendFormat": "{{type}} unknown",
+          "refId": "B"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 9,
+      "title": "Resources",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 14,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 10,
+      "title": "CPU Usage by Pod",
+      "type": "timeseries",
+      "datasource": {
+        "uid": "grafanacloud-prom",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 15,
         "w": 12,
         "h": 8
       },
@@ -324,7 +446,7 @@
       }
     },
     {
-      "id": 8,
+      "id": 11,
       "title": "Memory Usage by Pod",
       "type": "timeseries",
       "datasource": {
@@ -333,7 +455,7 @@
       },
       "gridPos": {
         "x": 12,
-        "y": 6,
+        "y": 15,
         "w": 12,
         "h": 8
       },
@@ -361,120 +483,6 @@
       "fieldConfig": {
         "defaults": {
           "unit": "bytes",
-          "custom": {
-            "lineWidth": 1,
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "spanNulls": false
-          }
-        },
-        "overrides": []
-      }
-    },
-    {
-      "id": 9,
-      "title": "Reliability",
-      "type": "row",
-      "collapsed": false,
-      "gridPos": {
-        "x": 0,
-        "y": 14,
-        "w": 24,
-        "h": 1
-      },
-      "panels": []
-    },
-    {
-      "id": 10,
-      "title": "Container Restarts",
-      "type": "timeseries",
-      "datasource": {
-        "uid": "grafanacloud-prom",
-        "type": "prometheus"
-      },
-      "gridPos": {
-        "x": 0,
-        "y": 15,
-        "w": 12,
-        "h": 8
-      },
-      "targets": [
-        {
-          "expr": "sum by (pod, container) (rate(kube_pod_container_status_restarts_total{cluster=\"k8s-vms-daniele\",namespace=\"teleport-agent\"}[5m]))",
-          "legendFormat": "{{pod}}/{{container}}",
-          "refId": "A"
-        }
-      ],
-      "options": {
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        },
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "calcs": [
-            "lastNotNull",
-            "max"
-          ]
-        }
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "custom": {
-            "lineWidth": 1,
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "spanNulls": false
-          }
-        },
-        "overrides": []
-      }
-    },
-    {
-      "id": 11,
-      "title": "Network I/O",
-      "type": "timeseries",
-      "datasource": {
-        "uid": "grafanacloud-prom",
-        "type": "prometheus"
-      },
-      "gridPos": {
-        "x": 12,
-        "y": 15,
-        "w": 12,
-        "h": 8
-      },
-      "targets": [
-        {
-          "expr": "sum(rate(container_network_receive_bytes_total{cluster=\"k8s-vms-daniele\",namespace=\"teleport-agent\"}[5m]))",
-          "legendFormat": "Receive",
-          "refId": "A"
-        },
-        {
-          "expr": "sum(rate(container_network_transmit_bytes_total{cluster=\"k8s-vms-daniele\",namespace=\"teleport-agent\"}[5m]))",
-          "legendFormat": "Transmit",
-          "refId": "B"
-        }
-      ],
-      "options": {
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        },
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "calcs": [
-            "lastNotNull",
-            "max"
-          ]
-        }
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "Bps",
           "custom": {
             "lineWidth": 1,
             "fillOpacity": 10,

--- a/terraform/grafana/dashboards/kubenuc/cloudflare.json
+++ b/terraform/grafana/dashboards/kubenuc/cloudflare.json
@@ -3,7 +3,8 @@
   "uid": "kn-cloudflare",
   "tags": [
     "kubenuc",
-    "cloudflare",
+    "cloudflared",
+    "networking",
     "kubernetes"
   ],
   "timezone": "browser",
@@ -94,7 +95,7 @@
     },
     {
       "id": 3,
-      "title": "Ready Containers",
+      "title": "Requests/s",
       "type": "stat",
       "datasource": {
         "uid": "grafanacloud-prom",
@@ -108,7 +109,7 @@
       },
       "targets": [
         {
-          "expr": "sum(kube_pod_container_status_ready{cluster=\"kubenuc\",namespace=\"cloudflare\"})",
+          "expr": "sum(rate(cloudflared_tunnel_total_requests{cluster=\"kubenuc\",job=\"cloudflared\"}[5m]))",
           "legendFormat": "",
           "refId": "A"
         }
@@ -128,16 +129,12 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "short",
+          "unit": "reqps",
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
                 "value": null,
-                "color": "red"
-              },
-              {
-                "value": 1,
                 "color": "green"
               }
             ]
@@ -152,7 +149,7 @@
     },
     {
       "id": 4,
-      "title": "Restarts (24h)",
+      "title": "Errors/s",
       "type": "stat",
       "datasource": {
         "uid": "grafanacloud-prom",
@@ -166,7 +163,69 @@
       },
       "targets": [
         {
-          "expr": "sum(increase(kube_pod_container_status_restarts_total{cluster=\"kubenuc\",namespace=\"cloudflare\"}[24h]))",
+          "expr": "sum(rate(cloudflared_tunnel_request_errors{cluster=\"kubenuc\",job=\"cloudflared\"}[5m]))",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "green"
+              },
+              {
+                "value": 0.1,
+                "color": "yellow"
+              },
+              {
+                "value": 1,
+                "color": "red"
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": []
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 5,
+      "title": "HA Connections (min per pod)",
+      "type": "stat",
+      "datasource": {
+        "uid": "grafanacloud-prom",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 18,
+        "y": 1,
+        "w": 6,
+        "h": 4
+      },
+      "targets": [
+        {
+          "expr": "min(cloudflared_tunnel_ha_connections{cluster=\"kubenuc\",job=\"cloudflared\"})",
           "legendFormat": "",
           "refId": "A"
         }
@@ -192,15 +251,11 @@
             "steps": [
               {
                 "value": null,
-                "color": "green"
+                "color": "red"
               },
               {
                 "value": 1,
-                "color": "yellow"
-              },
-              {
-                "value": 5,
-                "color": "red"
+                "color": "green"
               }
             ]
           },
@@ -213,58 +268,8 @@
       }
     },
     {
-      "id": 5,
-      "title": "Replicas (Available / Desired)",
-      "type": "stat",
-      "datasource": {
-        "uid": "grafanacloud-prom",
-        "type": "prometheus"
-      },
-      "gridPos": {
-        "x": 18,
-        "y": 1,
-        "w": 6,
-        "h": 4
-      },
-      "targets": [
-        {
-          "expr": "sum(kube_deployment_status_replicas_available{cluster=\"kubenuc\",namespace=\"cloudflare\"})",
-          "legendFormat": "Available",
-          "refId": "A"
-        },
-        {
-          "expr": "sum(kube_deployment_spec_replicas{cluster=\"kubenuc\",namespace=\"cloudflare\"})",
-          "legendFormat": "Desired",
-          "refId": "B"
-        }
-      ],
-      "options": {
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "orientation": "horizontal",
-        "textMode": "value_and_name",
-        "colorMode": "value",
-        "graphMode": "none"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": []
-        },
-        "overrides": []
-      }
-    },
-    {
       "id": 6,
-      "title": "Resources",
+      "title": "Requests",
       "type": "row",
       "collapsed": false,
       "gridPos": {
@@ -277,7 +282,7 @@
     },
     {
       "id": 7,
-      "title": "CPU Usage by Pod",
+      "title": "Requests/s by Pod",
       "type": "timeseries",
       "datasource": {
         "uid": "grafanacloud-prom",
@@ -291,7 +296,7 @@
       },
       "targets": [
         {
-          "expr": "sum by (pod) (rate(container_cpu_usage_seconds_total{cluster=\"kubenuc\",namespace=\"cloudflare\",container!=\"\",container!=\"POD\"}[5m]))",
+          "expr": "sum by (pod) (rate(cloudflared_tunnel_total_requests{cluster=\"kubenuc\",job=\"cloudflared\"}[5m]))",
           "legendFormat": "{{pod}}",
           "refId": "A"
         }
@@ -312,7 +317,7 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "short",
+          "unit": "reqps",
           "custom": {
             "lineWidth": 1,
             "fillOpacity": 10,
@@ -325,7 +330,7 @@
     },
     {
       "id": 8,
-      "title": "Memory Usage by Pod",
+      "title": "Responses/s by Status Code",
       "type": "timeseries",
       "datasource": {
         "uid": "grafanacloud-prom",
@@ -339,8 +344,8 @@
       },
       "targets": [
         {
-          "expr": "sum by (pod) (container_memory_working_set_bytes{cluster=\"kubenuc\",namespace=\"cloudflare\",container!=\"\",container!=\"POD\"})",
-          "legendFormat": "{{pod}}",
+          "expr": "sum by (status_code) (rate(cloudflared_tunnel_response_by_code{cluster=\"kubenuc\",job=\"cloudflared\"}[5m]))",
+          "legendFormat": "{{status_code}}",
           "refId": "A"
         }
       ],
@@ -360,7 +365,7 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "bytes",
+          "unit": "reqps",
           "custom": {
             "lineWidth": 1,
             "fillOpacity": 10,
@@ -373,7 +378,7 @@
     },
     {
       "id": 9,
-      "title": "Reliability",
+      "title": "Sessions",
       "type": "row",
       "collapsed": false,
       "gridPos": {
@@ -386,7 +391,7 @@
     },
     {
       "id": 10,
-      "title": "Container Restarts",
+      "title": "Active TCP/UDP Sessions",
       "type": "timeseries",
       "datasource": {
         "uid": "grafanacloud-prom",
@@ -395,14 +400,19 @@
       "gridPos": {
         "x": 0,
         "y": 15,
-        "w": 12,
+        "w": 24,
         "h": 8
       },
       "targets": [
         {
-          "expr": "sum by (pod, container) (rate(kube_pod_container_status_restarts_total{cluster=\"kubenuc\",namespace=\"cloudflare\"}[5m]))",
-          "legendFormat": "{{pod}}/{{container}}",
+          "expr": "sum(cloudflared_tcp_active_sessions{cluster=\"kubenuc\",job=\"cloudflared\"})",
+          "legendFormat": "tcp",
           "refId": "A"
+        },
+        {
+          "expr": "sum(cloudflared_udp_active_sessions{cluster=\"kubenuc\",job=\"cloudflared\"})",
+          "legendFormat": "udp",
+          "refId": "B"
         }
       ],
       "options": {
@@ -434,59 +444,6 @@
     },
     {
       "id": 11,
-      "title": "Network I/O",
-      "type": "timeseries",
-      "datasource": {
-        "uid": "grafanacloud-prom",
-        "type": "prometheus"
-      },
-      "gridPos": {
-        "x": 12,
-        "y": 15,
-        "w": 12,
-        "h": 8
-      },
-      "targets": [
-        {
-          "expr": "sum(rate(container_network_receive_bytes_total{cluster=\"kubenuc\",namespace=\"cloudflare\"}[5m]))",
-          "legendFormat": "Receive",
-          "refId": "A"
-        },
-        {
-          "expr": "sum(rate(container_network_transmit_bytes_total{cluster=\"kubenuc\",namespace=\"cloudflare\"}[5m]))",
-          "legendFormat": "Transmit",
-          "refId": "B"
-        }
-      ],
-      "options": {
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        },
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "calcs": [
-            "lastNotNull",
-            "max"
-          ]
-        }
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "Bps",
-          "custom": {
-            "lineWidth": 1,
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "spanNulls": false
-          }
-        },
-        "overrides": []
-      }
-    },
-    {
-      "id": 12,
       "title": "Logs",
       "type": "row",
       "collapsed": false,
@@ -499,7 +456,7 @@
       "panels": []
     },
     {
-      "id": 13,
+      "id": 12,
       "title": "Pod Logs",
       "type": "logs",
       "datasource": {

--- a/terraform/grafana/dashboards/kubenuc/sso.json
+++ b/terraform/grafana/dashboards/kubenuc/sso.json
@@ -1,9 +1,10 @@
 {
-  "title": "SSO (Keycloak) \u2014 kubenuc",
+  "title": "Authentik (SSO) \u2014 kubenuc",
   "uid": "kn-sso",
   "tags": [
     "kubenuc",
     "sso",
+    "authentik",
     "kubernetes"
   ],
   "timezone": "browser",
@@ -50,7 +51,7 @@
       },
       "targets": [
         {
-          "expr": "sum(kube_pod_status_phase{cluster=\"kubenuc\",namespace=\"sso\",phase=\"Running\"})",
+          "expr": "sum(kube_pod_status_phase{cluster=\"kubenuc\",namespace=\"sso\",pod=~\"authentik-.*\",phase=\"Running\"})",
           "legendFormat": "",
           "refId": "A"
         }
@@ -108,7 +109,7 @@
       },
       "targets": [
         {
-          "expr": "sum(kube_pod_container_status_ready{cluster=\"kubenuc\",namespace=\"sso\"})",
+          "expr": "sum(kube_pod_container_status_ready{cluster=\"kubenuc\",namespace=\"sso\",pod=~\"authentik-.*\"})",
           "legendFormat": "",
           "refId": "A"
         }
@@ -166,7 +167,7 @@
       },
       "targets": [
         {
-          "expr": "sum(increase(kube_pod_container_status_restarts_total{cluster=\"kubenuc\",namespace=\"sso\"}[24h]))",
+          "expr": "sum(increase(kube_pod_container_status_restarts_total{cluster=\"kubenuc\",namespace=\"sso\",pod=~\"authentik-.*\"}[24h]))",
           "legendFormat": "",
           "refId": "A"
         }
@@ -228,12 +229,12 @@
       },
       "targets": [
         {
-          "expr": "sum(kube_deployment_status_replicas_available{cluster=\"kubenuc\",namespace=\"sso\"})",
+          "expr": "sum(kube_deployment_status_replicas_available{cluster=\"kubenuc\",namespace=\"sso\",deployment=~\"authentik-.*\"})",
           "legendFormat": "Available",
           "refId": "A"
         },
         {
-          "expr": "sum(kube_deployment_spec_replicas{cluster=\"kubenuc\",namespace=\"sso\"})",
+          "expr": "sum(kube_deployment_spec_replicas{cluster=\"kubenuc\",namespace=\"sso\",deployment=~\"authentik-.*\"})",
           "legendFormat": "Desired",
           "refId": "B"
         }
@@ -264,7 +265,7 @@
     },
     {
       "id": 6,
-      "title": "Resources",
+      "title": "Tasks",
       "type": "row",
       "collapsed": false,
       "gridPos": {
@@ -277,6 +278,417 @@
     },
     {
       "id": 7,
+      "title": "Workers",
+      "type": "stat",
+      "datasource": {
+        "uid": "grafanacloud-prom",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 6,
+        "w": 6,
+        "h": 4
+      },
+      "targets": [
+        {
+          "expr": "sum(authentik_tasks_workers{cluster=\"kubenuc\",job=\"authentik\"})",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "red"
+              },
+              {
+                "value": 1,
+                "color": "green"
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": []
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 8,
+      "title": "Tasks In Progress",
+      "type": "stat",
+      "datasource": {
+        "uid": "grafanacloud-prom",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 6,
+        "y": 6,
+        "w": 6,
+        "h": 4
+      },
+      "targets": [
+        {
+          "expr": "sum(authentik_tasks_in_progress{cluster=\"kubenuc\",job=\"authentik\"})",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "green"
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": []
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 9,
+      "title": "Tasks Queued",
+      "type": "stat",
+      "datasource": {
+        "uid": "grafanacloud-prom",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 6,
+        "w": 6,
+        "h": 4
+      },
+      "targets": [
+        {
+          "expr": "sum(authentik_tasks_queued{cluster=\"kubenuc\",job=\"authentik\"})",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "green"
+              },
+              {
+                "value": 20,
+                "color": "yellow"
+              },
+              {
+                "value": 100,
+                "color": "red"
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": []
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 10,
+      "title": "Outposts Connected",
+      "type": "stat",
+      "datasource": {
+        "uid": "grafanacloud-prom",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 18,
+        "y": 6,
+        "w": 6,
+        "h": 4
+      },
+      "targets": [
+        {
+          "expr": "sum(authentik_outposts_connected{cluster=\"kubenuc\",job=\"authentik\"})",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "green"
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": []
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 11,
+      "title": "Requests",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 10,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 12,
+      "title": "Request Rate by Destination",
+      "type": "timeseries",
+      "datasource": {
+        "uid": "grafanacloud-prom",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 11,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum by (dest) (rate(authentik_main_request_duration_seconds_count{cluster=\"kubenuc\",job=\"authentik\"}[5m]))",
+          "legendFormat": "{{dest}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 13,
+      "title": "Avg Request Duration by Destination",
+      "type": "timeseries",
+      "datasource": {
+        "uid": "grafanacloud-prom",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 11,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum by (dest) (rate(authentik_main_request_duration_seconds_sum{cluster=\"kubenuc\",job=\"authentik\"}[5m])) / sum by (dest) (rate(authentik_main_request_duration_seconds_count{cluster=\"kubenuc\",job=\"authentik\"}[5m]))",
+          "legendFormat": "{{dest}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 14,
+      "title": "Task Queue by Actor",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 19,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 15,
+      "title": "Top 10 Queued Task Types",
+      "type": "timeseries",
+      "datasource": {
+        "uid": "grafanacloud-prom",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 20,
+        "w": 24,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "topk(10, sum by (actor_name) (authentik_tasks_queued{cluster=\"kubenuc\",job=\"authentik\"}))",
+          "legendFormat": "{{actor_name}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 16,
+      "title": "Resources",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 28,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 17,
       "title": "CPU Usage by Pod",
       "type": "timeseries",
       "datasource": {
@@ -285,13 +697,13 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 6,
+        "y": 29,
         "w": 12,
         "h": 8
       },
       "targets": [
         {
-          "expr": "sum by (pod) (rate(container_cpu_usage_seconds_total{cluster=\"kubenuc\",namespace=\"sso\",container!=\"\",container!=\"POD\"}[5m]))",
+          "expr": "sum by (pod) (rate(container_cpu_usage_seconds_total{cluster=\"kubenuc\",namespace=\"sso\",pod=~\"authentik-.*\",container!=\"\",container!=\"POD\"}[5m]))",
           "legendFormat": "{{pod}}",
           "refId": "A"
         }
@@ -324,7 +736,7 @@
       }
     },
     {
-      "id": 8,
+      "id": 18,
       "title": "Memory Usage by Pod",
       "type": "timeseries",
       "datasource": {
@@ -333,13 +745,13 @@
       },
       "gridPos": {
         "x": 12,
-        "y": 6,
+        "y": 29,
         "w": 12,
         "h": 8
       },
       "targets": [
         {
-          "expr": "sum by (pod) (container_memory_working_set_bytes{cluster=\"kubenuc\",namespace=\"sso\",container!=\"\",container!=\"POD\"})",
+          "expr": "sum by (pod) (container_memory_working_set_bytes{cluster=\"kubenuc\",namespace=\"sso\",pod=~\"authentik-.*\",container!=\"\",container!=\"POD\"})",
           "legendFormat": "{{pod}}",
           "refId": "A"
         }
@@ -372,20 +784,20 @@
       }
     },
     {
-      "id": 9,
+      "id": 19,
       "title": "Reliability",
       "type": "row",
       "collapsed": false,
       "gridPos": {
         "x": 0,
-        "y": 14,
+        "y": 37,
         "w": 24,
         "h": 1
       },
       "panels": []
     },
     {
-      "id": 10,
+      "id": 20,
       "title": "Container Restarts",
       "type": "timeseries",
       "datasource": {
@@ -394,13 +806,13 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 15,
+        "y": 38,
         "w": 12,
         "h": 8
       },
       "targets": [
         {
-          "expr": "sum by (pod, container) (rate(kube_pod_container_status_restarts_total{cluster=\"kubenuc\",namespace=\"sso\"}[5m]))",
+          "expr": "sum by (pod, container) (rate(kube_pod_container_status_restarts_total{cluster=\"kubenuc\",namespace=\"sso\",pod=~\"authentik-.*\"}[5m]))",
           "legendFormat": "{{pod}}/{{container}}",
           "refId": "A"
         }
@@ -433,7 +845,7 @@
       }
     },
     {
-      "id": 11,
+      "id": 21,
       "title": "Network I/O",
       "type": "timeseries",
       "datasource": {
@@ -442,7 +854,7 @@
       },
       "gridPos": {
         "x": 12,
-        "y": 15,
+        "y": 38,
         "w": 12,
         "h": 8
       },
@@ -486,20 +898,20 @@
       }
     },
     {
-      "id": 12,
+      "id": 22,
       "title": "Logs",
       "type": "row",
       "collapsed": false,
       "gridPos": {
         "x": 0,
-        "y": 23,
+        "y": 46,
         "w": 24,
         "h": 1
       },
       "panels": []
     },
     {
-      "id": 13,
+      "id": 23,
       "title": "Pod Logs",
       "type": "logs",
       "datasource": {
@@ -508,13 +920,13 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 24,
+        "y": 47,
         "w": 24,
         "h": 8
       },
       "targets": [
         {
-          "expr": "{cluster=\"kubenuc\",namespace=\"sso\"}",
+          "expr": "{cluster=\"kubenuc\",namespace=\"sso\"} | pod=~\"authentik-.*\"",
           "refId": "A",
           "queryType": "range"
         }

--- a/terraform/grafana/generate_dashboards.py
+++ b/terraform/grafana/generate_dashboards.py
@@ -934,6 +934,169 @@ def build_traefik(uid_str):
     return make_dashboard(f"Traefik — {c}", uid_str, [c, "traefik", "ingress", "kubernetes"], panels)
 
 
+def build_cloudflared(uid_str):
+    """kubenuc only. namespace=cloudflare, job=cloudflared (confirmed live)."""
+    c, n = "kubenuc", "cloudflare"
+    jf = ',job="cloudflared"'
+    panels = []
+    pid, y = 1, 0
+
+    panels.append(p_row(pid, "Status", y)); pid += 1; y += 1
+    panels.append(p_stat(pid, "Running Pods",
+        f'sum(kube_pod_status_phase{{cluster="{c}",namespace="{n}",phase="Running"}})',
+        0, y, thresholds=[{"value": None, "color": "red"}, {"value": 1, "color": "green"}]
+    )); pid += 1
+    panels.append(p_stat(pid, "Requests/s",
+        f'sum(rate(cloudflared_tunnel_total_requests{{cluster="{c}"{jf}}}[5m]))',
+        6, y, unit="reqps"
+    )); pid += 1
+    panels.append(p_stat(pid, "Errors/s",
+        f'sum(rate(cloudflared_tunnel_request_errors{{cluster="{c}"{jf}}}[5m]))',
+        12, y, unit="reqps",
+        thresholds=[{"value": None, "color": "green"}, {"value": 0.1, "color": "yellow"}, {"value": 1, "color": "red"}]
+    )); pid += 1
+    panels.append(p_stat(pid, "HA Connections (min per pod)",
+        f'min(cloudflared_tunnel_ha_connections{{cluster="{c}"{jf}}})',
+        18, y, thresholds=[{"value": None, "color": "red"}, {"value": 1, "color": "green"}]
+    )); pid += 1; y += 4
+
+    panels.append(p_row(pid, "Requests", y)); pid += 1; y += 1
+    panels.append(p_ts(pid, "Requests/s by Pod",
+        [{"expr": f'sum by (pod) (rate(cloudflared_tunnel_total_requests{{cluster="{c}"{jf}}}[5m]))', "legend": "{{pod}}"}],
+        0, y, w=12, unit="reqps"
+    )); pid += 1
+    panels.append(p_ts(pid, "Responses/s by Status Code",
+        [{"expr": f'sum by (status_code) (rate(cloudflared_tunnel_response_by_code{{cluster="{c}"{jf}}}[5m]))', "legend": "{{status_code}}"}],
+        12, y, w=12, unit="reqps"
+    )); pid += 1; y += 8
+
+    panels.append(p_row(pid, "Sessions", y)); pid += 1; y += 1
+    panels.append(p_ts(pid, "Active TCP/UDP Sessions",
+        [
+            {"expr": f'sum(cloudflared_tcp_active_sessions{{cluster="{c}"{jf}}})', "legend": "tcp"},
+            {"expr": f'sum(cloudflared_udp_active_sessions{{cluster="{c}"{jf}}})', "legend": "udp"},
+        ],
+        0, y, w=24, unit="short"
+    )); pid += 1; y += 8
+
+    panels.append(p_row(pid, "Logs", y)); pid += 1; y += 1
+    panels.append(p_logs(pid, c, n, y))
+
+    return make_dashboard(f"Cloudflare Tunnel — {c}", uid_str, [c, "cloudflared", "networking", "kubernetes"], panels)
+
+
+def build_teleport_agent(uid_str):
+    """k8s-vms-daniele only. namespace=teleport-agent, job=teleport-agent
+    (confirmed live). No /metrics request-rate counters exist for the agent
+    itself (it's a connection-holding proxy, not an HTTP server) — built
+    from cache/resource health and connection-attempt signals instead.
+    """
+    c, n = "k8s-vms-daniele", "teleport-agent"
+    jf = ',job="teleport-agent"'
+    panels = []
+    pid, y = 1, 0
+
+    panels.append(p_row(pid, "Status", y)); pid += 1; y += 1
+    panels.append(p_stat(pid, "Running Pods",
+        f'sum(kube_pod_status_phase{{cluster="{c}",namespace="{n}",phase="Running"}})',
+        0, y, thresholds=[{"value": None, "color": "red"}, {"value": 1, "color": "green"}]
+    )); pid += 1
+    panels.append(p_stat(pid, "Kubernetes Resource Healthy",
+        f'min(teleport_resources_health_status_healthy{{cluster="{c}"{jf},type="kubernetes"}})',
+        6, y, thresholds=[{"value": None, "color": "red"}, {"value": 1, "color": "green"}]
+    )); pid += 1
+    panels.append(p_stat(pid, "Cache Healthy (kube)",
+        f'min(teleport_cache_health{{cluster="{c}"{jf},cache_component="kube"}})',
+        12, y, thresholds=[{"value": None, "color": "red"}, {"value": 1, "color": "green"}]
+    )); pid += 1
+    panels.append(p_stat(pid, "Restarts (24h)",
+        f'sum(increase(kube_pod_container_status_restarts_total{{cluster="{c}",namespace="{n}"}}[24h]))',
+        18, y, thresholds=[{"value": None, "color": "green"}, {"value": 1, "color": "yellow"}, {"value": 5, "color": "red"}]
+    )); pid += 1; y += 4
+
+    panels.append(p_row(pid, "Connectivity", y)); pid += 1; y += 1
+    panels.append(p_ts(pid, "Connect-to-Node Attempts/s",
+        [{"expr": f'sum(rate(teleport_connect_to_node_attempts_total{{cluster="{c}"{jf}}}[5m]))', "legend": "attempts/s"}],
+        0, y, w=12, unit="ops"
+    )); pid += 1
+    panels.append(p_ts(pid, "Resource Health Status by Type",
+        [
+            {"expr": f'sum by (type) (teleport_resources_health_status_healthy{{cluster="{c}"{jf}}})', "legend": "{{type}} healthy"},
+            {"expr": f'sum by (type) (teleport_resources_health_status_unknown{{cluster="{c}"{jf}}})', "legend": "{{type}} unknown"},
+        ],
+        12, y, w=12, unit="short"
+    )); pid += 1; y += 8
+
+    rp, pid, y = resource_row(pid, y, c, n)
+    panels += rp
+
+    panels.append(p_row(pid, "Logs", y)); pid += 1; y += 1
+    panels.append(p_logs(pid, c, n, y))
+
+    return make_dashboard(f"Teleport Agent — {c}", uid_str, [c, "teleport", "kubernetes"], panels)
+
+
+def build_authentik(uid_str):
+    """kubenuc only. namespace=sso, job=authentik (confirmed live). The sso
+    namespace also runs Zitadel (unrelated) - pod/deployment filters scope
+    to authentik-* only, matching the nextcloud/s3 shared-namespace pattern.
+    Histogram _bucket metrics were dropped for cardinality (see
+    grafana-alloy release.yml) - uses _sum/_count for average duration
+    instead of histogram_quantile().
+    """
+    c, n = "kubenuc", "sso"
+    jf = ',job="authentik"'
+    pf = ',pod=~"authentik-.*"'
+    df = ',deployment=~"authentik-.*"'
+    panels, pid, y = status_row(1, 0, c, n, pf, df)
+
+    panels.append(p_row(pid, "Tasks", y)); pid += 1; y += 1
+    panels.append(p_stat(pid, "Workers",
+        f'sum(authentik_tasks_workers{{cluster="{c}"{jf}}})',
+        0, y, w=6, thresholds=[{"value": None, "color": "red"}, {"value": 1, "color": "green"}]
+    )); pid += 1
+    panels.append(p_stat(pid, "Tasks In Progress",
+        f'sum(authentik_tasks_in_progress{{cluster="{c}"{jf}}})',
+        6, y, w=6
+    )); pid += 1
+    panels.append(p_stat(pid, "Tasks Queued",
+        f'sum(authentik_tasks_queued{{cluster="{c}"{jf}}})',
+        12, y, w=6,
+        thresholds=[{"value": None, "color": "green"}, {"value": 20, "color": "yellow"}, {"value": 100, "color": "red"}]
+    )); pid += 1
+    panels.append(p_stat(pid, "Outposts Connected",
+        f'sum(authentik_outposts_connected{{cluster="{c}"{jf}}})',
+        18, y, w=6
+    )); pid += 1; y += 4
+
+    panels.append(p_row(pid, "Requests", y)); pid += 1; y += 1
+    panels.append(p_ts(pid, "Request Rate by Destination",
+        [{"expr": f'sum by (dest) (rate(authentik_main_request_duration_seconds_count{{cluster="{c}"{jf}}}[5m]))', "legend": "{{dest}}"}],
+        0, y, w=12, unit="reqps"
+    )); pid += 1
+    panels.append(p_ts(pid, "Avg Request Duration by Destination",
+        [{"expr": f'sum by (dest) (rate(authentik_main_request_duration_seconds_sum{{cluster="{c}"{jf}}}[5m])) / '
+                  f'sum by (dest) (rate(authentik_main_request_duration_seconds_count{{cluster="{c}"{jf}}}[5m]))', "legend": "{{dest}}"}],
+        12, y, w=12, unit="s"
+    )); pid += 1; y += 8
+
+    panels.append(p_row(pid, "Task Queue by Actor", y)); pid += 1; y += 1
+    panels.append(p_ts(pid, "Top 10 Queued Task Types",
+        [{"expr": f'topk(10, sum by (actor_name) (authentik_tasks_queued{{cluster="{c}"{jf}}}))', "legend": "{{actor_name}}"}],
+        0, y, w=24, unit="short"
+    )); pid += 1; y += 8
+
+    rp, pid, y = resource_row(pid, y, c, n, pf)
+    panels += rp
+    rp, pid, y = reliability_row(pid, y, c, n, pf)
+    panels += rp
+
+    panels.append(p_row(pid, "Logs", y)); pid += 1; y += 1
+    panels.append(p_logs(pid, c, n, y, extra_filter=' | pod=~"authentik-.*"'))
+
+    return make_dashboard(f"Authentik (SSO) — {c}", uid_str, [c, "sso", "authentik", "kubernetes"], panels)
+
+
 # ---------------------------------------------------------------------------
 # App registry
 # ---------------------------------------------------------------------------
@@ -943,7 +1106,7 @@ APPS = {
     "kubenuc": [
         ("1password",                "1password",             "1Password",                    "standard"),
         ("cert-manager",             "cert-manager",          "cert-manager",                  "cert-manager"),
-        ("cloudflare",               "cloudflare",            "Cloudflare Tunnel",             "standard"),
+        ("cloudflare",               "cloudflare",            "Cloudflare Tunnel",             "cloudflared"),
         ("coredns",                  "kube-system",           "CoreDNS",                       "coredns"),
         ("falco",                    "falco",                 "Falco",                         "falco"),
         ("film-tv-exporter",         "film-tv",               "Film/TV Exporter",              "no-container"),
@@ -960,7 +1123,7 @@ APPS = {
         ("openebs",                  "openebs",               "OpenEBS",                       "standard"),
         ("postgresql",               "databases",             "PostgreSQL (Zalando)",          "postgresql"),
         ("s3",                       "nextcloud-fastnetserv", "S3 / SeaweedFS",               "s3"),
-        ("sso",                      "sso",                   "SSO (Keycloak)",                "standard"),
+        ("sso",                      "sso",                   "Authentik (SSO)",               "authentik"),
         ("system-upgrade-controller","system-upgrade",        "System Upgrade Controller",     "standard"),
         ("velero",                   "velero",                "Velero",                        "velero"),
     ],
@@ -977,7 +1140,7 @@ APPS = {
         ("node-exporter",            "node-exporter",         "Node Exporter",                 "standard"),
         ("node-resources",           None,                    "Node Resources",                "node-resources"),
         ("system-upgrade-controller","system-upgrade",        "System Upgrade Controller",     "standard"),
-        ("teleport-agent",           "teleport-agent",        "Teleport Agent",                "standard"),
+        ("teleport-agent",           "teleport-agent",        "Teleport Agent",                "teleport-agent-diag"),
         ("traefik",                  "kube-system",           "Traefik",                       "traefik"),
     ],
     "proxmox": [
@@ -1012,6 +1175,9 @@ def main():
                 "flux":         lambda c, fn, ns, d, u: build_flux(c, u),
                 "velero":       lambda c, fn, ns, d, u: build_velero(u),
                 "traefik":      lambda c, fn, ns, d, u: build_traefik(u),
+                "cloudflared":  lambda c, fn, ns, d, u: build_cloudflared(u),
+                "teleport-agent-diag": lambda c, fn, ns, d, u: build_teleport_agent(u),
+                "authentik":    lambda c, fn, ns, d, u: build_authentik(u),
             }
 
             dash = builders[app_type](cluster, file_name, namespace, display, uid_str)


### PR DESCRIPTION
## Summary
- Step 2 of Wave 2's two-step land process: `cloudflared`, `teleport-agent`, and `sso`/Authentik metrics were confirmed live in earlier merged PRs, so this replaces their generic `"standard"` dashboards with app-specific ones. Zero new cardinality — pure visualization of already-flowing metrics.
- **Cloudflare Tunnel** (kubenuc only — k8s-vms-daniele's cloudflared was never annotated for scraping): request/error rate, response codes, HA connection count, active TCP/UDP sessions.
- **Teleport Agent** (k8s-vms-daniele): cache/resource health, connect-to-node attempts. No request-rate panel — the agent is a connection-holding proxy with no HTTP-serving role of its own.
- **Authentik/SSO** (kubenuc, scoped to `authentik-*` pods since the `sso` namespace also runs Zitadel): task queue/worker status, request rate/duration by destination, top queued task types. Uses `_sum`/`_count` for duration averages, never the `_bucket` histograms just dropped for cardinality in #1891.
- Also fixes a pre-existing wrong display name: "SSO (Keycloak)" → "Authentik (SSO)" — this namespace has never run Keycloak.

## Test plan
- [x] Every metric/label name cross-checked against a live Prometheus query before being written into a panel.
- [x] `python3 generate_dashboards.py && git diff --exit-code dashboards/` — deterministic regeneration, exactly the 3 intended dashboards changed, total count unchanged (37, these are type-upgrades not new entries).
- [x] `terraform fmt`/`validate` clean, `dashboards.tf` has zero diff (no path changes).
- [x] Dual review (independent Claude/fable subagent + codex-rescue) — both confirmed no reference to any dropped `authentik_*_bucket` metric, correct builder signatures, and that k8s-vms-daniele's `cloudflare` entry was left untouched.
- [ ] After merge, `get_dashboard_by_uid`/`get_panel_image` on each dashboard's UID — confirm real, non-empty rendering.