### PR TITLE
fix(k8s-vms-daniele): AWX metrics scrape needs Basic auth, not Bearer

### DIFF
--- a/clusters/k8s-vms-daniele/apps/grafana-alloy/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/grafana-alloy/manifests/release.yml
@@ -366,42 +366,37 @@ spec:
         # config.alloy file, so it can reference prometheus.remote_write.
         # grafanacloudmetrics.receiver, defined later in that same file).
         #
-        # Started as an OAuth2 bearer token, but live-tested (by the human
-        # operator, directly against AWX) and confirmed Bearer auth doesn't
-        # work against this AWX deployment - Basic auth does. The
-        # awx-metrics-token Secret's bearer_token field now holds a
-        # pre-encoded base64("username:password") string for the same
-        # low-privilege System Auditor account instead (field name kept as
-        # bearer_token in 1Password/the Secret - only the scrape config's
-        # auth mechanism changed, not the secret's identity).
+        # Uses HTTP Basic auth for a dedicated, read-only System Auditor AWX
+        # account - OAuth2 bearer-token auth was tried first and live-tested
+        # (by the human operator, directly against AWX) to not work against
+        # this deployment. `basic_auth { username, password }` is the only
+        # mechanism that actually works here, needing the account's raw
+        # (unencoded) username/password - two other approaches were tried
+        # and ruled out first: `authorization { type = "Basic", credentials
+        # = <pre-encoded base64> }` is valid River but Prometheus's own HTTP
+        # client config (which prometheus.scrape wraps) explicitly rejects
+        # authorization type "basic" ("use basic_auth instead" -
+        # prometheus/common's http_config.go); a raw `http_headers =
+        # {"Authorization" = [...]}` map was tried next but Prometheus/
+        # common reserves that exact header name and rejects it too
+        # ("setting header \"Authorization\" is not allowed" -
+        # prometheus/common's headers.go ReservedHeaders list, which also
+        # covers Host/Content-Length/User-Agent/etc). Both rejections
+        # confirmed by reading prometheus/common's actual source, not
+        # assumed from docs. This repo's own grafanaCloudMetrics destination
+        # (defined later in this same rendered config.alloy file) already
+        # uses this same basic_auth mechanism successfully in production.
         #
-        # Two more auth-config attempts tried and rejected before this one:
-        # `authorization { type = "Basic", credentials = ... }` looks right
-        # and is valid River, but Prometheus's own HTTP client config (which
-        # Alloy's prometheus.scrape wraps) explicitly validates against and
-        # rejects type "basic" ("use basic_auth instead") - confirmed
-        # directly in prometheus/common's http_config.go, not just assumed.
-        # `basic_auth { username = ..., password = ... }` expects a raw,
-        # unencoded pair and computes its own base64 internally - feeding it
-        # this already-encoded value would double-encode and break auth.
-        # Settled on a raw `http_headers` map instead: `"Basic " + <secret>`
-        # relies on Alloy's own binary-op type coercion (syntax/internal/
-        # transform/binary.go's tryUnwrapString/tryUnwrapSecret - confirmed
-        # directly in Alloy's source, not just the reference docs, which
-        # don't document this) promoting the plain string literal to the
-        # `Secret` capsule type so the concatenation stays secret-typed
-        # (redacted from the UI/logs) all the way through.
-        #
-        # The token itself never appears in this repo, and - unlike
+        # The credentials never appear in this repo, and - unlike
         # grafanaCloudMetrics's own basic_auth credentials, which arrive via
         # this HelmRelease's valuesFrom/targetPath and so do transit Helm's
-        # merged values and land in Helm's release-storage Secret - it never
-        # transits Helm/Flux at all: the 1Password Operator populates the
-        # awx-metrics-token Secret directly, out-of-band, and
+        # merged values and land in Helm's release-storage Secret - they
+        # never transit Helm/Flux at all: the 1Password Operator populates
+        # the awx-metrics-token Secret directly, out-of-band, and
         # remote.kubernetes.secret reads it straight from the cluster at
-        # runtime. Alloy's `secret` argument type additionally keeps it out
-        # of the component-graph UI/debug output and logs (confirmed against
-        # Alloy's own docs, not assumed).
+        # runtime. Alloy's `secret` argument type additionally keeps them
+        # out of the component-graph UI/debug output and logs (confirmed
+        # against Alloy's own docs, not assumed).
         extraConfig: |
           remote.kubernetes.secret "awx_metrics_token" {
             name      = "awx-metrics-token"
@@ -414,11 +409,9 @@ spec:
             ]
             job_name     = "awx"
             metrics_path = "/api/v2/metrics"
-            http_headers = {
-              "Authorization" = [
-                "Basic " +
-                remote.kubernetes.secret.awx_metrics_token.data["bearer_token"],
-              ]
+            basic_auth {
+              username = remote.kubernetes.secret.awx_metrics_token.data["username"]
+              password = remote.kubernetes.secret.awx_metrics_token.data["credential"]
             }
             forward_to = [prometheus.remote_write.grafanacloudmetrics.receiver]
           }

--- a/clusters/k8s-vms-daniele/apps/grafana-alloy/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/grafana-alloy/manifests/release.yml
@@ -373,12 +373,24 @@ spec:
         # pre-encoded base64("username:password") string for the same
         # low-privilege System Auditor account instead (field name kept as
         # bearer_token in 1Password/the Secret - only the scrape config's
-        # auth mechanism changed, not the secret's identity). Alloy's
-        # `authorization { type = "Basic", credentials = ... }` block sends
-        # that string verbatim as `Authorization: Basic <credentials>`
-        # (confirmed against Alloy's own docs) - not `basic_auth {}`, which
-        # would instead expect a raw username/password pair and compute its
-        # own base64 encoding, double-encoding an already-encoded value.
+        # auth mechanism changed, not the secret's identity).
+        #
+        # Two more auth-config attempts tried and rejected before this one:
+        # `authorization { type = "Basic", credentials = ... }` looks right
+        # and is valid River, but Prometheus's own HTTP client config (which
+        # Alloy's prometheus.scrape wraps) explicitly validates against and
+        # rejects type "basic" ("use basic_auth instead") - confirmed
+        # directly in prometheus/common's http_config.go, not just assumed.
+        # `basic_auth { username = ..., password = ... }` expects a raw,
+        # unencoded pair and computes its own base64 internally - feeding it
+        # this already-encoded value would double-encode and break auth.
+        # Settled on a raw `http_headers` map instead: `"Basic " + <secret>`
+        # relies on Alloy's own binary-op type coercion (syntax/internal/
+        # transform/binary.go's tryUnwrapString/tryUnwrapSecret - confirmed
+        # directly in Alloy's source, not just the reference docs, which
+        # don't document this) promoting the plain string literal to the
+        # `Secret` capsule type so the concatenation stays secret-typed
+        # (redacted from the UI/logs) all the way through.
         #
         # The token itself never appears in this repo, and - unlike
         # grafanaCloudMetrics's own basic_auth credentials, which arrive via
@@ -402,9 +414,11 @@ spec:
             ]
             job_name     = "awx"
             metrics_path = "/api/v2/metrics"
-            authorization {
-              type        = "Basic"
-              credentials = remote.kubernetes.secret.awx_metrics_token.data["bearer_token"]
+            http_headers = {
+              "Authorization" = [
+                "Basic " +
+                remote.kubernetes.secret.awx_metrics_token.data["bearer_token"],
+              ]
             }
             forward_to = [prometheus.remote_write.grafanacloudmetrics.receiver]
           }

--- a/clusters/k8s-vms-daniele/apps/grafana-alloy/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/grafana-alloy/manifests/release.yml
@@ -356,15 +356,30 @@ spec:
                   fieldPath: metadata.name
         remoteConfig:
           enabled: false
-        # AWX's /api/v2/metrics requires an OAuth2 bearer token (superuser or
-        # System Auditor role) - the annotationAutodiscovery feature has no
-        # auth support, so this can't be a pod annotation like every other
+        # AWX's /api/v2/metrics requires authentication (superuser or System
+        # Auditor role) - the annotationAutodiscovery feature has no auth
+        # support, so this can't be a pod annotation like every other
         # scraped app in this repo. Hand-written River config, injected via
         # the chart's own collectors.<name>.extraConfig passthrough (traced
         # through the chart's templates/collectors/_collector_extraConfig.tpl
         # - it gets concatenated into this collector's single rendered
         # config.alloy file, so it can reference prometheus.remote_write.
         # grafanacloudmetrics.receiver, defined later in that same file).
+        #
+        # Started as an OAuth2 bearer token, but live-tested (by the human
+        # operator, directly against AWX) and confirmed Bearer auth doesn't
+        # work against this AWX deployment - Basic auth does. The
+        # awx-metrics-token Secret's bearer_token field now holds a
+        # pre-encoded base64("username:password") string for the same
+        # low-privilege System Auditor account instead (field name kept as
+        # bearer_token in 1Password/the Secret - only the scrape config's
+        # auth mechanism changed, not the secret's identity). Alloy's
+        # `authorization { type = "Basic", credentials = ... }` block sends
+        # that string verbatim as `Authorization: Basic <credentials>`
+        # (confirmed against Alloy's own docs) - not `basic_auth {}`, which
+        # would instead expect a raw username/password pair and compute its
+        # own base64 encoding, double-encoding an already-encoded value.
+        #
         # The token itself never appears in this repo, and - unlike
         # grafanaCloudMetrics's own basic_auth credentials, which arrive via
         # this HelmRelease's valuesFrom/targetPath and so do transit Helm's
@@ -387,8 +402,11 @@ spec:
             ]
             job_name     = "awx"
             metrics_path = "/api/v2/metrics"
-            bearer_token = remote.kubernetes.secret.awx_metrics_token.data["bearer_token"]
-            forward_to   = [prometheus.remote_write.grafanacloudmetrics.receiver]
+            authorization {
+              type        = "Basic"
+              credentials = remote.kubernetes.secret.awx_metrics_token.data["bearer_token"]
+            }
+            forward_to = [prometheus.remote_write.grafanacloudmetrics.receiver]
           }
 
       alloy-singleton:

--- a/clusters/k8s-vms-daniele/apps/grafana-alloy/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/grafana-alloy/manifests/release.yml
@@ -385,7 +385,12 @@ spec:
         # confirmed by reading prometheus/common's actual source, not
         # assumed from docs. This repo's own grafanaCloudMetrics destination
         # (defined later in this same rendered config.alloy file) already
-        # uses this same basic_auth mechanism successfully in production.
+        # uses this same basic_auth mechanism successfully in production -
+        # including the same convert.nonsensitive() wrapping on username
+        # (Alloy's basic_auth.username argument is plain-string-typed, not
+        # secret-typed, unlike .password - confirmed against the live
+        # rendered grafanaCloudMetrics block on this exact pod, which uses
+        # the identical convert.nonsensitive(...data["username"]) pattern).
         #
         # The credentials never appear in this repo, and - unlike
         # grafanaCloudMetrics's own basic_auth credentials, which arrive via
@@ -410,7 +415,7 @@ spec:
             job_name     = "awx"
             metrics_path = "/api/v2/metrics"
             basic_auth {
-              username = remote.kubernetes.secret.awx_metrics_token.data["username"]
+              username = convert.nonsensitive(remote.kubernetes.secret.awx_metrics_token.data["username"])
               password = remote.kubernetes.secret.awx_metrics_token.data["credential"]
             }
             forward_to = [prometheus.remote_write.grafanacloudmetrics.receiver]


### PR DESCRIPTION
## Summary
Follow-up to #1900. Live-testing directly against AWX confirmed Bearer token auth doesn't work against this deployment — Basic auth does. This PR went through 4 auth-mechanism attempts, 3 of which were caught by dual review reading primary sources (not just docs) rather than assuming:

1. `bearer_token = ...` (OAuth2 token) — confirmed by live test not to authenticate.
2. `authorization { type = "Basic", credentials = <pre-encoded base64> }` — valid River, but Prometheus's own HTTP client config (`prometheus/common/config/http_config.go`) explicitly rejects authorization type `"basic"` ("use basic_auth instead").
3. `http_headers = {"Authorization" = ["Basic " + <secret>]}` — Prometheus/common reserves the `Authorization` header name (`config/headers.go`'s `ReservedHeaders` list, also covering `Host`/`Content-Length`/`User-Agent`/etc) and rejects any attempt to set it via `http_headers`.
4. **Final**: `basic_auth { username = convert.nonsensitive(...), password = ... }` — the officially sanctioned mechanism (Prometheus's own error message for #2 literally says "use basic_auth instead"), using the System Auditor account's raw username/password (separate `username`/`credential` fields on the same 1Password item, `bearer_token` field now unused). `username` needs `convert.nonsensitive()` because Alloy's `basic_auth.username` argument is plain-string-typed while `.password` is secret-typed — caught independently by both reviewers, one tracing it through Alloy's actual pinned v1.19.0 source (`OptionalSecret.ConvertInto` rejecting secret→string conversion), the other via the working precedent already live in this same file (this repo's own `grafanaCloudMetrics` destination uses the identical `convert.nonsensitive(...data["username"])` pattern in production).

## Test plan
- [x] Every attempt dual-reviewed (codex-rescue + a fable subagent, independently) across multiple rounds; two independent reviewers converged on the identical final fix via different investigation paths (docs pattern-matching vs. tracing the actual pinned Alloy source)
- [x] Final version matches the exact `basic_auth` block shape already running successfully in production for this repo's `grafanaCloudMetrics` destination on the same Alloy pod
- [ ] After merge + Flux reconcile: confirm `awx_*` metrics actually appear via `list_prometheus_metric_names` (this is the first attempt with real reason to expect success — prior attempts never got a chance to prove out live)
- [ ] Re-check `grafanacloud_instance_active_series` delta
- [ ] Dashboard PR to follow once real metric names are confirmed live

🤖 Generated with [Claude Code](https://claude.com/claude-code)