### PR TITLE
fix(grafana-alloy): drop unused Django/Authentik-license/flux-resource-info series

### DIFF
--- a/clusters/k8s-vms-daniele/apps/grafana-alloy/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/grafana-alloy/manifests/release.yml
@@ -129,6 +129,16 @@ spec:
             regex         = "traefik_(service|entrypoint)_request_duration_seconds_bucket"
             action        = "drop"
           }
+          write_relabel_config {
+            // flux-operator's own per-resource info metric (80 series here)
+            // - distinct from kustomize-controller's gotk_resource_info,
+            // already dropped by the generic gotk_.* rule above. No
+            // dashboard/alert consumer; the Flux dashboard uses
+            // controller_runtime_reconcile_total/workqueue_* instead.
+            source_labels = ["__name__"]
+            regex         = "flux_resource_info"
+            action        = "drop"
+          }
       grafanaCloudLogs:
         type: loki
         url: ${GRAFANA_LOKI_URL}

--- a/clusters/kubenuc/apps/grafana-alloy/manifests/release.yml
+++ b/clusters/kubenuc/apps/grafana-alloy/manifests/release.yml
@@ -136,6 +136,27 @@ spec:
             regex         = "authentik_(flows_(execution_stage|plan|stage)_time|policies_engine_time_total_seconds|property_mapping_execution_time|tasks_duration_milliseconds)_bucket"
             action        = "drop"
           }
+          write_relabel_config {
+            // Found in a post-fix cardinality audit: Authentik's own Django
+            // web framework exposes a per-view-per-method request-latency
+            // histogram (289 series) and an enterprise-license-expiry gauge
+            // (162 series) - neither has a dashboard/alert consumer in this
+            // repo. Not part of the original Authentik drop rule above
+            // because these aren't authentik_-prefixed metric names.
+            source_labels = ["__name__"]
+            regex         = "django_http_requests_latency_seconds_by_view_method_bucket|authentik_enterprise_license_expiry_seconds"
+            action        = "drop"
+          }
+          write_relabel_config {
+            // flux-operator's own per-resource info metric (126 series here)
+            // - distinct from kustomize-controller's gotk_resource_info,
+            // already dropped by the generic gotk_.* rule above. No
+            // dashboard/alert consumer; the Flux dashboard uses
+            // controller_runtime_reconcile_total/workqueue_* instead.
+            source_labels = ["__name__"]
+            regex         = "flux_resource_info"
+            action        = "drop"
+          }
       grafanaCloudLogs:
         type: loki
         url: ${GRAFANA_LOKI_URL}

--- a/clusters/kubenuc/apps/grafana-alloy/manifests/release.yml
+++ b/clusters/kubenuc/apps/grafana-alloy/manifests/release.yml
@@ -142,9 +142,11 @@ spec:
             // histogram (289 series) and an enterprise-license-expiry gauge
             // (162 series) - neither has a dashboard/alert consumer in this
             // repo. Not part of the original Authentik drop rule above
-            // because these aren't authentik_-prefixed metric names.
-            source_labels = ["__name__"]
-            regex         = "django_http_requests_latency_seconds_by_view_method_bucket|authentik_enterprise_license_expiry_seconds"
+            // because these aren't authentik_-prefixed metric names. Scoped
+            // to job="authentik" (like the pg_ rules above) so a future
+            // non-Authentik source is never caught by name alone.
+            source_labels = ["__name__", "job"]
+            regex         = "(django_http_requests_latency_seconds_by_view_method_bucket|authentik_enterprise_license_expiry_seconds);authentik"
             action        = "drop"
           }
           write_relabel_config {


### PR DESCRIPTION
## Summary
Post-fix cardinality audit (active series holding at ~10,679, over the 10k free-tier cap after the earlier Authentik bucket-metric fix) found three more metric families with zero dashboard/alert consumers in this repo:

- `django_http_requests_latency_seconds_by_view_method_bucket` (289 series, kubenuc, job=authentik) — Authentik's own Django web framework request-latency histogram.
- `authentik_enterprise_license_expiry_seconds` (162 series, kubenuc, job=authentik).
- `flux_resource_info` (126 series kubenuc + 80 series k8s-vms-daniele, job=flux-operator) — flux-operator's own per-resource info metric, distinct from kustomize-controller's `gotk_resource_info` (already dropped by the existing generic `gotk_.*` rule).

Confirmed via `grep` across `terraform/grafana/` that none of the three are referenced by any Terraform-managed dashboard or `grafana_rule_group` alert rule. Total recoverable: ~657 series.

**Open residual risk** (flagged by dual review, not fully closeable from repo contents alone): no evidence found of a Grafana Cloud built-in/managed integration dashboard depending on `flux_resource_info` (`search_dashboards` for flux/gotk/gitops returns zero results, and `gotk_resource_info` has already been dropped with no prior incident) — but this can't be proven with full certainty without checking Grafana Cloud's Connections → Integrations page directly.

## Test plan
- [x] HCL/River syntax reviewed independently by codex-rescue + a fable subagent (both passed after one fix: scoped the Django/Authentik-license rule to `job="authentik"`, matching the sibling `pg_` rules' scoping convention)
- [ ] After merge + Flux reconcile + one scrape interval: confirm the three metric names stop appearing via `list_prometheus_metric_names`
- [ ] Re-check `grafanacloud_instance_active_series` drops by ~657

🤖 Generated with [Claude Code](https://claude.com/claude-code)