### PR TITLE
feat(kubenuc): enable SeaweedFS metrics scraping

### DIFF
--- a/clusters/kubenuc/apps/s3/manifests/release.yml
+++ b/clusters/kubenuc/apps/s3/manifests/release.yml
@@ -34,21 +34,42 @@ spec:
       persistence:
         storageClass: "openebs-hostpath"
         size: 100Mi
+      # Chart doesn't auto-annotate its own metrics port (confirmed against
+      # the chart's values.yaml - no prometheus.io annotation wiring exists
+      # anywhere in it), unlike some other charts in this repo - wire it up
+      # manually. metricsPort 9327 is this chart's own default, same for
+      # every component below.
+      podAnnotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9327"
+        prometheus.io/path: /metrics
 
     volume:
       replicaCount: 3
       persistence:
         storageClass: "openebs-hostpath"
         size: 10Gi
+      podAnnotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9327"
+        prometheus.io/path: /metrics
 
     filer:
       replicaCount: 1
       persistence:
         storageClass: "openebs-hostpath"
         size: 100Mi
+      podAnnotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9327"
+        prometheus.io/path: /metrics
 
     s3:
       enabled: true
+      podAnnotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9327"
+        prometheus.io/path: /metrics
       ingress:
         enabled: true
         className: "haproxy"


### PR DESCRIPTION
## Summary
Wave 3 step 1 (annotation-only, per the two-step land process used throughout this project): wire up `prometheus.io/scrape` annotations for SeaweedFS's `master`/`volume`/`filer`/`s3` components (port 9327, the chart's own confirmed default) so real metric names can be checked live before any dashboard work.

**OpenEBS's `localpv-provisioner` was originally included in this PR (port 9500), but dropped after dual review.** A web search claimed 9500 as the provisioner's documented metrics port; both codex-rescue and a fable subagent independently disproved this — fable traced it to source and confirmed the deployed `dynamic-localpv-provisioner` (built on `sig-storage-lib-external-provisioner`, not controller-runtime as originally assumed) never sets its `MetricsPort` option, which defaults to 0, and the library only starts a metrics HTTP server when that's `> 0`. There's no Prometheus endpoint on this binary at all as currently deployed — confirmed independently against the live pod too (zero declared container ports, no metrics-related CLI flags). Landing an annotation with nothing to scrape would've been a silent no-op, so it's dropped entirely rather than guessed at.

## Test plan
- [x] Dual-reviewed (codex-rescue + a fable subagent, independently) — SeaweedFS confirmed fully correct by both (fable went as far as pulling the chart's actual Helm templates to confirm `podAnnotations` is genuinely consumed into the Pod spec, not dead config); OpenEBS's port claim was caught and removed
- [ ] After merge + Flux reconcile + one scrape interval: confirm `seaweedfs_*` metrics appear via `list_prometheus_metric_names`
- [ ] Re-check `grafanacloud_instance_active_series` delta against estimate
- [ ] Dashboard PR to follow once real metric names are confirmed live

🤖 Generated with [Claude Code](https://claude.com/claude-code)