### PR TITLE
feat(grafana): add real haproxy-ingress dashboard using live metrics

### DIFF
--- a/terraform/grafana/dashboards/kubenuc/haproxy-ingress.json
+++ b/terraform/grafana/dashboards/kubenuc/haproxy-ingress.json
@@ -4,6 +4,7 @@
   "tags": [
     "kubenuc",
     "haproxy-ingress",
+    "ingress",
     "kubernetes"
   ],
   "timezone": "browser",
@@ -264,7 +265,7 @@
     },
     {
       "id": 6,
-      "title": "Resources",
+      "title": "Backends",
       "type": "row",
       "collapsed": false,
       "gridPos": {
@@ -277,6 +278,487 @@
     },
     {
       "id": 7,
+      "title": "Backends Down",
+      "type": "stat",
+      "datasource": {
+        "uid": "grafanacloud-prom",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 6,
+        "w": 6,
+        "h": 4
+      },
+      "targets": [
+        {
+          "expr": "count(count by (proxy) (haproxy_backend_status{cluster=\"kubenuc\",job=\"kubernetes-ingress\",state=\"DOWN\"} == 1)) or vector(0)",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "green"
+              },
+              {
+                "value": 1,
+                "color": "red"
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": []
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 8,
+      "title": "Backend Request Rate by Service",
+      "type": "timeseries",
+      "datasource": {
+        "uid": "grafanacloud-prom",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 6,
+        "y": 6,
+        "w": 18,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum by (proxy) (rate(haproxy_backend_http_requests_total{cluster=\"kubenuc\",job=\"kubernetes-ingress\"}[5m]))",
+          "legendFormat": "{{proxy}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 9,
+      "title": "Backend Response Codes",
+      "type": "timeseries",
+      "datasource": {
+        "uid": "grafanacloud-prom",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 14,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum by (code) (rate(haproxy_backend_http_responses_total{cluster=\"kubenuc\",job=\"kubernetes-ingress\"}[5m]))",
+          "legendFormat": "{{code}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 10,
+      "title": "Backend Current Sessions by Service",
+      "type": "timeseries",
+      "datasource": {
+        "uid": "grafanacloud-prom",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 14,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum by (proxy) (haproxy_backend_current_sessions{cluster=\"kubenuc\",job=\"kubernetes-ingress\"})",
+          "legendFormat": "{{proxy}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 11,
+      "title": "Frontends",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 22,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 12,
+      "title": "Frontend Request Rate",
+      "type": "timeseries",
+      "datasource": {
+        "uid": "grafanacloud-prom",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 23,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum by (proxy) (rate(haproxy_frontend_http_requests_total{cluster=\"kubenuc\",job=\"kubernetes-ingress\"}[5m]))",
+          "legendFormat": "{{proxy}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 13,
+      "title": "Frontend Denied Connections",
+      "type": "timeseries",
+      "datasource": {
+        "uid": "grafanacloud-prom",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 23,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum by (proxy) (rate(haproxy_frontend_denied_connections_total{cluster=\"kubenuc\",job=\"kubernetes-ingress\"}[5m]))",
+          "legendFormat": "{{proxy}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 14,
+      "title": "Process",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 31,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 15,
+      "title": "Uptime by Pod",
+      "type": "timeseries",
+      "datasource": {
+        "uid": "grafanacloud-prom",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 32,
+        "w": 8,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "haproxy_process_uptime_seconds{cluster=\"kubenuc\",job=\"kubernetes-ingress\"}",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 16,
+      "title": "Current Connections by Pod",
+      "type": "timeseries",
+      "datasource": {
+        "uid": "grafanacloud-prom",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 8,
+        "y": 32,
+        "w": 8,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "haproxy_process_current_connections{cluster=\"kubenuc\",job=\"kubernetes-ingress\"}",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 17,
+      "title": "Memory Pool Used by Pod",
+      "type": "timeseries",
+      "datasource": {
+        "uid": "grafanacloud-prom",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 32,
+        "w": 8,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "haproxy_process_pool_used_bytes{cluster=\"kubenuc\",job=\"kubernetes-ingress\"}",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 18,
+      "title": "Resources",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 40,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 19,
       "title": "CPU Usage by Pod",
       "type": "timeseries",
       "datasource": {
@@ -285,7 +767,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 6,
+        "y": 41,
         "w": 12,
         "h": 8
       },
@@ -324,7 +806,7 @@
       }
     },
     {
-      "id": 8,
+      "id": 20,
       "title": "Memory Usage by Pod",
       "type": "timeseries",
       "datasource": {
@@ -333,7 +815,7 @@
       },
       "gridPos": {
         "x": 12,
-        "y": 6,
+        "y": 41,
         "w": 12,
         "h": 8
       },
@@ -372,20 +854,20 @@
       }
     },
     {
-      "id": 9,
+      "id": 21,
       "title": "Reliability",
       "type": "row",
       "collapsed": false,
       "gridPos": {
         "x": 0,
-        "y": 14,
+        "y": 49,
         "w": 24,
         "h": 1
       },
       "panels": []
     },
     {
-      "id": 10,
+      "id": 22,
       "title": "Container Restarts",
       "type": "timeseries",
       "datasource": {
@@ -394,7 +876,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 15,
+        "y": 50,
         "w": 12,
         "h": 8
       },
@@ -433,7 +915,7 @@
       }
     },
     {
-      "id": 11,
+      "id": 23,
       "title": "Network I/O",
       "type": "timeseries",
       "datasource": {
@@ -442,7 +924,7 @@
       },
       "gridPos": {
         "x": 12,
-        "y": 15,
+        "y": 50,
         "w": 12,
         "h": 8
       },
@@ -486,20 +968,20 @@
       }
     },
     {
-      "id": 12,
+      "id": 24,
       "title": "Logs",
       "type": "row",
       "collapsed": false,
       "gridPos": {
         "x": 0,
-        "y": 23,
+        "y": 58,
         "w": 24,
         "h": 1
       },
       "panels": []
     },
     {
-      "id": 13,
+      "id": 25,
       "title": "Pod Logs",
       "type": "logs",
       "datasource": {
@@ -508,7 +990,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 24,
+        "y": 59,
         "w": 24,
         "h": 8
       },

--- a/terraform/grafana/generate_dashboards.py
+++ b/terraform/grafana/generate_dashboards.py
@@ -1613,6 +1613,85 @@ def build_authentik(uid_str):
     return make_dashboard(f"Authentik (SSO) — {c}", uid_str, [c, "sso", "authentik", "kubernetes"], panels)
 
 
+def build_haproxy_ingress(uid_str):
+    """kubenuc only. namespace=haproxy-ingress, job=kubernetes-ingress
+    (confirmed live, Wave 5). Metrics use a `proxy` label for
+    backend/frontend name (not `service`/`ingress`) and a `state`
+    label (UP/DOWN, as separate 0/1 series per state - not a single
+    gauge) for haproxy_{backend,frontend}_status.
+
+    haproxy_server_* (per pre-reserved server slot, not per actual pod -
+    ~5,088 series, no dashboard value) is deliberately excluded here and
+    dropped at the source via a write_relabel_config in grafana-alloy's
+    release.yml (see that file's comment for the live cardinality
+    numbers this was scoped against) - do not add panels querying it
+    without first re-adding it to remote-write and re-checking the
+    budget.
+    """
+    c, n = "kubenuc", "haproxy-ingress"
+    jf = ',job="kubernetes-ingress"'
+    panels, pid, y = status_row(1, 0, c, n)
+
+    panels.append(p_row(pid, "Backends", y)); pid += 1; y += 1
+    panels.append(p_stat(pid, "Backends Down",
+        # Every replica reports its own view of every backend (its own `pod`
+        # label) - count by (proxy) first to dedup to one series per unique
+        # backend name before counting, or a backend down across all 3
+        # replicas would inflate this to 3. `or vector(0)` because count()
+        # over an empty vector (the normal, all-healthy case) returns no
+        # series at all, not a 0 - without it this panel shows "No Data"
+        # instead of a green "0" whenever nothing is actually down.
+        f'count(count by (proxy) (haproxy_backend_status{{cluster="{c}"{jf},state="DOWN"}} == 1)) or vector(0)',
+        0, y, w=6, thresholds=[{"value": None, "color": "green"}, {"value": 1, "color": "red"}]
+    )); pid += 1
+    panels.append(p_ts(pid, "Backend Request Rate by Service",
+        [{"expr": f'sum by (proxy) (rate(haproxy_backend_http_requests_total{{cluster="{c}"{jf}}}[5m]))', "legend": "{{proxy}}"}],
+        6, y, w=18, unit="reqps"
+    )); pid += 1; y += 8
+    panels.append(p_ts(pid, "Backend Response Codes",
+        [{"expr": f'sum by (code) (rate(haproxy_backend_http_responses_total{{cluster="{c}"{jf}}}[5m]))', "legend": "{{code}}"}],
+        0, y, w=12, unit="reqps"
+    )); pid += 1
+    panels.append(p_ts(pid, "Backend Current Sessions by Service",
+        [{"expr": f'sum by (proxy) (haproxy_backend_current_sessions{{cluster="{c}"{jf}}})', "legend": "{{proxy}}"}],
+        12, y, w=12, unit="short"
+    )); pid += 1; y += 8
+
+    panels.append(p_row(pid, "Frontends", y)); pid += 1; y += 1
+    panels.append(p_ts(pid, "Frontend Request Rate",
+        [{"expr": f'sum by (proxy) (rate(haproxy_frontend_http_requests_total{{cluster="{c}"{jf}}}[5m]))', "legend": "{{proxy}}"}],
+        0, y, w=12, unit="reqps"
+    )); pid += 1
+    panels.append(p_ts(pid, "Frontend Denied Connections",
+        [{"expr": f'sum by (proxy) (rate(haproxy_frontend_denied_connections_total{{cluster="{c}"{jf}}}[5m]))', "legend": "{{proxy}}"}],
+        12, y, w=12, unit="short"
+    )); pid += 1; y += 8
+
+    panels.append(p_row(pid, "Process", y)); pid += 1; y += 1
+    panels.append(p_ts(pid, "Uptime by Pod",
+        [{"expr": f'haproxy_process_uptime_seconds{{cluster="{c}"{jf}}}', "legend": "{{pod}}"}],
+        0, y, w=8, unit="s"
+    )); pid += 1
+    panels.append(p_ts(pid, "Current Connections by Pod",
+        [{"expr": f'haproxy_process_current_connections{{cluster="{c}"{jf}}}', "legend": "{{pod}}"}],
+        8, y, w=8, unit="short"
+    )); pid += 1
+    panels.append(p_ts(pid, "Memory Pool Used by Pod",
+        [{"expr": f'haproxy_process_pool_used_bytes{{cluster="{c}"{jf}}}', "legend": "{{pod}}"}],
+        16, y, w=8, unit="bytes"
+    )); pid += 1; y += 8
+
+    rp, pid, y = resource_row(pid, y, c, n)
+    panels += rp
+    rp, pid, y = reliability_row(pid, y, c, n)
+    panels += rp
+
+    panels.append(p_row(pid, "Logs", y)); pid += 1; y += 1
+    panels.append(p_logs(pid, c, n, y))
+
+    return make_dashboard(f"HAProxy Ingress — {c}", uid_str, [c, "haproxy-ingress", "ingress", "kubernetes"], panels)
+
+
 # ---------------------------------------------------------------------------
 # App registry
 # ---------------------------------------------------------------------------
@@ -1628,7 +1707,7 @@ APPS = {
         ("film-tv-exporter",         "film-tv",               "Film/TV Exporter",              "no-container"),
         ("flux",                     "flux-system",           "Flux",                          "flux"),
         ("grafana-alloy",            "grafana-alloy",         "Grafana Alloy",                 "standard"),
-        ("haproxy-ingress",          "haproxy-ingress",       "HAProxy Ingress",               "standard"),
+        ("haproxy-ingress",          "haproxy-ingress",       "HAProxy Ingress",               "haproxy-ingress"),
         ("harbor",                   "harbor",                "Harbor Registry",               "harbor"),
         ("jellyfin",                 "jellyfin",              "Jellyfin",                      "standard"),
         ("jenkins",                  "jenkins",               "Jenkins",                       "standard"),
@@ -1695,6 +1774,7 @@ def main():
                 "cloudflared":  lambda c, fn, ns, d, u: build_cloudflared_from_template(u),
                 "teleport-agent-diag": lambda c, fn, ns, d, u: build_teleport_agent(u),
                 "authentik":    lambda c, fn, ns, d, u: build_authentik(u),
+                "haproxy-ingress": lambda c, fn, ns, d, u: build_haproxy_ingress(u),
             }
 
             dash = builders[app_type](cluster, file_name, namespace, display, uid_str)


### PR DESCRIPTION
## Summary
- Wave 5's dashboard-builder follow-up: replaces the generic "standard" placeholder (kube_pod_status_phase only) with a hand-rolled dashboard using real `haproxy_backend_*`/`frontend_*`/`process_*` metrics confirmed live after #1908.
- Panels: backends-down count, request rate/response codes/current sessions by backend, frontend request rate/denied connections, process uptime/connections/memory pool by pod, plus standard status/resource/reliability/logs rows.
- Deliberately excludes `haproxy_server_*` (dropped at the source in #1910 for cardinality — per pre-reserved server slot, not per actual pod, ~5,088 series with no dashboard value).

## Known follow-up (not blocking, not introduced by this diff)
- Confirmed live: only 1 of the 3 haproxy-ingress replicas is currently being scraped (`count by (pod) (haproxy_process_uptime_seconds{...})` = 1 distinct pod, despite all 3 pods carrying identical, correct scrape annotations). This is an Alloy discovery-side gap, not a dashboard bug — the "by Pod" panels and per-backend dedup logic are correct but only see one replica's data today. Worth its own investigation.

## Test plan
- [x] `python3 generate_dashboards.py` runs clean, `git diff --exit-code -- dashboards/` shows zero drift
- [x] `terraform fmt -check -diff` passes
- [x] Every PromQL expr's metric/label names verified against live data (no typos, no accidental `haproxy_server_*`, legends match each metric's actual label set)
- [x] Grid layout hand-verified — no panel overlaps, every row sums to ≤24
- [x] Independent dual review (codex-rescue + fable, run separately) — caught two real bugs, both fixed: (1) "Backends Down" was counting per-replica series instead of unique backends (3x inflation risk), (2) same panel showed "No Data" instead of "0" when healthy (count() over an empty vector), fixed with `or vector(0)`