### PR TITLE
feat(kubenuc): enable haproxy-ingress metrics scraping

### DIFF
--- a/clusters/kubenuc/apps/haproxy-ingress/manifests/release.yml
+++ b/clusters/kubenuc/apps/haproxy-ingress/manifests/release.yml
@@ -58,6 +58,21 @@ spec:
 
       replicaCount: 3
 
+      # Wave 5: controller.prometheus.enabled defaults to true in this chart
+      # (metrics served on the stat port, containerPort.stat=1024, at /metrics)
+      # - only the scrape annotation was missing. No NetworkPolicy exists in
+      # this namespace (no default-deny), so no allow-rule is needed here,
+      # unlike nut/harbor. Investigate live haproxy_* series cardinality
+      # before building a dashboard - per-backend/per-server stats scale
+      # with both the number of ingress-fronted apps and this controller's
+      # replicaCount: 3, so land this annotation-only first and checkpoint
+      # grafanacloud_instance_active_series before deciding whether a
+      # cardinality-trimming relabel rule is needed.
+      podAnnotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "1024"
+        prometheus.io/path: "/metrics"
+
       PodDisruptionBudget:
         enable: true
         minAvailable: 1


### PR DESCRIPTION
## Summary
- Wave 5 of the Grafana Dashboard Overhaul: annotation-only precursor PR, no dashboard yet.
- `controller.prometheus.enabled` already defaults to `true` in this chart (metrics on the stat port at `/metrics`) — only the scrape annotation was missing. Adds `controller.podAnnotations` (`prometheus.io/scrape`, `prometheus.io/port: "1024"`, `prometheus.io/path`) matching this repo's Alloy annotation-autodiscovery convention.
- No NetworkPolicy exists in this namespace (no default-deny), so no allow-rule is needed, unlike nut/harbor.
- Deliberately sequenced per this project's two-step pattern: land the annotation, checkpoint `grafanacloud_instance_active_series` (currently ~8,449/10,000) once Alloy has scraped, then decide whether a cardinality-trimming relabel rule is needed before any dashboard-builder follow-up. This controller runs 3 replicas fronting ~8 apps' ingress, so per-backend/per-server HAProxy stats could be a meaningful chunk of the remaining budget — investigating live before committing to a dashboard, per the plan.

## Test plan
- [x] `helm show values`/`helm template` against the pinned chart version confirms `controller.prometheus.enabled: true` and `containerPort.stat: 1024` are chart defaults, matching the new annotation's port
- [x] YAML parses cleanly, `podAnnotations` correctly nested under `controller:`
- [x] CRLF line endings preserved (pre-existing repo quirk on this file)
- [x] Independent dual review (codex-rescue + fable, run separately) — no functional bugs found
- [ ] Post-merge: checkpoint `grafanacloud_instance_active_series` after Flux reconcile + one scrape interval, before any dashboard-builder PR