### PR TITLE
feat(k8s-vms-daniele): probe AWX/AWX-test/Semaphore via blackbox-exporter

### DIFF
--- a/clusters/k8s-vms-daniele/apps/grafana-alloy/manifests/release.yml
+++ b/clusters/k8s-vms-daniele/apps/grafana-alloy/manifests/release.yml
@@ -421,6 +421,44 @@ spec:
             forward_to = [prometheus.remote_write.grafanacloudmetrics.receiver]
           }
 
+          // blackbox-exporter (deployed with only an http_2xx module, no
+          // podAnnotations - annotationAutodiscovery can't express the
+          // __param_target rewrite a blackbox probe needs, so this is
+          // hand-written like the awx block above). Small, fixed probe set
+          // (~10-15 series each, negligible against budget) referenced by
+          // cluster-vars hostname, never a hardcoded FQDN, per repo
+          // convention - only apps that are real HTTP web UIs on this
+          // cluster (teleport-agent is a connection-holding proxy, not an
+          // HTTP server, same reasoning as its own dashboard builder).
+          discovery.relabel "blackbox_probe_targets" {
+            targets = [
+              {"__address__" = "https://${AWX_HOST}"},
+              {"__address__" = "https://${AWX_TEST_HOST}"},
+              {"__address__" = "https://${SEMAPHORE_HOST}"},
+            ]
+
+            rule {
+              source_labels = ["__address__"]
+              target_label  = "__param_target"
+            }
+            rule {
+              source_labels = ["__param_target"]
+              target_label  = "instance"
+            }
+            rule {
+              target_label = "__address__"
+              replacement  = "blackbox-blackbox-exporter.monitoring.svc.cluster.local:9115"
+            }
+          }
+
+          prometheus.scrape "blackbox" {
+            targets      = discovery.relabel.blackbox_probe_targets.output
+            job_name     = "blackbox"
+            metrics_path = "/probe"
+            params       = {"module" = ["http_2xx"]}
+            forward_to   = [prometheus.remote_write.grafanacloudmetrics.receiver]
+          }
+
       alloy-singleton:
         presets:
           - singleton


### PR DESCRIPTION
## Summary
- blackbox-exporter was deployed on this cluster (`monitoring` namespace) with only an `http_2xx` module and empty `podAnnotations` — no probing was ever actually wired up.
- Annotation-based autodiscovery can't express the `__param_target` rewrite a blackbox probe needs, so this adds a hand-written `discovery.relabel` + `prometheus.scrape` block via the same `extraConfig` mechanism already proven for AWX's own authenticated metrics scrape in this same collector.
- Small, fixed probe set — AWX, AWX-test, Semaphore (the real HTTP web UIs on this cluster; `teleport-agent` is a connection-holding proxy, not probed, same reasoning as its own dashboard builder) — referenced by `cluster-vars` hostname (`${AWX_HOST}`, `${AWX_TEST_HOST}`, `${SEMAPHORE_HOST}`), never a hardcoded FQDN.
- Estimated cost: ~10-15 series per target × 3 ≈ 30-45 new series, negligible against current budget (~7,096 of a real 15,000 hard cap).

## Test plan
- [x] YAML parses cleanly, new River config correctly nested inside the existing `extraConfig:` block-scalar (not dedented out of it)
- [x] `${AWX_HOST}`/`${AWX_TEST_HOST}`/`${SEMAPHORE_HOST}` already exist in `.github/fixtures/cluster-vars-ci.yaml` — no CI fixture gap
- [x] Relabel rule ordering traced through manually and independently by both reviewers: `__param_target`/`instance` correctly capture the probed URL before `__address__` is overwritten to point at the blackbox-exporter Service
- [x] `discovery.relabel`/`prometheus.scrape` field names and types verified against Alloy's actual component reference docs, not just internal consistency
- [x] Blackbox-exporter Service name/port (`blackbox-blackbox-exporter.monitoring.svc.cluster.local:9115`) confirmed live before writing this
- [x] Independent dual review (codex-rescue + fable, run separately) — no bugs found by either
- [ ] Post-merge: confirm `probe_success`/`probe_duration_seconds` etc. actually flow for all 3 targets