### PR TITLE
feat(k8s-vms-daniele): scrape AWX metrics via bearer-token authenticated Alloy

### DIFF
--- a/clusters/k8s-vms-daniele/apps/grafana-alloy/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/grafana-alloy/manifests/release.yml
@@ -356,6 +356,40 @@ spec:
                   fieldPath: metadata.name
         remoteConfig:
           enabled: false
+        # AWX's /api/v2/metrics requires an OAuth2 bearer token (superuser or
+        # System Auditor role) - the annotationAutodiscovery feature has no
+        # auth support, so this can't be a pod annotation like every other
+        # scraped app in this repo. Hand-written River config, injected via
+        # the chart's own collectors.<name>.extraConfig passthrough (traced
+        # through the chart's templates/collectors/_collector_extraConfig.tpl
+        # - it gets concatenated into this collector's single rendered
+        # config.alloy file, so it can reference prometheus.remote_write.
+        # grafanacloudmetrics.receiver, defined later in that same file).
+        # The token itself never appears in this repo, and - unlike
+        # grafanaCloudMetrics's own basic_auth credentials, which arrive via
+        # this HelmRelease's valuesFrom/targetPath and so do transit Helm's
+        # merged values and land in Helm's release-storage Secret - it never
+        # transits Helm/Flux at all: the 1Password Operator populates the
+        # awx-metrics-token Secret directly, out-of-band, and
+        # remote.kubernetes.secret reads it straight from the cluster at
+        # runtime. Alloy's `secret` argument type additionally keeps it out
+        # of the component-graph UI/debug output and logs (confirmed against
+        # Alloy's own docs, not assumed).
+        extraConfig: |
+          remote.kubernetes.secret "awx_metrics_token" {
+            name      = "awx-metrics-token"
+            namespace = "grafana-alloy"
+          }
+
+          prometheus.scrape "awx" {
+            targets = [
+              {"__address__" = "awx-service.awx.svc.cluster.local:80"},
+            ]
+            job_name     = "awx"
+            metrics_path = "/api/v2/metrics"
+            bearer_token = remote.kubernetes.secret.awx_metrics_token.data["bearer_token"]
+            forward_to   = [prometheus.remote_write.grafanacloudmetrics.receiver]
+          }
 
       alloy-singleton:
         presets:

--- a/clusters/k8s-vms-daniele/apps/grafana-alloy/secrets/awx-metrics-token.yml
+++ b/clusters/k8s-vms-daniele/apps/grafana-alloy/secrets/awx-metrics-token.yml
@@ -1,0 +1,8 @@
+---
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: awx-metrics-token
+  namespace: grafana-alloy
+spec:
+  itemPath: "vaults/k8s_secrets/items/awx-metrics-token"


### PR DESCRIPTION
## Summary
Wave 3 step 1. AWX's `/api/v2/metrics` requires an OAuth2 bearer token from a user with superuser or System Auditor (read-only) role — the `annotationAutodiscovery` feature this repo uses for every other scraped app has no auth support, so this needed a hand-written River scrape config rather than a pod annotation.

- Token minted for a dedicated, read-only **System Auditor** AWX user (not the admin superuser), stored in 1Password at `vaults/k8s_secrets/items/awx-metrics-token`, field `bearer_token`.
- New `OnePasswordItem` syncs it into the `grafana-alloy` namespace (not `awx`) so Alloy's own service account can read it without any cross-namespace RBAC change.
- Injected via `collectors.alloy-metrics.extraConfig`, the k8s-monitoring chart's raw-config passthrough — traced through the chart's own template source, confirmed it gets concatenated into the same rendered `config.alloy` file as the rest of the collector, so it can reference the existing `prometheus.remote_write.grafanacloudmetrics.receiver` component directly.
- **Token handling**: it never transits Helm/Flux at all — the 1Password Operator populates the Secret directly, out-of-band, and `remote.kubernetes.secret` reads it straight from the cluster at runtime. This is actually stronger than this chart's own `grafanaCloudMetrics` credentials, which arrive via `valuesFrom`/`targetPath` and do land in Helm's release-storage Secret. Alloy's `bearer_token` argument is a `secret`-typed value, confirmed via Alloy's own docs to be redacted from the component-graph UI, live debugging, and logs.
- Target: `awx-service.awx.svc.cluster.local:80` (confirmed live — ClusterIP Service, targetPort 8052, TLS terminates at the ingress).

## Test plan
- [x] Dual-reviewed (codex-rescue + a fable subagent, independently) — fable verified every claim against primary sources (Alloy's official docs, Alloy's own parser source, the k8s-monitoring chart's template source, and a live read against the cluster) rather than trusting the commit's own claims. No blocking issues; confirmed the token-handling design is safer than the precedent it's modeled on.
- [ ] After merge + Flux reconcile + one scrape interval: confirm `awx_*` metrics appear via `list_prometheus_metric_names`
- [ ] Re-check `grafanacloud_instance_active_series` delta
- [ ] Dashboard PR to follow once real metric names are confirmed live (search grafana.com first, per this project's established process)

🤖 Generated with [Claude Code](https://claude.com/claude-code)