### PR TITLE
fix(grafana-alloy): drop haproxy_server_* to recover cardinality budget

### DIFF
--- a/clusters/kubenuc/apps/grafana-alloy/manifests/release.yml
+++ b/clusters/kubenuc/apps/grafana-alloy/manifests/release.yml
@@ -197,6 +197,24 @@ spec:
             regex         = "coredns_proxy_request_duration_seconds_bucket|coredns_proxy_request_duration_seconds_sum|coredns_proxy_request_duration_seconds_count"
             action        = "drop"
           }
+          write_relabel_config {
+            // haproxy-ingress: confirmed live at ~5,088 of the ~6,471 total
+            // series this app added (query_prometheus, 2026-08-26) -
+            // haproxy_server_* is per pre-reserved server SLOT, not per
+            // actual backend pod (haproxy_server_bytes_in_total alone was
+            // 588 series across 3 replicas and ~15 backends, i.e. ~13
+            // slots/backend/replica - this chart over-provisions slots for
+            // dynamic scaling without a reload, a well-known HAProxy
+            // Ingress behavior). No dashboard consumer yet (annotation-only
+            // landing, PR #1908) and this family alone pushed
+            // grafanacloud_instance_active_series from ~8,449 to 9,653,
+            // right at the budget ceiling. haproxy_backend_*/frontend_*/
+            // process_* aggregates (~1,383 series) are retained for a
+            // future dashboard-builder PR.
+            source_labels = ["__name__"]
+            regex         = "haproxy_server_.*"
+            action        = "drop"
+          }
       grafanaCloudLogs:
         type: loki
         url: ${GRAFANA_LOKI_URL}


### PR DESCRIPTION
## Summary
- **Urgent, live budget mitigation** — not routine dashboard work. Enabling haproxy-ingress metrics scraping (#1908) pushed `grafanacloud_instance_active_series` to 9,653, right at this project's ≤9,500 target and close to the hard 10,000 cap where Grafana Cloud drops all metrics account-wide.
- Root cause confirmed live: `haproxy_server_*` (9 metric names) carries ~5,088 of the namespace's ~6,471 total series — 588 or 384 series per metric name, vastly disproportionate to `haproxy_backend_*` (14-84 each). Almost certainly per pre-reserved server *slot* (a documented HAProxy Ingress behavior for scaling without a reload), not per actual running pod.
- Drops `haproxy_server_*` entirely via a new `write_relabel_config` block (same pattern as 6+ existing precedent rules in this file). Zero dashboard/alert consumers exist anywhere in the repo (grepped, confirmed by both reviewers independently). `haproxy_backend_*`/`frontend_*`/`process_*` aggregates (~1,383 series) are retained for a future dashboard-builder PR.

## Test plan
- [x] YAML parses cleanly, brace-balanced, correctly placed inside `destinations.grafanaCloudMetrics.metricProcessingRules` (not spilling into sibling `grafanaCloudLogs`)
- [x] Regex `haproxy_server_.*` is fully anchored — matches only the 9 target metric names, confirmed not to match `haproxy_backend_*`/`frontend_*`/`process_*`
- [x] Zero `haproxy_server_*` consumers anywhere in the repo (dashboards, alert rules)
- [x] Independent dual review (codex-rescue + fable, run separately) — both clean, no bugs found
- [ ] Post-merge: confirm `haproxy_server_*` series actually drop out and `grafanacloud_instance_active_series` recovers toward the ≤9,500 target