### PR TITLE
fix(grafana-alloy): drop unused kube-state-metrics fields to recover cardinality

### DIFF
--- a/clusters/k8s-vms-daniele/apps/grafana-alloy/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/grafana-alloy/manifests/release.yml
@@ -139,6 +139,44 @@ spec:
             regex         = "flux_resource_info"
             action        = "drop"
           }
+          write_relabel_config {
+            // Systematic audit: every kube-state-metrics field this repo's
+            // dashboards don't query, confirmed live with zero consumers
+            // across all 37 Terraform-managed dashboards (grepped every
+            // panel target's expr). Not covered by the metricsTuning.
+            // excludeMetrics list in this HelmRelease's values (that list
+            // only trims a handful of especially-noisy KSM fields at the
+            // chart level) - this catches the rest. Confirmed Grafana
+            // Cloud's built-in Kubernetes Monitoring integration/app isn't
+            // installed on this stack either, so nothing outside this
+            // repo depends on these fields.
+            source_labels = ["__name__"]
+            regex         = "kube_pod_container_resource_requests|kube_pod_container_info|kube_persistentvolume_status_phase|kube_pod_container_resource_limits|kube_pod_info|kube_pod_restart_policy|kube_pod_owner|kube_pod_start_time|kube_node_status_condition|kube_namespace_status_phase|kube_pod_container_status_last_terminated_timestamp|kube_deployment_status_observed_generation|kube_deployment_status_replicas_updated"
+            action        = "drop"
+          }
+          write_relabel_config {
+            // Same audit, the cluster:namespace:*:active:* recording-rule
+            // outputs and namespace_workload_pod:kube_pod_owner:relabel -
+            // computed from the raw kube_pod_container_resource_requests/
+            // limits fields above, but themselves separate series reaching
+            // remote-write. Zero dashboard consumers, same as above.
+            source_labels = ["__name__"]
+            regex         = "cluster:namespace:pod_(memory|cpu):active:kube_pod_container_resource_(requests|limits)|namespace_workload_pod:kube_pod_owner:relabel"
+            action        = "drop"
+          }
+          write_relabel_config {
+            // CoreDNS's "proxy" plugin latency histogram - considered as a
+            // substitute for the (nonexistent here) "forward" plugin
+            // metrics during the CoreDNS dashboard import, but the entire
+            // row that would have used it was dropped instead (see
+            // build_coredns_from_template's docstring) - never actually
+            // wired into any panel. Zero consumers, drop the whole family
+            // (not just _bucket - _sum/_count are unused here too, unlike
+            // the other _bucket-only drops above).
+            source_labels = ["__name__"]
+            regex         = "coredns_proxy_request_duration_seconds_bucket|coredns_proxy_request_duration_seconds_sum|coredns_proxy_request_duration_seconds_count"
+            action        = "drop"
+          }
       grafanaCloudLogs:
         type: loki
         url: ${GRAFANA_LOKI_URL}

--- a/clusters/kubenuc/apps/grafana-alloy/manifests/release.yml
+++ b/clusters/kubenuc/apps/grafana-alloy/manifests/release.yml
@@ -159,6 +159,44 @@ spec:
             regex         = "flux_resource_info"
             action        = "drop"
           }
+          write_relabel_config {
+            // Systematic audit: every kube-state-metrics field this repo's
+            // dashboards don't query, confirmed live with zero consumers
+            // across all 37 Terraform-managed dashboards (grepped every
+            // panel target's expr). Not covered by the metricsTuning.
+            // excludeMetrics list in this HelmRelease's values (that list
+            // only trims a handful of especially-noisy KSM fields at the
+            // chart level) - this catches the rest. Confirmed Grafana
+            // Cloud's built-in Kubernetes Monitoring integration/app isn't
+            // installed on this stack either, so nothing outside this
+            // repo depends on these fields.
+            source_labels = ["__name__"]
+            regex         = "kube_pod_container_resource_requests|kube_pod_container_info|kube_persistentvolume_status_phase|kube_pod_container_resource_limits|kube_pod_info|kube_pod_restart_policy|kube_pod_owner|kube_pod_start_time|kube_node_status_condition|kube_namespace_status_phase|kube_pod_container_status_last_terminated_timestamp|kube_deployment_status_observed_generation|kube_deployment_status_replicas_updated"
+            action        = "drop"
+          }
+          write_relabel_config {
+            // Same audit, the cluster:namespace:*:active:* recording-rule
+            // outputs and namespace_workload_pod:kube_pod_owner:relabel -
+            // computed from the raw kube_pod_container_resource_requests/
+            // limits fields above, but themselves separate series reaching
+            // remote-write. Zero dashboard consumers, same as above.
+            source_labels = ["__name__"]
+            regex         = "cluster:namespace:pod_(memory|cpu):active:kube_pod_container_resource_(requests|limits)|namespace_workload_pod:kube_pod_owner:relabel"
+            action        = "drop"
+          }
+          write_relabel_config {
+            // CoreDNS's "proxy" plugin latency histogram - considered as a
+            // substitute for the (nonexistent here) "forward" plugin
+            // metrics during the CoreDNS dashboard import, but the entire
+            // row that would have used it was dropped instead (see
+            // build_coredns_from_template's docstring) - never actually
+            // wired into any panel. Zero consumers, drop the whole family
+            // (not just _bucket - _sum/_count are unused here too, unlike
+            // the other _bucket-only drops above).
+            source_labels = ["__name__"]
+            regex         = "coredns_proxy_request_duration_seconds_bucket|coredns_proxy_request_duration_seconds_sum|coredns_proxy_request_duration_seconds_count"
+            action        = "drop"
+          }
       grafanaCloudLogs:
         type: loki
         url: ${GRAFANA_LOKI_URL}


### PR DESCRIPTION
## Summary
Systematic audit of every metric name referenced across all 37 Terraform-managed dashboards (grepped every panel target's `expr`, not spot-checked) found ~2,903 series of standard kube-state-metrics fields and Grafana-Cloud-side recording-rule outputs with zero consumers:

- `kube_pod_container_resource_requests`/`_info`/`_restart_policy`/`_owner`/`_start_time`/`_container_status_last_terminated_timestamp`
- `kube_persistentvolume_status_phase`, `kube_pod_container_resource_limits`
- `kube_node_status_condition`, `kube_namespace_status_phase`
- `kube_deployment_status_observed_generation`/`_replicas_updated`
- `cluster:namespace:pod_{memory,cpu}:active:kube_pod_container_resource_{requests,limits}` recording rules
- `namespace_workload_pod:kube_pod_owner:relabel`
- the `coredns_proxy_request_duration_seconds` family (considered as a substitute metric during the CoreDNS dashboard import in #1894 but never actually wired into a panel — the whole row that would have used it was dropped instead)

Confirmed Grafana Cloud's built-in Kubernetes Monitoring integration/app isn't installed on this stack either, so nothing outside this repo's own Terraform-managed dashboards depends on these fields.

Brings active series from ~9,945 to an estimated ~7,042 — comfortably under both the 10k hard cap and the 9,500 soft target, with real headroom for future waves.

## Test plan
- [x] Dual-reviewed (codex-rescue + a fable subagent, independently) — no correctness bugs found in either pass. Fable independently re-verified the dashboard-usage grep, both regexes (including the alternation grouping), the cardinality estimate via live query (~2,961, close to the ~2,903 estimate), and cross-checked against `generate_dashboards.py`'s panel-builder helpers.
- [x] Confirmed via user that no Grafana Cloud UI-created alert rules (outside this repo's Terraform) depend on `kube_node_status_condition`/`kube_pod_container_status_last_terminated_timestamp` — the one gap neither the reviewer nor I could check via API (missing `alert.rules:read` permission)
- [ ] After merge + Flux reconcile + one scrape interval: confirm the dropped metric names stop appearing via `list_prometheus_metric_names`
- [ ] Re-check `grafanacloud_instance_active_series` lands near the ~7,042 estimate

🤖 Generated with [Claude Code](https://claude.com/claude-code)