### PR TITLE
fix(grafana-alloy): raise alloy-metrics memory limit to stop OOM crash loop

### DIFF
--- a/clusters/kubenuc/apps/grafana-alloy/manifests/release.yml
+++ b/clusters/kubenuc/apps/grafana-alloy/manifests/release.yml
@@ -512,12 +512,29 @@ spec:
           - clustered
           - statefulset
         alloy:
+          # Bumped from 64Mi/128Mi 2026-08-26: this collector was OOMKilling
+          # in a tight crash loop (exitCode 137, 21 restarts observed, WAL
+          # replay alone taking 11.5s inside a container that lived only
+          # 16-32s between kills) - the annotation-autodiscovery scrape
+          # target set has grown substantially across Waves 2-5 (nut,
+          # cloudflared, sso/authentik, seaweedfs, awx, harbor,
+          # haproxy-ingress) without this limit ever being revisited. It was
+          # already the smallest of the four collectors despite doing the
+          # most work (cluster-wide pod/service discovery + relabel + WAL +
+          # remote-write for every annotated target). No empirical usage
+          # data was available to size this precisely - the crash loop
+          # itself prevented this pod's own memory metrics from ever
+          # completing a scrape+remote-write cycle - so 512Mi is a
+          # conservative absolute ceiling matching alloy-logs' limit (the
+          # most generously provisioned sibling), not a ratio match; revisit
+          # if it recurs, since the WAL lives on an emptyDir that persists
+          # across container restarts within the pod.
           resources:
             requests:
               cpu: 20m
-              memory: 64Mi
-            limits:
               memory: 128Mi
+            limits:
+              memory: 512Mi
           extraEnv:
             - name: CLUSTER_NAME
               value: kubenuc


### PR DESCRIPTION
## Summary
- **Live incident, not routine dashboard work.** `alloy-metrics` (the annotation-autodiscovery collector — cluster-wide `prometheus.io/scrape`-annotated pod/service discovery, relabel, WAL, remote-write) is actively OOMKilling in a tight crash loop: `exitCode 137`, 21 restarts, container lifetimes as short as 16-32s — not enough time to finish replaying its own WAL (152 segments, 11.5s alone).
- Its `128Mi` memory limit was already the smallest of the 4 Alloy collectors despite doing the most work, and was never revisited as the annotated-app count grew across this project's Waves 2-5 (nut, cloudflared, sso, seaweedfs, awx, harbor, haproxy-ingress). A 14-day restart-count trend shows the crash loop climbing steadily since ~2026-08-23, accelerating sharply today.
- Raises `requests.memory` 64Mi→128Mi, `limits.memory` 128Mi→512Mi. No empirical usage data was available to size this precisely (the crash loop prevented this pod's own memory metrics from ever completing a scrape cycle) — 512Mi is a conservative absolute ceiling matching `alloy-logs`' limit, explicitly *not* a ratio match (comment says so directly, after dual review caught an earlier draft's inaccurate "ratio" claim).
- This likely explains why some newly-annotated apps' metrics never reliably reached Grafana Cloud.

## Known follow-up (not blocking this fix)
- The WAL lives on an `emptyDir` shared across all 4 collectors, which persists across container restarts within the same pod — if discovery/WAL state keeps growing as more apps get annotated, this may need revisiting rather than being a permanent fix.
- `annotationAutodiscovery` has no namespace/labelSelector scoping (cluster-wide by design) — the only relabel/drop rules in this file run post-scrape on the remote-write path, they don't reduce discovery/scrape target count or this collector's own memory footprint.

## Test plan
- [x] YAML parses cleanly, diff scoped to only `alloy-metrics`' resources block — 3 sibling collector blocks untouched
- [x] No ResourceQuota/LimitRange exists in this namespace that would cap or reject 512Mi
- [x] Independent dual review (codex-rescue + fable, run separately) — both caught the same comment inaccuracy (now fixed); no other bugs found
- [ ] Post-merge: verify pod-level restart-count trend stays flat over several minutes (not just `flux get hr`/Kustomization Ready — these pods are created via `alloy-operator`'s `Alloy` CR, not directly by Helm, so green CI doesn't guarantee pod health)