### PR TITLE
feat(kubenuc): enable Harbor exporter metrics scraping

### DIFF
--- a/clusters/kubenuc/apps/harbor/manifests/release.yml
+++ b/clusters/kubenuc/apps/harbor/manifests/release.yml
@@ -109,15 +109,32 @@ spec:
     metrics:
       enabled: true
     # Wave 4: metrics.enabled alone doesn't add scrape annotations in this
-    # chart version - only the registry sub-component's podAnnotations are
-    # wired up here (matches what was already drafted below, before this
-    # was uncommented). core/jobservice/trivy annotation blocks were never
-    # drafted - only consider adding them in a later, separate PR if
-    # registry-only proves valuable and cardinality budget allows, per the
-    # original plan's caution against enabling all four at once.
+    # chart version - registry and exporter's podAnnotations are wired up
+    # manually. core/jobservice/trivy annotation blocks were never drafted
+    # - only consider adding them in a later, separate PR if this proves
+    # valuable and cardinality budget allows, per the original plan's
+    # caution against enabling all four sub-components' metrics at once.
     registry:
       podAnnotations:
         backup.velero.io/backup-volumes: "registry-data"
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: "8001"
+    # The exporter sub-component (metrics.enabled: true already deploys it,
+    # confirmed live: harbor-exporter Deployment, replicas: 1 per the chart
+    # default - not scaled with core/registry) is a dedicated Prometheus
+    # aggregator that queries Harbor's own Postgres DB directly for
+    # business-level metrics (project/repository/artifact counts, quota
+    # usage) - complementary to, not redundant with, registry's protocol-
+    # level metrics (HTTP/blob-storage request counts). Single pod, so
+    # cheap relative to value. Same port number (8001) as registry is NOT
+    # coincidental - the chart's underlying metrics.<component>.port block
+    # (values.yaml, never overridden by this repo) defaults core/registry/
+    # jobservice/exporter all to 8001 uniformly. That block lives outside
+    # exporter:/registry: entirely - a future port change belongs there,
+    # not under either sub-component's own key.
+    exporter:
+      podAnnotations:
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "8001"


### PR DESCRIPTION
## Summary
Follow-up to #1905. While investigating Harbor's live cluster state after that PR merged, found `metrics.enabled: true` already deploys a separate `harbor-exporter` Deployment (`replicas: 1`, confirmed live — not scaled with core/registry like the rest of Harbor) that #1905 didn't wire up for scraping.

The exporter sub-component is a dedicated Prometheus aggregator that queries Harbor's own Postgres DB directly for business-level metrics (project/repository/artifact counts, quota usage) — complementary to, not redundant with, `registry`'s protocol-level metrics (HTTP/blob-storage request counts to the OCI registry API). Single pod, so cheap relative to value — a much better cost/coverage ratio than anything else in this wave.

Confirmed the chart's `exporter.podAnnotations` key exists (`goharbor/harbor-helm` v1.19.2's `values.yaml`, default `{}`) and is genuinely consumed by the exporter Deployment template's pod spec (not just present in `values.yaml`). Port 8001 confirmed via the chart's own `metrics.exporter.port` default (`values.yaml` sets `metrics.core`/`registry`/`jobservice`/`exporter.port` all to 8001 uniformly — a deliberate chart default, not a coincidental match with registry's own port, as an earlier version of this PR's comment incorrectly claimed — caught by dual review).

No dashboard changes in this PR — follows once real `harbor_*` metric names from both registry and exporter are confirmed live via `list_prometheus_metric_names`.

## Test plan
- [x] Dual-reviewed (codex-rescue + a fable subagent, independently) — both confirmed correct against the actual Harbor chart templates (not just values.yaml assumption), including definitively resolving the port question via the chart's own `metrics.exporter.port` wiring rather than analogy. Fable caught one inaccurate code comment (fixed).
- [ ] After merge + Flux reconcile: confirm `harbor_*` metrics from the exporter appear via `list_prometheus_metric_names`
- [ ] Re-check `grafanacloud_instance_active_series` delta
- [ ] Dashboard PR to follow once real metric names (registry + exporter combined) are confirmed live

🤖 Generated with [Claude Code](https://claude.com/claude-code)